### PR TITLE
Add processing of python requirements to run AWX case to completion

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -8,6 +8,7 @@ from .colors import MessageColors
 from .main import AnsibleBuilder, DefinitionError
 from . import constants
 from .introspect import add_introspect_options, process
+from .requirements import sanitize_requirements
 
 
 def run():
@@ -25,9 +26,15 @@ def run():
     elif args.action == 'introspect':
         for folder in args.folders:
             data = process(folder)
-            print()
-            print('Dependency data for {0}'.format(folder))
-            print(yaml.dump(data, default_flow_style=False))
+            if args.sanitize:
+                data['python'] = sanitize_requirements(data['python'])
+                print()
+                print('Sanitized dependencies for {0}'.format(folder))
+                print(yaml.dump(data, default_flow_style=False))
+            else:
+                print()
+                print('Dependency data for {0}'.format(folder))
+                print(yaml.dump(data, default_flow_style=False))
         sys.exit(0)
 
     print(MessageColors.FAIL + "An error has occured." + MessageColors.ENDC)
@@ -97,6 +104,13 @@ def parse_args(args=sys.argv[1:]):
         )
     )
     add_introspect_options(introspect_parser)
+    introspect_parser.add_argument(
+        '--sanitize', help=(
+            'Sanite and de-duplicate requirements. '
+            'This is normally done separately from the introspect script, but this '
+            'option is given to more accurately test collection content.'
+        ), action='store_true'
+    )
 
     args = parser.parse_args(args)
 

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -106,7 +106,7 @@ def parse_args(args=sys.argv[1:]):
     add_introspect_options(introspect_parser)
     introspect_parser.add_argument(
         '--sanitize', help=(
-            'Sanite and de-duplicate requirements. '
+            'Sanitize and de-duplicate requirements. '
             'This is normally done separately from the introspect script, but this '
             'option is given to more accurately test collection content.'
         ), action='store_true'

--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -1,0 +1,50 @@
+import requirements
+
+
+EXCLUDE_REQUIREMENTS = frozenset((
+    # obviously already satisfied or unwanted
+    'ansible', 'ansible-base', 'python',
+    # general python test requirements
+    'tox', 'pycodestyle', 'yamllint', 'pylint',
+    'flake8', 'pytest', 'pytest-xdist', 'coverage', 'mock',
+    # test requirements highly specific to Ansible testing
+    'ansible-lint', 'molecule', 'galaxy-importer', 'voluptuous',
+    # already present in image for py3 environments
+    'requests', 'yaml', 'pyyaml', 'json',
+))
+
+
+def sanitize_requirements(py_reqs):
+    parsed = requirements.parse('\n'.join(py_reqs))
+
+    # de-duplication
+    consolidated = []
+    seen_pkgs = set()
+    for req in parsed:
+        if req.name is None:
+            consolidated.append(req)
+            continue
+        if req.name in seen_pkgs:
+            for prior_req in consolidated:
+                if req.name == prior_req.name:
+                    prior_req.specs.extend(req.specs)
+                    break
+            continue
+        consolidated.append(req)
+        seen_pkgs.add(req.name)
+
+    # removal of unwanted packages
+    sanitized = []
+    for req in consolidated:
+        if req.name and req.name.lower() in EXCLUDE_REQUIREMENTS:
+            continue
+        if req.name is None and req.vcs:
+            # A source control requirement like git+, return as-is
+            sanitized.append(req.line)
+        elif req.name:
+            specs = ['{}{}'.format(cmp, ver) for cmp, ver in req.specs]
+            sanitized.append(req.name + ','.join(specs))
+        else:
+            raise RuntimeError('Could not process {}'.format(req.line))
+
+    return sanitized

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -78,6 +78,7 @@ class BindepSteps(Steps):
                 "RUN dnf -y install $(bindep -q -f {})".format(file)
             )
 
