### PR TITLE
Fix incorrect argument to role install command

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -94,6 +94,6 @@ class GalaxySteps:
         basename = os.path.basename(definition.galaxy_requirements_file)
         return [
             "ADD {} /build/".format(basename),
-            "RUN ansible-galaxy role install --requirements-file /build/{} --roles-path /usr/share/ansible/roles".format(basename),
+            "RUN ansible-galaxy role install --role-file /build/{} --roles-path /usr/share/ansible/roles".format(basename),
             "RUN ansible-galaxy collection install --requirements-file /build/{} --collections-path /usr/share/ansible/collections".format(basename)
         ]


### PR DESCRIPTION
my goof from last merge #4 

fixes

```
$ docker build .
Sending build context to Docker daemon  3.072kB
Step 1/4 : FROM shanemcd/ansible-runner
latest: Pulling from shanemcd/ansible-runner
6910e5a164f7: Pull complete 
612afcfe5d37: Pull complete 
5f2ce45157b8: Pull complete 
5f22cfb4e045: Pull complete 
0b86153bef75: Pull complete 
e482af1044bb: Pull complete 
44ed75809656: Pull complete 
4fcf6f523f27: Pull complete 
2c09e84b7520: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:71b90499b40c7516e7e2aa5e47f69a7f7bc974ae4cf6e94671717e045190b7d7
Status: Downloaded newer image for shanemcd/ansible-runner:latest
 ---> 076625a99a3b
Step 2/4 : ADD scm_metadata.yml /build/
 ---> 531f4940f68a
Step 3/4 : RUN ansible-galaxy role install --requirements-file /build/scm_metadata.yml --roles-path /usr/share/ansible/roles
 ---> Running in 1cc4ceb8de62
usage: ansible-galaxy [-h] [--version] [-v] TYPE ...
ansible-galaxy: error: unrecognized arguments: --requirements-file
 
usage: ansible-galaxy [-h] [--version] [-v] TYPE ...

Perform various Role and Collection related operations.

positional arguments:
  TYPE
    collection   Manage an Ansible Galaxy collection.
    role         Manage an Ansible Galaxy role.

optional arguments:
  --version      show program's version number, config file location,
                 configured module search path, module location, executable
                 location and exit
  -h, --help     show this help message and exit
  -v, --verbose  verbose mode (-vvv for more, -vvvv to enable connection
                 debugging)
 The command '/bin/sh -c ansible-galaxy role install --requirements-file /build/scm_metadata.yml --roles-path /usr/share/ansible/roles' returned a non-zero code: 2
```