### PR TITLE
Accept user bindep file

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -6,7 +6,7 @@ import textwrap
 
 from . import constants
 from .colors import MessageColors
-from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, IntrospectionSteps
+from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, IntrospectionSteps, BindepSteps
 from .utils import run_command
 import ansible_builder.introspect
 
@@ -243,6 +243,12 @@ class Containerfile:
                 requirements_files
             )
         )
+
+        system_req_path = self.definition.get_dependency('system')
+        if system_req_path:
+            shutil.copy(system_req_path, self.build_context)
+
+        self.steps.extend(BindepSteps(system_req_path))
 
         return self.steps
 

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -61,6 +61,7 @@ class AnsibleBuilder:
         run_command(self.build_command)
         self.containerfile.prepare_pip_steps()
         print(MessageColors.OK + 'Rewriting Containerfile to capture collection requirements' + MessageColors.ENDC)
+        self.containerfile.prepare_system_steps()
         self.containerfile.prepare_appended_steps()
         self.containerfile.write()
         run_command(self.build_command)
@@ -225,6 +226,7 @@ class Containerfile:
         galaxy_file = self.definition.get_dep('galaxy')
         if galaxy_file:
             self.steps.extend(GalaxySteps(galaxy_file))
+        return self.steps
 
     def prepare_pip_steps(self):
         python_req_file = self.definition.get_dep('python')
@@ -243,13 +245,12 @@ class Containerfile:
                 requirements_files
             )
         )
+        return self.steps
 
-        system_req_path = self.definition.get_dependency('system')
-        if system_req_path:
-            shutil.copy(system_req_path, self.build_context)
-
-        self.steps.extend(BindepSteps(system_req_path))
-
+    def prepare_system_steps(self):
+        system_req_file = self.definition.get_dep('system')
+        if system_req_file:
+            self.steps.extend(BindepSteps(system_req_file))
         return self.steps
 
     def write(self):

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -75,7 +75,7 @@ class BindepSteps(Steps):
 
         for file in sanitized_files:
             self.steps.append(
-                "RUN yum -y install $(bindep -q -f {})".format(file)
+                "RUN dnf -y install $(bindep -q -f {})".format(file)
             )
 
 

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -5,7 +5,12 @@ from . import constants
 from .colors import MessageColors
 
 
-class AdditionalBuildSteps:
+class Steps:
+    def __iter__(self):
+        return iter(self.steps)
+
+
+class AdditionalBuildSteps(Steps):
     def __init__(self, additional_steps):
         """Allows for additional prepended / appended build steps to be
         in the Containerfile or Dockerfile.
@@ -25,7 +30,7 @@ class AdditionalBuildSteps:
         return iter(self.steps)
 
 
-class IntrospectionSteps:
+class IntrospectionSteps(Steps):
     def __init__(self, context_file):
         self.steps = []
         self.steps.extend([
@@ -33,11 +38,8 @@ class IntrospectionSteps:
             "RUN chmod +x /usr/local/bin/introspect"
         ])
 
-    def __iter__(self):
-        return iter(self.steps)
 
-
-class GalaxySteps:
+class GalaxySteps(Steps):
     def __init__(self, requirements_naming):
         """Assumes given requirements file name has been placed in the build context
         """
@@ -53,11 +55,31 @@ class GalaxySteps:
                 requirements_naming, constants.base_collections_path)
         ])
 
-    def __iter__(self):
-        return iter(self.steps)
+
+class BindepSteps(Steps):
+    def __init__(self, context_file):
+        self.steps = []
+        sanitized_files = []
+        if context_file:
+            # requirements file added to build context
+            file_naming = os.path.basename(context_file)
+            self.steps.append(
+                "ADD {} /build/".format(file_naming)
+            )
+            sanitized_files.append(os.path.join('/build/', file_naming))
+
+        if sanitized_files:
+            self.steps.append(
+                "RUN pip3 install bindep"
+            )
+
+        for file in sanitized_files:
+            self.steps.append(
+                "RUN yum -y install $(bindep -q -f {})".format(file)
+            )
 
 
-class PipSteps:
+class PipSteps(Steps):
     def __init__(self, context_file, collection_files):
         """Allows for 1 python requirement file in the build context
         In collection files, expects a list of relative paths where python requirements files live
@@ -91,6 +113,3 @@ class PipSteps:
                     content=line_return.join(sanitized_files)
                 )
             ])
-
-    def __iter__(self):
-        return iter(self.steps)

--- a/test/test_steps.py
+++ b/test/test_steps.py
@@ -1,7 +1,7 @@
 import pytest
 import textwrap
 
-from ansible_builder.steps import AdditionalBuildSteps, PipSteps
+from ansible_builder.steps import AdditionalBuildSteps, PipSteps, BindepSteps
 
 
 def test_steps_for_collection_dependencies():
