### PR TITLE
Add validation step, combine makedirs and copy code

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -5,7 +5,7 @@ import yaml
 from . import __version__
 
 from .colors import MessageColors
-from .main import AnsibleBuilder
+from .main import AnsibleBuilder, DefinitionError
 from . import constants
 from .introspect import add_introspect_options, process
 
@@ -20,9 +20,13 @@ def run():
     if args.action in ['build']:
         ab = AnsibleBuilder(**vars(args))
         action = getattr(ab, ab.action)
-        if action():
-            print(MessageColors.OKGREEN + "Complete! The build context can be found at: {}".format(ab.build_context) + MessageColors.ENDC)
-            sys.exit(0)
+        try:
+            if action():
+                print(MessageColors.OKGREEN + "Complete! The build context can be found at: {}".format(ab.build_context) + MessageColors.ENDC)
+                sys.exit(0)
+        except DefinitionError as e:
+            print(MessageColors.FAIL + e.args[0] + MessageColors.ENDC)
+            sys.exit(1)
     elif args.action == 'introspect':
         for folder in args.folders:
             data = process(folder)

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -52,7 +52,7 @@ class AnsibleBuilder:
         ]
 
     def build(self):
-        self.containerfile.initialize_folder()
+        self.containerfile.create_folder_copy_files()
         self.containerfile.prepare_prepended_steps()
         self.containerfile.prepare_introspection_steps()
         self.containerfile.prepare_galaxy_steps()
@@ -171,7 +171,7 @@ class Containerfile:
             ""
         ]
 
-    def initialize_folder(self):
+    def create_folder_copy_files(self):
         """Creates the build context file for this Containerfile
         moves files from the definition into the folder
         """

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -1,6 +1,5 @@
 import os
 import yaml
-import sys
 import shutil
 import filecmp
 import textwrap
@@ -10,6 +9,14 @@ from .colors import MessageColors
 from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, IntrospectionSteps
 from .utils import run_command
 import ansible_builder.introspect
+
+
+# Files that need to be moved into the build context
+CONTEXT_FILES = ['galaxy', 'python', 'system']
+
+
+class DefinitionError(RuntimeError):
+    pass
 
 
 class AnsibleBuilder:
@@ -25,7 +32,6 @@ class AnsibleBuilder:
         self.build_context = build_context
         self.container_runtime = container_runtime
         self.containerfile = Containerfile(
-            filename=constants.runtime_files[self.container_runtime],
             definition=self.definition,
             base_image=base_image,
             build_context=self.build_context,
@@ -46,6 +52,7 @@ class AnsibleBuilder:
         ]
 
     def build(self):
+        self.containerfile.initialize_folder()
         self.containerfile.prepare_prepended_steps()
         self.containerfile.prepare_introspection_steps()
         self.containerfile.prepare_galaxy_steps()
@@ -86,15 +93,20 @@ class UserDefinition(BaseDefinition):
                 y = yaml.load(f)
                 self.raw = y if y else {}
         except FileNotFoundError:
-            sys.exit(MessageColors.FAIL + """
+            raise DefinitionError("""
             Could not detect '{0}' file in this directory.
             Use -f to specify a different location.
-            """.format(constants.default_file) + MessageColors.ENDC)
+            """.format(constants.default_file))
         except yaml.parser.ParserError as e:
-            sys.exit(MessageColors.FAIL + textwrap.dedent("""
+            raise DefinitionError(textwrap.dedent("""
             An error occured while parsing the definition file:
             {0}
-            """).format(str(e)) + MessageColors.ENDC)
+            """).format(str(e)))
+
+        if not isinstance(self.raw, dict):
+            raise DefinitionError('Definition must be a dictionary, not {}'.format(
+                type(self.raw).__name__
+            ))
 
     def get_additional_commands(self):
         """Gets additional commands from the exec env file, if any are specified.
@@ -102,7 +114,7 @@ class UserDefinition(BaseDefinition):
         commands = self.raw.get('additional_build_steps')
         return commands
 
-    def get_dependency(self, entry):
+    def get_dep_abs_path(self, entry):
         """Unique to the user EE definition, files can be referenced by either
         an absolute path or a path relative to the EE definition folder
         This method will return the absolute path.
@@ -117,20 +129,39 @@ class UserDefinition(BaseDefinition):
 
         return os.path.join(self.reference_path, req_file)
 
+    def get_dep(self, entry):
+        """Returns the filename of the file within the build context.
+        """
+        original_path = self.get_dep_abs_path(entry)
+        if original_path:
+            return os.path.basename(original_path)
+        return original_path
+
+    def validate(self):
+        bc_files = set(['introspect.py', 'Dockerfile', 'Containerfile'])
+        for item in CONTEXT_FILES:
+            requirement_path = self.get_dep_abs_path(item)
+            if requirement_path:
+                filename = os.path.basename(requirement_path)
+                if filename in bc_files:
+                    raise DefinitionError('Duplicated filename {} in definition.'.format(filename))
+                if not os.path.exists(requirement_path):
+                    raise DefinitionError('Dependency file {} does not exist.'.format(requirement_path))
+                bc_files.add(filename)
+
 
 class Containerfile:
     newline_char = '\n'
 
     def __init__(self, definition,
-                 filename=constants.default_file,
                  build_context=constants.default_build_context,
                  base_image=constants.default_base_image,
                  container_runtime=constants.default_container_runtime,
                  tag=constants.default_tag):
 
         self.build_context = build_context
