### PR TITLE
Update gitignore File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 \#*\#
 .#*
 *.egg-info/
+setup-to-compare.py
 
 /.pytest_cache/
 /context/

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,4 @@ commands =
     poetry install
     poetry run dephell deps convert --from=pyproject.toml --to-format=setuppy --to-path=setup-to-compare.py
     diff setup.py setup-to-compare.py
+    rm setup-to-compare.py


### PR DESCRIPTION
Adding `setup-to-compare.py` to the list of items to be ignored during development (this file is auto-generated when running the `poetry run dephell deps convert --from=pyproject.toml --to-format=setuppy --to-path=setup-to-compare.py` command after making any changes to `pyproject.toml`/`setup.py`)