+
 class PipSteps(Steps):
     def __init__(self, context_file):
         """Allows for 1 python requirement file in the build context"""

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -78,38 +78,16 @@ class BindepSteps(Steps):
                 "RUN dnf -y install $(bindep -q -f {})".format(file)
             )
 
-
 class PipSteps(Steps):
-    def __init__(self, context_file, collection_files):
-        """Allows for 1 python requirement file in the build context
-        In collection files, expects a list of relative paths where python requirements files live
-        returns a list of commands to put in Containerfile
-        """
+    def __init__(self, context_file):
+        """Allows for 1 python requirement file in the build context"""
         self.steps = []
-        sanitized_files = []
-        if context_file:
-            # requirements file added to build context
-            file_naming = os.path.basename(context_file)
-            self.steps.append(
-                "ADD {} /build/".format(file_naming)
-            )
-            sanitized_files.append(os.path.join('/build/', file_naming))
+        if not context_file:
+            return
 
-        for entry in collection_files:
-            # requirements file from collection, use absolute path
-            sanitized_files.append(os.path.join(
-                constants.base_collections_path, 'ansible_collections', entry
-            ))
-
-        if len(sanitized_files) == 1:
-            self.steps.append(
-                "RUN pip3 install -r {content}".format(content=sanitized_files[0])
-            )
-        elif len(sanitized_files) > 1:
-            line_return = ' \\\n    -r '
-            self.steps.extend([
-                "RUN pip3 install{line_return}{content}".format(
-                    line_return=line_return,
-                    content=line_return.join(sanitized_files)
-                )
-            ])
+        # requirements file added to build context
+        self.steps.append("ADD {} /build/".format(context_file))
+        container_path = os.path.join('/build/', context_file)
+        self.steps.append(
+            "RUN pip3 install --upgrade -r {content}".format(content=container_path)
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -865,6 +865,14 @@ security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
+category = "main"
+description = "Parses Pip requirement files"
+name = "requirements-parser"
+optional = false
+python-versions = "*"
+version = "0.2.0"
+
+[[package]]
 category = "dev"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 name = "ruamel.yaml"
@@ -1193,7 +1201,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "618bc5caed1ba5105e5315625e1a3437cadfef754716f265fe328073a2d7b42f"
+content-hash = "35006568b62b9d710316c6f13e07263b6c11291d47d9ab3af0f12fe5f58343f8"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1582,6 +1590,10 @@ regex = [
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
+requirements-parser = [
+    {file = "requirements-parser-0.2.0.tar.gz", hash = "sha256:5963ee895c2d05ae9f58d3fc641082fb38021618979d6a152b6b1398bd7d4ed4"},
+    {file = "requirements_parser-0.2.0-py2-none-any.whl", hash = "sha256:76650b4a9d98fc65edf008a7920c076bb2a76c08eaae230ce4cfc6f51ea6a773"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.16.10-py2.py3-none-any.whl", hash = "sha256:0962fd7999e064c4865f96fb1e23079075f4a2a14849bcdc5cdba53a24f9759b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Matthew Jones <matburt@redhat.com>",
 [tool.poetry.dependencies]
 python = "^3.6"
 pyyaml = "^3.12"     # Do not bump this version, its the minimum for el7 and el8 packaging
+requirements-parser = "^0.2.0"
 
 [tool.poetry.scripts]
 ansible-builder = 'ansible_builder.cli:run'

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     packages=['ansible_builder'],
     package_dir={"": "."},
     package_data={},
-    install_requires=['pyyaml==3.*,>=3.12.0'],
+    install_requires=['pyyaml==3.*,>=3.12.0', 'requirements-parser==0.*,>=0.2.0'],
     extras_require={"dev": ["black==19.*,>=19.10.0.b0", "dephell==0.*,>=0.8.3", "flake8==3.*,>=3.7.9", "ipdb==0.*,>=0.13.2", "pylint==2.*,>=2.4.4", "pyparsing==2.*,>=2.4.5", "pytest==5.*,>=5.2.0", "sphinx==2.*,>=2.4.4", "tox==3.*,>=3.14.5", "yamllint==1.*,>=1.20.0"]},
 )

--- a/test/data/ansible_collections/test/bindep/bindep.txt
+++ b/test/data/ansible_collections/test/bindep/bindep.txt
@@ -1,0 +1,2 @@
+subversion [platform:rpm]
+subversion [platform:dpkg]

--- a/test/data/ansible_collections/test/metadata/my-requirements.txt
+++ b/test/data/ansible_collections/test/metadata/my-requirements.txt
@@ -1,1 +1,1 @@
-pyvcloud
+pyvcloud>=14

--- a/test/data/ansible_collections/test/reqfile/extra_req.txt
+++ b/test/data/ansible_collections/test/reqfile/extra_req.txt
@@ -1,0 +1,2 @@
+tacacs_plus
+pyvcloud>=18.0.10  # duplicate with test.metadata collection

--- a/test/data/ansible_collections/test/reqfile/requirements.txt
+++ b/test/data/ansible_collections/test/reqfile/requirements.txt
@@ -1,1 +1,2 @@
 pytz
+-r extra_req.txt

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -4,6 +4,7 @@ import pytest
 from ansible_builder import __version__
 from ansible_builder.main import AnsibleBuilder, UserDefinition, DefinitionError
 from ansible_builder.introspect import process
+from ansible_builder.requirements import sanitize_requirements
 
 
 def test_version():
@@ -95,11 +96,15 @@ def data_dir():
 def test_collection_metadata(data_dir):
 
     files = process(data_dir)
+    files['python'] = sanitize_requirements(files['python'])
 
-    assert files == [
-        'test/metadata/my-requirements.txt',
-        'test/reqfile/requirements.txt'
-    ]
+    assert files == {'python': [
+        'pyvcloud>=14,>=18.0.10',
+        'pytz',
+        'tacacs_plus'
+    ], 'system': [
+        'test/bindep/bindep.txt'
+    ]}
 
 
 def test_nested_galaxy_file(data_dir, tmpdir):

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -1,0 +1,23 @@
+from ansible_builder.requirements import sanitize_requirements
+
+
+def test_combine_entries():
+    assert sanitize_requirements([
+        'foo>1.0',
+        'foo>=2.0'
+    ]) == ['foo>1.0,>=2.0']
+
+
+def test_remove_unwanted_requirements():
+    assert sanitize_requirements([
+        'foo',
+        'ansible',
+        'bar',
+        'pytest',
+        'bar',
+        'zoo'
+    ]) == [
+        'foo',
+        'bar',
+        'zoo'
+    ]

--- a/test/test_steps.py
+++ b/test/test_steps.py
@@ -5,15 +5,9 @@ from ansible_builder.steps import AdditionalBuildSteps, PipSteps, BindepSteps
 
 
 def test_steps_for_collection_dependencies():
-    assert list(PipSteps(None, [
-        'test/metadata/my-requirements.txt',
-        'test/reqfile/requirements.txt'
-    ])) == [
-        '\n'.join([
-            'RUN pip3 install \\',
-            '    -r /usr/share/ansible/collections/ansible_collections/test/metadata/my-requirements.txt \\',
-            '    -r /usr/share/ansible/collections/ansible_collections/test/reqfile/requirements.txt'
-        ])
+    assert list(PipSteps('requirements.txt')) == [
+        'ADD requirements.txt /build/',
+        'RUN pip3 install --upgrade -r /build/requirements.txt'
     ]
 
 


### PR DESCRIPTION
Fixes #45 

This gets it so that the "awx" case in my examples PR (also still open) will run to completion and finish the playbook.

This changes several major mechanics of how `ansible-builder` runs:

 - `introspect.py` now returns lines of requirements files, instead of the location of requirements files
 - a dependency is added to parse python requirements
 - after reading the output of the introspect script, the main program does light processing of the requirements, and combines then into a single `requirements.txt` inside of the build context. This also means that the user's python requirements are combined, and not copied into the build context anymore
 - obviously, the pip steps are now just 1 `-r`