-        os.makedirs(self.build_context, exist_ok=True)
         self.definition = definition
+        filename = constants.runtime_files[container_runtime]
         self.path = os.path.join(self.build_context, filename)
         self.base_image = base_image
         self.container_runtime = container_runtime
@@ -139,6 +170,29 @@ class Containerfile:
             "FROM {}".format(self.base_image),
             ""
         ]
+
+    def initialize_folder(self):
+        """Creates the build context file for this Containerfile
+        moves files from the definition into the folder
+        """
+        # courteously validate items before starting to write files
+        self.definition.validate()
+
+        os.makedirs(self.build_context, exist_ok=True)
+
+        for item in CONTEXT_FILES:
+            requirement_path = self.definition.get_dep_abs_path(item)
+            if requirement_path is None:
+                continue
+            dest = os.path.join(self.build_context, os.path.basename(requirement_path))
+            exists = os.path.exists(dest)
+            do_copy = True
+            if exists:
+                do_copy = not filecmp.cmp(requirement_path, dest, shallow=False)
+                if do_copy:
+                    print(MessageColors.WARNING + 'File {} had modifications and will be rewritten'.format(dest) + MessageColors.ENDC)
+            if do_copy:
+                shutil.copy(requirement_path, self.build_context)
 
     def prepare_prepended_steps(self):
         additional_prepend_steps = self.definition.get_additional_commands()
@@ -168,23 +222,12 @@ class Containerfile:
         self.steps.extend(IntrospectionSteps(os.path.basename(dest)))
 
     def prepare_galaxy_steps(self):
-        galaxy_requirements_path = self.definition.get_dependency('galaxy')
-        if galaxy_requirements_path:
-            # name is most likely "requirements.yml"
-            galaxy_requirements_name = os.path.basename(galaxy_requirements_path)
-            # TODO: what if build context file exists? https://github.com/ansible/ansible-builder/issues/20
-            dest = os.path.join(self.build_context, galaxy_requirements_name)
-            exists = os.path.exists(dest)
-            if not exists or not filecmp.cmp(galaxy_requirements_path, dest, shallow=False):
-                shutil.copy(galaxy_requirements_path, dest)
-
-            self.steps.extend(GalaxySteps(galaxy_requirements_name))
+        galaxy_file = self.definition.get_dep('galaxy')
+        if galaxy_file:
+            self.steps.extend(GalaxySteps(galaxy_file))
 
     def prepare_pip_steps(self):
-        python_req_path = self.definition.get_dependency('python')
-        if python_req_path:
-            shutil.copy(python_req_path, self.build_context)
-
+        python_req_file = self.definition.get_dep('python')
 
         command = [self.container_runtime, "run", "--rm", self.tag, "introspect"]
         rc, output = run_command(command, capture_output=True)
@@ -196,7 +239,7 @@ class Containerfile:
 
         self.steps.extend(
             PipSteps(
-                python_req_path,
+                python_req_file,
                 requirements_files
             )
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,11 +13,17 @@ def do_not_run_commands():
 @pytest.fixture
 def exec_env_definition_file(tmpdir):
 
-    def _write_file(content={}):
+    def _write_file(content=None):
         path = tmpdir.mkdir('aee').join('execution-env.yml')
 
+        write_str = {}
+        if isinstance(content, dict):
+            write_str = yaml.dump(content)
+        elif isinstance(content, str):
+            write_str = content
+
         with open(path, 'w') as outfile:
-            yaml.dump(content, outfile)
+            outfile.write(write_str)
 
         return path
 


### PR DESCRIPTION
I'm willing to say this Fixes #20 and Fixes #17 

The core reason for doing this is that `python` and `galaxy` are accepted in dependencies now. I didn't realize the complexity of what @shanemcd had previously done with `filecmp.cmp`, and this right away reveals that we are inconsistent with how we treat the python file vs. the galaxy file. We may _always_ copy one, but not the other. I'm looking at adding the `system` file in #52, so it's critical that whatever validation we do in advance of copying this stuff happens consistently for all the files.

### tests

This undoes a lot of what I did in https://github.com/ansible/ansible-builder/pull/34/files#diff-3e85841b8cff61e2a613aa9b0c63a081, which fixed tests leaving artifacts around. Now, a fake directory is no longer necessary for things that don't actually call the `.build` command.

### file paths

The name `get_dep_abs_path` is intentionally obscure, because it's something that we should need early in the process, but only briefly, and never after then. The python/galaxy/system files could be any crazy place on the computer, but `ansible-builder` will copy them into the build context. After they are copied, they only have their `basename` like `requirements.yml`. The code is confusing switching between the source path and the plain path. This formats it so that we will always use the plain path when in the parts figuring out the galaxy steps.