### PR TITLE
Add version flag

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -1,12 +1,18 @@
 import argparse
 import sys
 
+from . import __version__
+
 from .main import AnsibleBuilder
 from . import constants
 
 
 def prepare(args=sys.argv[1:]):
     parser = argparse.ArgumentParser(prog='ansible-builder')
+    parser.add_argument(
+        '--version', action='version', version=__version__,
+        help='Print ansible-builder version and exit.'
+    )
     # TODO: Need to have a paragraph come up when running `ansible-builder -h` that explains what Builder is/does
     subparsers = parser.add_subparsers(help='The command to invoke.', dest='action')
 


### PR DESCRIPTION
```
(ansible-builder_test) arominge-OSX:ansible-builder alancoding$ ansible-builder --version
0.1.0
(ansible-builder_test) arominge-OSX:ansible-builder alancoding$ 
(ansible-builder_test) arominge-OSX:ansible-builder alancoding$ ansible-builder --help
usage: ansible-builder [-h] [--version] {create} ...

positional arguments:
  {create}    The command to invoke.
    create    Outputs a build context, including a Containerfile, populated
              with dependencies.

optional arguments:
  -h, --help  show this help message and exit
  --version   Print ansible-builder version and exit.
```