### PR TITLE
Enable Additional Build Commands to be Specified in Definition File

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,4 @@
+---
+ignore: |
+  .tox
+  test/data/definition_files/bad.yml

--- a/README.md
+++ b/README.md
@@ -34,11 +34,21 @@ version: 1
 dependencies:
   galaxy: requirements.yml
   python: requirements.txt
+
+additional_build_steps:
+  prepend: |
+    RUN whoami
+    RUN cat /etc/os-release
+  append:
+    - RUN echo This is a post-install command!
+    - RUN ls -la /etc
 ```
 
-The entries such as `requirements.yml` and `requirements.txt` may be a relative
-path from the directory of the execution environment definition's folder,
-or an absolute path.
+The entries such as `requirements.yml` and `requirements.txt` may be a relative path from the directory of the execution environment definition's folder, or an absolute path.
+
+Additional commands may be specified in the `additional_build_steps` section, either for before the main build steps (`prepend`) or after (`append`).  The syntax needs to be either a:
+  - multi-line string (example shown in the `prepend` section above)
+  - dictionary (as shown via `append`)
 
 ## Collection Execution Environment Dependencies
 

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -3,6 +3,7 @@ import sys
 
 from . import __version__
 
+from .colors import MessageColors
 from .main import AnsibleBuilder
 from . import constants
 
@@ -18,10 +19,10 @@ def run():
         ab = AnsibleBuilder(**vars(args))
         action = getattr(ab, ab.action)
         if action():
-            print("Complete! The build context can be found at: {}".format(ab.build_context))
+            print(MessageColors.OKGREEN + "Complete! The build context can be found at: {}".format(ab.build_context) + MessageColors.ENDC)
             sys.exit(0)
 
-    print("An error has occured.")
+    print(MessageColors.FAIL + "An error has occured." + MessageColors.ENDC)
     sys.exit(1)
 
 

--- a/ansible_builder/colors.py
+++ b/ansible_builder/colors.py
@@ -1,0 +1,7 @@
+class MessageColors:
+    HEADER = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[1m'
+    OK = '\033[95m'
+    ENDC = '\033[0m'

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -5,6 +5,7 @@ import shutil
 import filecmp
 
 from . import constants
+from .colors import MessageColors
 from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, IntrospectionSteps
 from .utils import run_command
 import ansible_builder.introspect
@@ -49,11 +50,11 @@ class AnsibleBuilder:
         self.containerfile.prepare_prepended_steps()
         self.containerfile.prepare_introspection_steps()
         self.containerfile.prepare_galaxy_steps()
-        print('Writing partial Containerfile without collection requirements')
+        print(MessageColors.OK + 'Writing partial Containerfile without collection requirements' + MessageColors.ENDC)
         self.containerfile.write()
         run_command(self.build_command)
         self.containerfile.prepare_pip_steps()
-        print('Rewriting Containerfile to capture collection requirements')
+        print(MessageColors.OK + 'Rewriting Containerfile to capture collection requirements' + MessageColors.ENDC)
         self.containerfile.prepare_appended_steps()
         self.containerfile.write()
         run_command(self.build_command)
@@ -86,10 +87,10 @@ class UserDefinition(BaseDefinition):
                 y = yaml.load(f)
                 self.raw = y if y else {}
         except FileNotFoundError:
-            sys.exit("""
+            sys.exit(MessageColors.FAIL + """
             Could not detect '{0}' file in this directory.
             Use -f to specify a different location.
-            """.format(constants.default_file))
+            """.format(constants.default_file) + MessageColors.ENDC)
 
     def get_additional_commands(self):
         """Gets additional commands from the exec env file, if any are specified.
@@ -185,7 +186,7 @@ class Containerfile:
         command = [self.container_runtime, "run", "--rm", self.tag, "introspect"]
         rc, output = run_command(command, capture_output=True)
         if rc != 0:
-            print('No collections requirements file found, skipping ansible-galaxy install...')
+            print(MessageColors.WARNING + 'No collections requirements file found, skipping ansible-galaxy install...' + MessageColors.ENDC)
             requirements_files = []
         else:
             requirements_files = yaml.load("\n".join(output)) or []

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -17,7 +17,6 @@ class AnsibleBuilder:
                  base_image=constants.default_base_image,
                  build_context=constants.default_build_context,
                  tag=constants.default_tag,
-                 get_additional_commands=None,
                  container_runtime=constants.default_container_runtime):
         self.action = action
         self.definition = UserDefinition(filename=filename)
@@ -30,8 +29,7 @@ class AnsibleBuilder:
             base_image=base_image,
             build_context=self.build_context,
             container_runtime=self.container_runtime,
-            tag=self.tag,
-            get_additional_commands=get_additional_commands)
+            tag=self.tag)
 
     @property
     def version(self):
@@ -117,7 +115,7 @@ class UserDefinition(BaseDefinition):
 class Containerfile:
     newline_char = '\n'
 
-    def __init__(self, definition, get_additional_commands=None,
+    def __init__(self, definition,
                  filename=constants.default_file,
                  build_context=constants.default_build_context,
                  base_image=constants.default_base_image,
@@ -131,7 +129,6 @@ class Containerfile:
         self.base_image = base_image
         self.container_runtime = container_runtime
         self.tag = tag
-        self.get_additional_commands = get_additional_commands
         self.steps = [
             "FROM {}".format(self.base_image),
             ""

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -3,6 +3,7 @@ import yaml
 import sys
 import shutil
 import filecmp
+import textwrap
 
 from . import constants
 from .colors import MessageColors
@@ -89,6 +90,11 @@ class UserDefinition(BaseDefinition):
             Could not detect '{0}' file in this directory.
             Use -f to specify a different location.
             """.format(constants.default_file) + MessageColors.ENDC)
+        except yaml.parser.ParserError as e:
+            sys.exit(MessageColors.FAIL + textwrap.dedent("""
+            An error occured while parsing the definition file:
+            {0}
+            """).format(str(e)) + MessageColors.ENDC)
 
     def get_additional_commands(self):
         """Gets additional commands from the exec env file, if any are specified.

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from . import constants
 from .colors import MessageColors
@@ -15,8 +16,9 @@ class AdditionalBuildSteps:
         elif isinstance(additional_steps, list):
             lines = additional_steps
         else:
-            lines = []
-            print(MessageColors.WARNING + "Unknown type found for additional_build_steps.  Ignoring..." + MessageColors.ENDC)
+            print(MessageColors.FAIL + "Error: unknown type found for additional_build_steps; "
+                  "must be list or multi-line string." + MessageColors.ENDC)
+            sys.exit(1)
         self.steps.extend(lines)
 
     def __iter__(self):

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -3,6 +3,26 @@ import os
 from . import constants
 
 
+class AdditionalBuildSteps:
+    def __init__(self, additional_steps):
+        """Allows for additional prepended / appended build steps to be
+        in the Containerfile or Dockerfile.
+        """
+        self.steps = []
+        if isinstance(additional_steps, str):
+            lines = additional_steps.strip().splitlines()
+        elif isinstance(additional_steps, list):
+            lines = additional_steps
+        else:
+            lines = []
+            print("Unknown type found for additional_build_steps.  Ignoring...")
+
+        self.steps.extend(lines)
+
+    def __iter__(self):
+        return iter(self.steps)
+
+
 class IntrospectionSteps:
     def __init__(self, context_file):
         self.steps = []

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -16,7 +16,7 @@ class AdditionalBuildSteps:
         elif isinstance(additional_steps, list):
             lines = additional_steps
         else:
-            print(MessageColors.FAIL + "Error: unknown type found for additional_build_steps; "
+            print(MessageColors.FAIL + "Error: Unknown type found for additional_build_steps; "
                   "must be list or multi-line string." + MessageColors.ENDC)
             sys.exit(1)
         self.steps.extend(lines)

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -1,6 +1,7 @@
 import os
 
 from . import constants
+from .colors import MessageColors
 
 
 class AdditionalBuildSteps:
@@ -15,8 +16,7 @@ class AdditionalBuildSteps:
             lines = additional_steps
         else:
             lines = []
-            print("Unknown type found for additional_build_steps.  Ignoring...")
-
+            print(MessageColors.WARNING + "Unknown type found for additional_build_steps.  Ignoring..." + MessageColors.ENDC)
         self.steps.extend(lines)
 
     def __iter__(self):

--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -1,10 +1,12 @@
 import subprocess
 import sys
 
+from .colors import MessageColors
+
 
 def run_command(command, capture_output=False):
-    print('Running command:')
-    print('  {0}'.format(' '.join(command)))
+    print(MessageColors.HEADER + 'Running command:' + MessageColors.ENDC)
+    print(MessageColors.HEADER + '  {0}'.format(' '.join(command)) + MessageColors.ENDC)
 
     process = subprocess.Popen(command,
                                stdout=subprocess.PIPE,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,7 +34,7 @@ def good_exec_env_definition_path(tmpdir):
     with open(path, 'w') as outfile:
         yaml.dump(good_content, outfile)
 
-    return path
+    return str(path)
 
 
 @pytest.fixture

--- a/test/data/definition_files/bad.yml
+++ b/test/data/definition_files/bad.yml
@@ -1,0 +1,10 @@
+---
+version: 1
+
+additional_build_steps:
+  prepend:
+    foo: RUN whoami
+    - RUN cat /etc/os-release
+  append:
+    - RUN echo Oh hey this is a post_install command!
+    - RUN ls -la /etc

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,6 +1,5 @@
-import pytest
-
 import os
+import pytest
 
 from ansible_builder import __version__
 from ansible_builder.main import AnsibleBuilder
@@ -118,3 +117,12 @@ def test_nested_galaxy_file(data_dir, tmpdir):
     with open(req_in_bc, 'r') as f_in_bc:
         with open(req_original, 'r') as f_in_def:
             assert f_in_bc.read() == f_in_def.read()
+
+
+def test_definition_syntax_error(data_dir, tmpdir):
+    path = os.path.join(data_dir, 'definition_files/bad.yml')
+
+    with pytest.raises(SystemExit) as error:
+        AnsibleBuilder(filename=path, build_context=tmpdir.mkdir('bc'))
+
+    assert 'An error occured while parsing the definition file:' in str(error.value)

--- a/test/test_steps.py
+++ b/test/test_steps.py
@@ -1,4 +1,7 @@
-from ansible_builder.steps import PipSteps
+import pytest
+import textwrap
+
+from ansible_builder.steps import AdditionalBuildSteps, PipSteps
 
 
 def test_steps_for_collection_dependencies():
@@ -12,3 +15,17 @@ def test_steps_for_collection_dependencies():
             '    -r /usr/share/ansible/collections/ansible_collections/test/reqfile/requirements.txt'
         ])
     ]
+
+
+@pytest.mark.parametrize('verb', ['prepend', 'append'])
+def test_additional_build_steps(verb):
+    additional_build_steps = {
+        'prepend': ["RUN echo This is the prepend test", "RUN whoami"],
+        'append': textwrap.dedent("""
+        RUN echo This is the append test
+        RUN whoami
+        """)
+    }
+    steps = AdditionalBuildSteps(additional_build_steps[verb])
+
+    assert len(list(steps)) == 2


### PR DESCRIPTION
Addresses part of Issue https://github.com/ansible/ansible-builder/issues/21.

With this PR, a user can add info in an `additional_build_steps` section in the Execution Environment definition file, like so:

<img width="471" alt="Screen Shot 2020-07-10 at 12 40 34 PM" src="https://user-images.githubusercontent.com/28930622/87180292-48d15d80-c2ae-11ea-87bb-47871e130316.png">

...and the commands will be detected + recorded during the `ansible-builder build` process:

<img width="807" alt="Screen Shot 2020-07-10 at 12 40 20 PM" src="https://user-images.githubusercontent.com/28930622/87180294-4b33b780-c2ae-11ea-947a-64108619e7ba.png">

The containerfile will get those additional commands written into it:

<img width="441" alt="Screen Shot 2020-07-10 at 1 17 32 PM" src="https://user-images.githubusercontent.com/28930622/87181114-c184e980-c2af-11ea-8aeb-29afb8263a5e.png">


Commands can be run before requirements are dealt with (`prepend`) vs after (`append`), which allows for more customization.

