### PR TITLE
[alt 1] Remove the unused prepare method

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -10,11 +10,6 @@ from . import constants
 from .introspect import add_introspect_options, process
 
 
-def prepare(args=sys.argv[1:]):
-    args = parse_args(args)
-    return AnsibleBuilder(**vars(args))
-
-
 def run():
     args = parse_args()
     if args.action in ['build']:
@@ -35,7 +30,10 @@ def run():
     sys.exit(1)
 
 
-def parse_args(args=sys.argv[1:]):
+def parse_args(args=None):
+    if args is None:
+        args = sys.argv[1:]
+
     parser = argparse.ArgumentParser(
         prog='ansible-builder',
         description=(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,18 +1,29 @@
-from ansible_builder.cli import prepare
+from ansible_builder.cli import run, sys
+from contextlib import contextmanager
+
+import os
+import pytest
+
+from unittest import mock
 
 
-def test_custom_image(exec_env_definition_file, tmpdir):
+@pytest.fixture
+def cli_mock():
+    @contextmanager
+    def rf(args):
+        with mock.patch.object(sys, 'argv', args):
+            with pytest.raises(SystemExit):
+                yield
+    return rf
+
+
+def test_custom_image(exec_env_definition_file, tmpdir, cli_mock):
     content = {'version': 1}
     path = str(exec_env_definition_file(content=content))
 
-    aee = prepare(['build', '-f', path, '-b', 'my-custom-image', '-c', str(tmpdir)])
+    args = ['ansible-builder', 'build', '-f', path, '-b', 'my-custom-image', '-c', str(tmpdir)]
+    with cli_mock(args):
+        run()
 
-    assert aee.containerfile.base_image == 'my-custom-image'
-
-
-def test_build_context(good_exec_env_definition_path, tmpdir):
-    path = str(good_exec_env_definition_path)
-    build_context = str(tmpdir)
-    aee = prepare(['build', '-f', path, '-c', build_context])
-
-    assert aee.build_context == build_context
+    with open(os.path.join(str(tmpdir), 'Containerfile')) as f:
+        assert 'FROM my-custom-image' in f.read()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,8 +12,8 @@ def cli_mock():
     @contextmanager
     def rf(args):
         with mock.patch.object(sys, 'argv', args):
-            with pytest.raises(SystemExit):
-                yield
+            with pytest.raises(SystemExit) as exc:
+                yield exc
     return rf
 
 
@@ -22,8 +22,18 @@ def test_custom_image(exec_env_definition_file, tmpdir, cli_mock):
     path = str(exec_env_definition_file(content=content))
 
     args = ['ansible-builder', 'build', '-f', path, '-b', 'my-custom-image', '-c', str(tmpdir)]
-    with cli_mock(args):
+    with cli_mock(args) as sys_exit:
         run()
+
+    assert sys_exit.value.code == 0
 
     with open(os.path.join(str(tmpdir), 'Containerfile')) as f:
         assert 'FROM my-custom-image' in f.read()
+
+
+def test_invalid_path(tmpdir, cli_mock):
+    args = ['ansible-builder', 'build', '-f', 'foo/invalid', '-c', str(tmpdir)]
+    with cli_mock(args) as sys_exit:
+        run()
+
+    assert sys_exit.value.code != 0


### PR DESCRIPTION
I was trying to outline the program flow, and noticed that `prepare` didn't have any references to it, but we still had tests running it. If someone wants to refactor the actual code to make the testing prettier, then go ahead, but I'm trying to avoid doing that unnecessarily.