### PR TITLE
tox: Specify lower limit for poetry

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,19 @@
 envlist = linters, py3
 isolated_build = True
 
+[tox:.package]
+## Required for poetry
+# note tox will use the same python version as under what tox is installed to package
+# so unless this is python 3 you can require a given python version for the packaging
+# environment via the basepython key
+basepython = python3
+
 [testenv]
-deps = poetry
+deps = poetry >= 1.0.5
+commands =
+    poetry install
+    poetry env info
+    poetry run py.test -v test
 
 [testenv:linters]
 basepython = python3
@@ -13,9 +24,3 @@ commands=
     poetry run flake8 setup.py docs ansible_builder test
     poetry run yamllint --version
     poetry run yamllint -s .
-
-[testenv:py3]
-basepython = python3
-commands =
-    poetry install
-    poetry run py.test -v test


### PR DESCRIPTION
This commit aims to specify the `poetry` lower limit and make `tox` work out of the box on CentOS 8 images. Without this, the following is being encountered.

```
[root@localhost ansible-builder]# tox                                           
.package create: /home/vagrant/ansible-builder/.tox/.package                                                                                                    
.package installdeps: poetry>=1.0.5, poetry                                                                                                                     
ERROR: invocation failed (exit code 1), logfile: /home/vagrant/ansible-builder/.tox/.package/log/.package-1.log
ERROR: actionid: .package                                                       
msg: getenv                                                                     
cmdargs: "/home/vagrant/ansible-builder/.tox/.package/bin/python -m pip install 'poetry>=1.0.5' poetry"

ERROR: Double requirement given: poetry (already in poetry>=1.0.5, name='poetry')

ERROR: could not install deps [poetry>=1.0.5, poetry]; v = InvocationError('/home/vagrant/ansible-builder/.tox/.package/bin/python -m pip install poetry>=1.0.5 
poetry (see /home/vagrant/ansible-builder/.tox/.package/log/.package-1.log)', 1) 
ERROR: invocation failed (exit code 1), logfile: /home/vagrant/ansible-builder/.tox/.package/log/.package-2.log
ERROR: actionid: .package
msg: get-build-requires
cmdargs: "/home/vagrant/ansible-builder/.tox/.package/bin/python -c 'import poetry.masonry.api\nimport json\n\nbackend = poetry.masonry.api\nfor_build_requires 
= backend.get_requires_for_build_sdist(None)\nprint(json.dumps(for_build_requires))'"

Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'poetry'

ERROR: FAIL could not package project - v = InvocationError('/home/vagrant/ansible-builder/.tox/.package/bin/python -c import poetry.masonry.api\nimport json\n\
nbackend = poetry.masonry.api\nfor_build_requires = backend.get_requires_for_build_sdist(None)\nprint(json.dumps(for_build_requires)) (see /home/vagrant/ansible
-builder/.tox/.package/log/.package-2.log)', 1)
```

It also aligns with the pattern used in `ansible/ansible-runner`: https://github.com/ansible/ansible-runner/blob/devel/tox.ini