### PR TITLE
Add Documentation for Builder Repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Ansible Builder Contributing Guidelines
+
+If you have questions about this document or anything not covered here, come chat with us at `#ansible-awx` or `#ansible-builder` on irc.freenode.net
+
+
+## Things to Know Before Submitting Code
+
+- All code and doc submissions are done through pull requests against the `devel` branch.
+- Take care to make sure no merge commits are in the submission, and use `git rebase` vs `git merge` for this reason.
+- We ask all of our community members and contributors to adhere to the [Ansible code of conduct](http://docs.ansible.com/ansible/latest/community/code_of_conduct.html). If you have questions, or need assistance, please reach out to our community team at [codeofconduct@ansible.com](mailto:codeofconduct@ansible.com)
+
+
+## Setting Up Your Development Environment
+
+Ansible Builder development is powered by [Poetry](https://python-poetry.org/); make sure you have it [installed](https://python-poetry.org/docs/#installation) and then:
+
+```bash
+(host)$ poetry install
+```
+
+This will automatically set up the development environment under a virtualenv, which you can then switch to with:
+
+```bash
+(host)$ poetry shell
+```
+
+## Linting and Unit Tests
+
+`tox` is used to run linters (`flake8` and `yamllint`) and unit tests on both Python 2 and 3. It uses Poetry to bootstrap these two environments.
+
+## A Note About `setup.py`
+
+In this repository you will find a [`setup.py` file](https://docs.python.org/3/installing/index.html#installing-index) (for downstream packaging purposes).  If your PR makes any changes to `pyproject.toml`, then this `setup.py` file needs to reflect those changes.  Poetry can help with this.
+
+```bash
+$ run poetry
+$ run dephell deps convert --from=pyproject.toml --to=setup.py
+```
+
+A new `setup.py` file will be generated from these commands if edits are detected in `pyproject.toml`, which you can then commit along with any other changes.
+
+## Gating and Merging
+
+We require at least one approval on a pull request before it can be merged.  Merges are done through CI, via the `gate` label.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,7 @@ This will automatically set up the development environment under a virtualenv, w
 In this repository you will find a [`setup.py` file](https://docs.python.org/3/installing/index.html#installing-index) (for downstream packaging purposes).  If your PR makes any changes to `pyproject.toml`, then this `setup.py` file needs to reflect those changes.  Poetry can help with this.
 
 ```bash
-$ run poetry
-$ run dephell deps convert --from=pyproject.toml --to=setup.py
+$ poetry run dephell deps convert --from=pyproject.toml --to=setup.py
 ```
 
 A new `setup.py` file will be generated from these commands if edits are detected in `pyproject.toml`, which you can then commit along with any other changes.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Ansible Builder
+
+Ansible Builder is a tool that automates the process of building and shipping a set of execution environments using the schemas and tooling defined in various Ansible Collections.
+
+## Get Involved:
+
+* We use [GitHub issues](https://github.com/ansible/ansible-builder/issues) to track bug reports and feature ideas
+* Want to contribute, check out our [guide](CONTRIBUTING.md)
+* Join us in the `#ansible-builder` channel on Freenode IRC
+* Join the discussion in [awx-project](https://groups.google.com/forum/#!forum/awx-project)
+* For the full list of Ansible email Lists, IRC channels and working groups, check out the [Ansible Mailing lists](https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information) page of the official Ansible documentation
+
+## Project Maintainers:
+
+Shane McDonald (shanemcd@redhat.com) <br>
+Alan Rominger (arominge@redhat.com) <br>
+Bianca Henderson (bianca@redhat.com)


### PR DESCRIPTION
Added a `README` as well as a separate page with contribution information (see Issue https://github.com/ansible/ansible-builder/issues/11).