### PR TITLE
Add test for coverage of relative galaxy file

### DIFF
--- a/test/data/foo/requirements.yml
+++ b/test/data/foo/requirements.yml
@@ -1,0 +1,1 @@
+collections: []

--- a/test/data/foo/requirements.yml
+++ b/test/data/foo/requirements.yml
@@ -1,1 +1,2 @@
+---
 collections: []

--- a/test/data/nested-galaxy.yml
+++ b/test/data/nested-galaxy.yml
@@ -1,3 +1,4 @@
+---
 version: 1
 dependencies:
   galaxy: foo/requirements.yml

--- a/test/data/nested-galaxy.yml
+++ b/test/data/nested-galaxy.yml
@@ -1,0 +1,3 @@
+version: 1
+dependencies:
+  galaxy: foo/requirements.yml

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -109,3 +109,7 @@ def test_collection_metadata(tmpdir, data_dir, exec_env_definition_file):
     ]
 
 
+def test_nested_galaxy_file(data_dir, tmpdir):
+    if not os.path.exists('test/data/nested-galaxy.yml'):
+        pytest.skip('Test is only valid when ran from ansible-builder root')
+    AnsibleBuilder(filename='test/data/nested-galaxy.yml', build_context=str(tmpdir)).build()


### PR DESCRIPTION
This should pass now, but with https://github.com/ansible/ansible-builder/pull/38 at the moment it fails with

```
E               FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/fj/6z5pn3wj5w31zvn2pws34svm0000gn/T/pytest-of-alancoding/pytest-141/test_nested_galaxy_file0/test/data/foo/requirements.yml'
```

So by merging it into devel we enforce those expectations so that we just automatically enforce this as changes are made.