### PR TITLE
Update example to new syntax from runner

### DIFF
--- a/examples/pytz/env/settings
+++ b/examples/pytz/env/settings
@@ -1,4 +1,4 @@
 ---
-containerized: true
-container_runtime: docker
 container_image: ansible-execution-env
+process_isolation_executable: docker
+process_isolation: true


### PR DESCRIPTION
Because the PR https://github.com/ansible/ansible-runner/pull/470 has been actively changing, and these get renamed. That's what it means to be on the bleeding edge. Even so, I think it's a fight worth fighting, or else I do not have confidence in what we're doing.