### PR TITLE
Do not traceback when no collections requirements

### DIFF
--- a/ansible_builder/collections.py
+++ b/ansible_builder/collections.py
@@ -27,6 +27,9 @@ class CollectionManager:
     def ensure_installed(self):
         if self.installed:
             return
+        if not self.requirements_file:
+            print('No collections requirements file found, skipping ansible-galaxy install...')
+            return
         run_command([
             'ansible-galaxy', 'collection', 'install',
             '-r', self.requirements_file,


### PR DESCRIPTION
Previously, if no collections requirments file indicated in execution-environments.yml,
we'd get a traceback from run_command

Old output:
```
ansible-builder build                                                                                
Using temporary directory to obtain collection information:                                    
  /tmp/ansible_builder_y2mm4g9h                                                                
Processing...                                                                                                                                                                                 
Running command:                                                                               
Traceback (most recent call last):                                                             
  File "/home/elijah/.cache/pypoetry/virtualenvs/ansible-builder-d47oRQeY-py3.8/bin/ansible-builder", line 11, in <module>
    load_entry_point('ansible-builder', 'console_scripts', 'ansible-builder')()                
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/cli.py", line 85, in run                                                                                                     
    if build_or_create():                                                                                                                                                                     
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/main.py", line 47, in build   
    self.create()                                                                              
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/main.py", line 35, in create
    self.containerfile.build_steps()
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/main.py", line 203, in build_steps
    self.definition.collection_dependencies()
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/main.py", line 155, in collection_dependencies
    for path in self.manager.path_list():
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/collections.py", line 38, in path_list
    self.ensure_installed()
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/collections.py", line 30, in ensure_installed
    run_command([
  File "/home/elijah/sfw/ansible/ansible-builder/ansible_builder/utils.py", line 6, in run_command
    print('  {0}'.format(' '.join(command)))
TypeError: sequence item 4: expected str instance, NoneType found
```


New output:

```
ansible-builder build
Using temporary directory to obtain collection information:
  /tmp/ansible_builder_vjr0xzs1
Processing...
No collections requirements file found, skipping ansible-galaxy install...
Running command:
  podman build -f context/Containerfile -t ansible-execution-env:latest context
STEP 1: FROM shanemcd/ansible-runner
STEP 2: COMMIT ansible-execution-env:latest
--> 076625a99a3
076625a99a3bcac2a3b767bd0b1563d0e32880e3b3df61326409565b0e16bdbb
Complete! Build context is at: context
```