@@ -29,3 +29,12 @@ def test_additional_build_steps(verb):
     steps = AdditionalBuildSteps(additional_build_steps[verb])
 
     assert len(list(steps)) == 2
+
+def test_system_steps():
+    assert list(BindepSteps(
+        'bindep.txt'
+    )) == [
+        'ADD bindep.txt /build/',
+        'RUN pip3 install bindep',
+        'RUN yum -y install $(bindep -q -f /build/bindep.txt)'
+    ]

--- a/test/test_steps.py
+++ b/test/test_steps.py
@@ -30,6 +30,7 @@ def test_additional_build_steps(verb):
 
     assert len(list(steps)) == 2
 
+
 def test_system_steps():
     assert list(BindepSteps(
         'bindep.txt'

--- a/test/test_steps.py
+++ b/test/test_steps.py
@@ -37,5 +37,5 @@ def test_system_steps():
     )) == [
         'ADD bindep.txt /build/',
         'RUN pip3 install bindep',
-        'RUN yum -y install $(bindep -q -f /build/bindep.txt)'
+        'RUN dnf -y install $(bindep -q -f /build/bindep.txt)'
     ]


### PR DESCRIPTION
Connect https://github.com/ansible/ansible-builder/issues/50

Running the subversion example

```
$ ./examples/run.sh subversion

Running Example: subversion
Untagged: exec-env-subversion:latest
Writing partial Containerfile without collection requirements
Running command:
  docker build -f bc/Dockerfile -t exec-env-subversion bc
Sending build context to Docker daemon  7.168kB
Step 1/3 : FROM shanemcd/ansible-runner
 ---> f0c79677d9b1
Step 2/3 : ADD introspect.py /usr/local/bin/introspect
 ---> Using cache
 ---> cba3da5faf2e
Step 3/3 : RUN chmod +x /usr/local/bin/introspect
 ---> Using cache
 ---> 13c1dc7b98f2
Successfully built 13c1dc7b98f2
Successfully tagged exec-env-subversion:latest
Running command:
  docker run --rm exec-env-subversion introspect
[]

Rewriting Containerfile to capture collection requirements
Running command:
  docker build -f bc/Dockerfile -t exec-env-subversion bc
Sending build context to Docker daemon  8.192kB
Step 1/6 : FROM shanemcd/ansible-runner
 ---> f0c79677d9b1
Step 2/6 : ADD introspect.py /usr/local/bin/introspect
 ---> Using cache
 ---> cba3da5faf2e
Step 3/6 : RUN chmod +x /usr/local/bin/introspect
 ---> Using cache
 ---> 13c1dc7b98f2
Step 4/6 : ADD bindep.txt /build/
 ---> Using cache
 ---> a8e7d75fea57
Step 5/6 : RUN pip3 install bindep
 ---> Using cache
 ---> 303631a88289
Step 6/6 : RUN yum -y install $(bindep -b -f /build/bindep.txt)
 ---> Running in aea05bc2c333
CentOS-8 - AppStream                            2.1 MB/s | 5.8 MB     00:02    
CentOS-8 - Base                                 1.3 MB/s | 2.2 MB     00:01    
CentOS-8 - Extras                                25 kB/s | 7.0 kB     00:00    
Ansible Runner for EL 8 - x86_64                 35 kB/s | 7.7 kB     00:00    
Extra Packages for Enterprise Linux Modular 8 - 184 kB/s |  82 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64  8.6 MB/s | 7.4 MB     00:00    
Dependencies resolved.
================================================================================
 Package          Arch   Version                                Repo       Size
================================================================================
Installing:
 subversion       x86_64 1.10.2-1.module_el8.0.0+45+75bba4f4    AppStream 1.1 M
Installing dependencies:
 apr              x86_64 1.6.3-9.el8                            AppStream 125 k
 apr-util         x86_64 1.6.1-6.el8                            AppStream 105 k
 libserf          x86_64 1.3.9-8.module_el8.0.0+45+75bba4f4     AppStream  60 k
 subversion-libs  x86_64 1.10.2-1.module_el8.0.0+45+75bba4f4    AppStream 1.5 M
 utf8proc         x86_64 2.1.1-4.module_el8.0.0+45+75bba4f4     AppStream  67 k
Installing weak dependencies:
 apr-util-bdb     x86_64 1.6.1-6.el8                            AppStream  25 k
 apr-util-openssl x86_64 1.6.1-6.el8                            AppStream  27 k
Enabling module streams:
 subversion              1.10                                                  

Transaction Summary
================================================================================
Install  8 Packages

Total download size: 3.0 M
Installed size: 11 M
Downloading Packages:
(1/8): apr-util-bdb-1.6.1-6.el8.x86_64.rpm      126 kB/s |  25 kB     00:00    
(2/8): apr-util-openssl-1.6.1-6.el8.x86_64.rpm  560 kB/s |  27 kB     00:00    
(3/8): apr-util-1.6.1-6.el8.x86_64.rpm          407 kB/s | 105 kB     00:00    
(4/8): apr-1.6.3-9.el8.x86_64.rpm               452 kB/s | 125 kB     00:00    
(5/8): libserf-1.3.9-8.module_el8.0.0+45+75bba4 631 kB/s |  60 kB     00:00    
(6/8): utf8proc-2.1.1-4.module_el8.0.0+45+75bba 1.1 MB/s |  67 kB     00:00    
(7/8): subversion-1.10.2-1.module_el8.0.0+45+75 2.5 MB/s | 1.1 MB     00:00    
(8/8): subversion-libs-1.10.2-1.module_el8.0.0+ 2.4 MB/s | 1.5 MB     00:00    
--------------------------------------------------------------------------------
Total                                           3.0 MB/s | 3.0 MB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : apr-1.6.3-9.el8.x86_64                                 1/8 
  Running scriptlet: apr-1.6.3-9.el8.x86_64                                 1/8 
  Installing       : apr-util-bdb-1.6.1-6.el8.x86_64                        2/8 
  Installing       : apr-util-openssl-1.6.1-6.el8.x86_64                    3/8 
  Installing       : apr-util-1.6.1-6.el8.x86_64                            4/8 
  Running scriptlet: apr-util-1.6.1-6.el8.x86_64                            4/8 
  Installing       : libserf-1.3.9-8.module_el8.0.0+45+75bba4f4.x86_64      5/8 
  Running scriptlet: libserf-1.3.9-8.module_el8.0.0+45+75bba4f4.x86_64      5/8 
  Installing       : utf8proc-2.1.1-4.module_el8.0.0+45+75bba4f4.x86_64     6/8 
  Running scriptlet: utf8proc-2.1.1-4.module_el8.0.0+45+75bba4f4.x86_64     6/8 
  Installing       : subversion-libs-1.10.2-1.module_el8.0.0+45+75bba4f4.   7/8 
  Running scriptlet: subversion-libs-1.10.2-1.module_el8.0.0+45+75bba4f4.   7/8 
  Installing       : subversion-1.10.2-1.module_el8.0.0+45+75bba4f4.x86_6   8/8 
  Running scriptlet: subversion-1.10.2-1.module_el8.0.0+45+75bba4f4.x86_6   8/8 
  Verifying        : apr-1.6.3-9.el8.x86_64                                 1/8 
  Verifying        : apr-util-1.6.1-6.el8.x86_64                            2/8 
  Verifying        : apr-util-bdb-1.6.1-6.el8.x86_64                        3/8 
  Verifying        : apr-util-openssl-1.6.1-6.el8.x86_64                    4/8 
  Verifying        : libserf-1.3.9-8.module_el8.0.0+45+75bba4f4.x86_64      5/8 
  Verifying        : subversion-1.10.2-1.module_el8.0.0+45+75bba4f4.x86_6   6/8 
  Verifying        : subversion-libs-1.10.2-1.module_el8.0.0+45+75bba4f4.   7/8 
  Verifying        : utf8proc-2.1.1-4.module_el8.0.0+45+75bba4f4.x86_64     8/8 

Installed:
  apr-1.6.3-9.el8.x86_64                                                        
  apr-util-1.6.1-6.el8.x86_64                                                   
  apr-util-bdb-1.6.1-6.el8.x86_64                                               
  apr-util-openssl-1.6.1-6.el8.x86_64                                           
  libserf-1.3.9-8.module_el8.0.0+45+75bba4f4.x86_64                             
  subversion-1.10.2-1.module_el8.0.0+45+75bba4f4.x86_64                         
  subversion-libs-1.10.2-1.module_el8.0.0+45+75bba4f4.x86_64                    
  utf8proc-2.1.1-4.module_el8.0.0+45+75bba4f4.x86_64                            

Complete!
Removing intermediate container aea05bc2c333
 ---> a30fbf2489e0
Successfully built a30fbf2489e0
Successfully tagged exec-env-subversion:latest
Complete! The build context can be found at: bc
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
No config file found; using defaults
[WARNING]: Unable to parse /runner/inventory/hosts as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************

TASK [Checkout subversion repository to specified folder] **********************
changed: [localhost] => {"after": ["Revision: 60336", "URL: https://github.com/ansible/test-playbooks.git"], "before": null, "changed": true}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

I have spent _very_ little time on this so far, but seeing the moving parts was really important to me, and I want to get support for this into the code base soon.