### PR TITLE
Initial processing of bindep.txt from collections

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -8,7 +8,7 @@ from .colors import MessageColors
 from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from . import constants
-from .introspect import add_introspect_options, process
+from .introspect import add_introspect_options, process, write_files, simple_combine
 from .requirements import sanitize_requirements
 
 
@@ -25,17 +25,17 @@ def run():
             print(e.args[0])
             sys.exit(1)
     elif args.action == 'introspect':
-        for folder in args.folders:
-            data = process(folder)
-            if args.sanitize:
-                data['python'] = sanitize_requirements(data['python'])
-                print()
-                print('Sanitized dependencies for {0}'.format(folder))
-                print(yaml.dump(data, default_flow_style=False))
-            else:
-                print()
-                print('Dependency data for {0}'.format(folder))
-                print(yaml.dump(data, default_flow_style=False))
+        data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
+        if args.sanitize:
+            data['python'] = sanitize_requirements(data['python'])
+            data['system'] = simple_combine(data['system'])
+            print()
+            print('Sanitized dependencies for {0}'.format(args.folder))
+        else:
+            print()
+            print('Dependency data for {0}'.format(args.folder))
+        print(yaml.dump(data, default_flow_style=False))
+        write_files(data, write_pip=args.write_pip, write_bindep=args.write_bindep)
         sys.exit(0)
 
     print(MessageColors.FAIL + "An error has occured." + MessageColors.ENDC)

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -8,7 +8,7 @@ from .colors import MessageColors
 from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from . import constants
-from .introspect import add_introspect_options, process, write_files, simple_combine
+from .introspect import add_introspect_options, process, simple_combine
 from .requirements import sanitize_requirements
 
 
@@ -25,17 +25,17 @@ def run():
             print(e.args[0])
             sys.exit(1)
     elif args.action == 'introspect':
-        data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
+        data = process(args.folder)
         if args.sanitize:
             data['python'] = sanitize_requirements(data['python'])
             data['system'] = simple_combine(data['system'])
             print()
-            print('Sanitized dependencies for {0}'.format(args.folder))
+            print('# Sanitized dependencies for {0}'.format(args.folder))
         else:
             print()
-            print('Dependency data for {0}'.format(args.folder))
+            print('# Dependency data for {0}'.format(args.folder))
+        print('---')
         print(yaml.dump(data, default_flow_style=False))
-        write_files(data, write_pip=args.write_pip, write_bindep=args.write_bindep)
         sys.exit(0)
 
     print(MessageColors.FAIL + "An error has occured." + MessageColors.ENDC)

--- a/ansible_builder/introspect.py
+++ b/ansible_builder/introspect.py
@@ -10,9 +10,6 @@ import argparse
 base_collections_path = '/usr/share/ansible/collections'
 default_file = 'execution-environment.yml'
 
-begin_delimiter = '----begin_introspect_output----'
-end_delimiter = '----end_introspect_output----'
-
 
 def line_is_empty(line):
     return bool((not line.strip()) or line.startswith('#'))
@@ -196,19 +193,6 @@ def write_files(data, write_pip=None, write_bindep=None):
             f.write('\n'.join(simple_combine(data.get('system')) + ['']))
 
 
-def parse_introspect_output(stdout):
-    p = re.compile(
-        '{0}(?P<yaml_text>.+){1}'.format(begin_delimiter, end_delimiter),
-        flags=re.MULTILINE | re.DOTALL
-    )
-    m = p.search(stdout)
-    if m is None:
-        return None
-    yaml_text = m.group('yaml_text').strip()
-    data = yaml.safe_load(yaml_text)
-    return data
-
-
 def add_introspect_options(parser):
     parser.add_argument(
         'folder', default=base_collections_path, nargs='?',
@@ -246,8 +230,6 @@ if __name__ == '__main__':
     add_introspect_options(parser)
     args = parser.parse_args()
     data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
-    print(begin_delimiter)
     print(yaml.dump(data, default_flow_style=False))
-    print(end_delimiter)
     write_files(data, write_pip=args.write_pip, write_bindep=args.write_bindep)
     sys.exit(0)

--- a/ansible_builder/introspect.py
+++ b/ansible_builder/introspect.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import sys
 import yaml
 import argparse
@@ -9,54 +10,91 @@ import argparse
 base_collections_path = '/usr/share/ansible/collections'
 default_file = 'execution-environment.yml'
 
+begin_delimiter = '----begin_introspect_output----'
+end_delimiter = '----end_introspect_output----'
+
+
+def line_is_empty(line):
+    return bool((not line.strip()) or line.startswith('#'))
+
 
 def pip_file_data(path):
-    req_list = []
     with open(path, 'r') as f:
-        for line in f.read().split('\n'):
-            if not line:
-                continue
-            if line.startswith('-r') or line.startswith('--requirement'):
-                _, new_filename = line.split(None, 1)
-                new_path = os.path.join(os.path.dirname(path or '.'), new_filename)
-                req_list.extend(pip_file_data(new_path))
-            else:
-                req_list.append(line)
-    return req_list
+        pip_content = f.read()
+
+    pip_lines = []
+    for line in pip_content.split('\n'):
+        if line_is_empty(line):
+            continue
+        if line.startswith('-r') or line.startswith('--requirement'):
+            _, new_filename = line.split(None, 1)
+            new_path = os.path.join(os.path.dirname(path or '.'), new_filename)
+            pip_lines.extend(pip_file_data(new_path))
+        else:
+            pip_lines.append(line)
+
+    return pip_lines
 
 
-def process(data_dir=base_collections_path):
+def bindep_file_data(path):
+    with open(path, 'r') as f:
+        sys_content = f.read()
+
+    sys_lines = []
+    for line in sys_content.split('\n'):
+        if line_is_empty(line):
+            continue
+        sys_lines.append(line)
+
+    return sys_lines
+
+
+def process(data_dir=base_collections_path, user_pip=None, user_bindep=None):
     paths = []
     path_root = os.path.join(data_dir, 'ansible_collections')
-    if not os.path.exists(path_root):
-        return {'python': [], 'system': []}
 
-    for namespace in sorted(os.listdir(path_root)):
-        if not os.path.isdir(os.path.join(path_root, namespace)):
-            continue
-        for name in sorted(os.listdir(os.path.join(path_root, namespace))):
-            collection_dir = os.path.join(path_root, namespace, name)
-            if not os.path.isdir(collection_dir):
+    # build a list of all the valid collection paths
+    if os.path.exists(path_root):
+        for namespace in sorted(os.listdir(path_root)):
+            if not os.path.isdir(os.path.join(path_root, namespace)):
                 continue
-            files_list = os.listdir(collection_dir)
-            if 'galaxy.yml' in files_list or 'MANIFEST.json' in files_list:
-                paths.append(collection_dir)
+            for name in sorted(os.listdir(os.path.join(path_root, namespace))):
+                collection_dir = os.path.join(path_root, namespace, name)
+                if not os.path.isdir(collection_dir):
+                    continue
+                files_list = os.listdir(collection_dir)
+                if 'galaxy.yml' in files_list or 'MANIFEST.json' in files_list:
+                    paths.append(collection_dir)
 
-    py_req = []
-    sys_req = []
+    # populate the requirements content
+    py_req = {}
+    sys_req = {}
     for path in paths:
         CD = CollectionDefinition(path)
         namespace, name = CD.namespace_name()
+        key = '{}.{}'.format(namespace, name)
 
         py_file = CD.get_dependency('python')
         if py_file:
-            py_req.extend(
-                pip_file_data(os.path.join(path, py_file))
-            )
+            col_pip_lines = pip_file_data(os.path.join(path, py_file))
+            if col_pip_lines:
+                py_req[key] = col_pip_lines
 
         sys_file = CD.get_dependency('system')
         if sys_file:
-            sys_req.append(os.path.join(namespace, name, sys_file))
+            col_sys_lines = bindep_file_data(os.path.join(path, sys_file))
+            if col_sys_lines:
+                sys_req[key] = col_sys_lines
+
+    # add on entries from user files, if they are given
+    if user_pip:
+        col_pip_lines = pip_file_data(user_pip)
+        if col_pip_lines:
+            py_req['user'] = col_pip_lines
+    if user_bindep:
+        col_sys_lines = bindep_file_data(user_bindep)
+        if col_sys_lines:
+            sys_req['user'] = col_sys_lines
 
     return {
         'python': py_req,
@@ -125,13 +163,75 @@ class CollectionDefinition:
         return req_file
 
 
+def simple_combine(reqs):
+    """Given a dictionary of requirement lines keyed off collections,
+    return a list with the most basic of de-duplication logic,
+    and comments indicating the sources based off the collection keys
+    """
+    consolidated = []
+    fancy_lines = []
+    for collection, lines in reqs.items():
+        for line in lines:
+            if line_is_empty(line):
+                continue
+
+            base_line = line.split('#')[0].strip()
+            if base_line in consolidated:
+                i = consolidated.index(base_line)
+                fancy_lines[i] += ', {}'.format(collection)
+            else:
+                fancy_line = base_line + '  # from collection {}'.format(collection)
+                consolidated.append(base_line)
+                fancy_lines.append(fancy_line)
+
+    return fancy_lines
+
+
+def write_files(data, write_pip=None, write_bindep=None):
+    if write_pip and data.get('python'):
+        with open(write_pip, 'w') as f:
+            f.write('\n'.join(simple_combine(data.get('python')) + ['']))
+    if write_bindep and data.get('system'):
+        with open(write_bindep, 'w') as f:
+            f.write('\n'.join(simple_combine(data.get('system')) + ['']))
+
+
+def parse_introspect_output(stdout):
+    p = re.compile(
+        '{0}(?P<yaml_text>.+){1}'.format(begin_delimiter, end_delimiter),
+        flags=re.MULTILINE | re.DOTALL
+    )
+    m = p.search(stdout)
+    if m is None:
+        return None
+    yaml_text = m.group('yaml_text').strip()
+    data = yaml.safe_load(yaml_text)
+    return data
+
+
 def add_introspect_options(parser):
     parser.add_argument(
-        'folders', default=[base_collections_path], nargs='*',
+        'folder', default=base_collections_path, nargs='?',
         help=(
             'Ansible collections path(s) to introspect. '
             'This should have a folder named ansible_collections inside of it.'
         )
+    )
+    parser.add_argument(
+        '--user-pip', dest='user_pip',
+        help='An additional file to combine with collection pip requirements.'
+    )
+    parser.add_argument(
+        '--user-bindep', dest='user_bindep',
+        help='An additional file to combine with collection bindep requirements.'
+    )
+    parser.add_argument(
+        '--write-pip', dest='write_pip',
+        help='Write the combined bindep file to this location.'
+    )
+    parser.add_argument(
+        '--write-bindep', dest='write_bindep',
+        help='Write the combined bindep file to this location.'
     )
 
 
@@ -145,11 +245,9 @@ if __name__ == '__main__':
     )
     add_introspect_options(parser)
     args = parser.parse_args()
-    # TODO: modify contract to handle multiple locations more gracefully
-    data = {'python': [], 'system': []}
-    for folder in args.folders:
-        this_data = process(folder)
-        data['python'].extend(this_data['python'])
-        data['system'].extend(this_data['system'])
+    data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
+    print(begin_delimiter)
     print(yaml.dump(data, default_flow_style=False))
+    print(end_delimiter)
+    write_files(data, write_pip=args.write_pip, write_bindep=args.write_bindep)
     sys.exit(0)

--- a/ansible_builder/introspect.py
+++ b/ansible_builder/introspect.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import re
 import sys
 import yaml
 import argparse
@@ -46,7 +45,7 @@ def bindep_file_data(path):
     return sys_lines
 
 
-def process(data_dir=base_collections_path, user_pip=None, user_bindep=None):
+def process(data_dir=base_collections_path):
     paths = []
     path_root = os.path.join(data_dir, 'ansible_collections')
 
@@ -82,16 +81,6 @@ def process(data_dir=base_collections_path, user_pip=None, user_bindep=None):
             col_sys_lines = bindep_file_data(os.path.join(path, sys_file))
             if col_sys_lines:
                 sys_req[key] = col_sys_lines
-
-    # add on entries from user files, if they are given
-    if user_pip:
-        col_pip_lines = pip_file_data(user_pip)
-        if col_pip_lines:
-            py_req['user'] = col_pip_lines
-    if user_bindep:
-        col_sys_lines = bindep_file_data(user_bindep)
-        if col_sys_lines:
-            sys_req['user'] = col_sys_lines
 
     return {
         'python': py_req,
@@ -184,15 +173,6 @@ def simple_combine(reqs):
     return fancy_lines
 
 
-def write_files(data, write_pip=None, write_bindep=None):
-    if write_pip and data.get('python'):
-        with open(write_pip, 'w') as f:
-            f.write('\n'.join(simple_combine(data.get('python')) + ['']))
-    if write_bindep and data.get('system'):
-        with open(write_bindep, 'w') as f:
-            f.write('\n'.join(simple_combine(data.get('system')) + ['']))
-
-
 def add_introspect_options(parser):
     parser.add_argument(
         'folder', default=base_collections_path, nargs='?',
@@ -200,22 +180,6 @@ def add_introspect_options(parser):
             'Ansible collections path(s) to introspect. '
             'This should have a folder named ansible_collections inside of it.'
         )
-    )
-    parser.add_argument(
-        '--user-pip', dest='user_pip',
-        help='An additional file to combine with collection pip requirements.'
-    )
-    parser.add_argument(
-        '--user-bindep', dest='user_bindep',
-        help='An additional file to combine with collection bindep requirements.'
-    )
-    parser.add_argument(
-        '--write-pip', dest='write_pip',
-        help='Write the combined bindep file to this location.'
-    )
-    parser.add_argument(
-        '--write-bindep', dest='write_bindep',
-        help='Write the combined bindep file to this location.'
     )
 
 
@@ -229,7 +193,6 @@ if __name__ == '__main__':
     )
     add_introspect_options(parser)
     args = parser.parse_args()
-    data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
+    data = process(args.folder)
     print(yaml.dump(data, default_flow_style=False))
-    write_files(data, write_pip=args.write_pip, write_bindep=args.write_bindep)
     sys.exit(0)

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -5,7 +5,7 @@ import yaml
 from . import constants
 from .colors import MessageColors
 from .exceptions import DefinitionError
-from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, IntrospectionSteps, BindepSteps
+from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, BindepSteps
 from .utils import run_command, write_file, copy_file
 from .requirements import sanitize_requirements
 import ansible_builder.introspect
@@ -13,9 +13,7 @@ import ansible_builder.introspect
 
 # Files that need to be moved into the build context, and their naming inside the context
 CONTEXT_FILES = {
-    'galaxy': 'requirements.yml',
-    'python': 'requirements_user.txt',
-    'system': 'bindep_user.txt'
+    'galaxy': 'requirements.yml'
 }
 BINDEP_COMBINED = 'bindep_combined.txt'
 BINDEP_OUTPUT = 'bindep_output.txt'
@@ -57,35 +55,50 @@ class AnsibleBuilder:
     def run_in_container(self, command, **kwargs):
         wrapped_command = [self.container_runtime, 'run','--rm']
 
-        volumes = kwargs.pop('volumes', [])
-        for volume in volumes:
-            wrapped_command.extend(['-v', volume])
+        wrapped_command.extend(['-v', f"{os.path.abspath(self.build_context)}:/context:Z"])
 
         wrapped_command.extend([self.tag, '/bin/bash', '-c', ' '.join(command)])
 
         return run_command(wrapped_command, **kwargs)
 
+    def run_intermission(self):
+        run_command(self.build_command, capture_output=True)
+
+        rc, introspect_output = self.run_in_container(
+            ['python3', '/context/introspect.py'], capture_output=True
+        )
+        collection_data = yaml.safe_load('\n'.join(introspect_output))
+
+        # Add data from user definition, go from dicts to list
+        collection_data['system']['user'] = self.definition.user_system
+        collection_data['python']['user'] = self.definition.user_python
+        system_lines = ansible_builder.introspect.simple_combine(collection_data['system'])
+        python_lines = sanitize_requirements(collection_data['python'])
+
+        bindep_output = []
+        if system_lines:
+            write_file(os.path.join(self.build_context, BINDEP_COMBINED), system_lines + [''])
+
+            rc, bindep_output = self.run_in_container(
+                ['bindep', '-b', '-f', '/context/{0}'.format(BINDEP_COMBINED)],
+                allow_error=True, capture_output=True
+            )
+
+        return (bindep_output, python_lines)
+
     def build(self):
+        # Phase 1 of Containerfile
         self.containerfile.create_folder_copy_files()
         self.containerfile.prepare_prepended_steps()
         self.containerfile.prepare_galaxy_steps()
-        self.containerfile.prepare_introspection_steps()
         print(MessageColors.OK + 'Writing partial Containerfile without collection requirements' + MessageColors.ENDC)
         self.containerfile.write()
-        rc, output = run_command(self.build_command, capture_output=True)
 
-        rc, output = self.run_in_container(['introspect', '--write-bindep', '/context/bindep_combined.txt'],
-                                           volumes=[f"{os.path.abspath(self.build_context)}:/context:Z"],
-                                           capture_output=True)
+        system_lines, pip_lines = self.run_intermission()
 
-        collection_data = yaml.safe_load('\n'.join(output))
-        if collection_data.get('system'):
-            rc, output = self.run_in_container(['bindep', '-b', '-f', '/context/{0}'.format(BINDEP_COMBINED)],
-                                               volumes=[f"{os.path.abspath(self.build_context)}:/context:Z"],
-                                               allow_error=True, capture_output=True)
-            self.containerfile.prepare_system_steps(bindep_output=output)
-
-        self.containerfile.prepare_pip_steps(collection_pip=collection_data['python'])
+        # Phase 2 of Containerfile
+        self.containerfile.prepare_system_steps(bindep_output=system_lines)
+        self.containerfile.prepare_pip_steps(pip_lines=pip_lines)
         self.containerfile.prepare_appended_steps()
         print(MessageColors.OK + 'Rewriting Containerfile to capture collection requirements' + MessageColors.ENDC)
         self.containerfile.write()
@@ -132,6 +145,9 @@ class UserDefinition(BaseDefinition):
         if not isinstance(self.raw, dict):
             raise DefinitionError("Definition must be a dictionary, not {0}".format(type(self.raw).__name__))
 
+        self.user_python = self.read_dependency('python')
+        self.user_system = self.read_dependency('system')
+
     def get_additional_commands(self):
         """Gets additional commands from the exec env file, if any are specified.
         """
@@ -153,25 +169,23 @@ class UserDefinition(BaseDefinition):
 
         return os.path.join(self.reference_path, req_file)
 
-    def get_dep(self, entry):
-        """Returns the filename of the file within the build context.
-        """
-        original_path = self.get_dep_abs_path(entry)
-        if original_path:
-            return os.path.basename(original_path)
-        return original_path
+    def read_dependency(self, entry):
+        requirement_path = self.get_dep_abs_path(entry)
+        if not requirement_path:
+            return []
+        try:
+            with open(requirement_path, 'r') as f:
+                return f.read().split('\n')
+        except FileNotFoundError:
+            raise DefinitionError("Dependency file {0} does not exist.".format(requirement_path))
 
     def validate(self):
-        bc_files = set(['introspect.py', 'Dockerfile', 'Containerfile'])
         for item in CONTEXT_FILES:
             requirement_path = self.get_dep_abs_path(item)
             if requirement_path:
-                filename = os.path.basename(requirement_path)
-                if filename in bc_files:
-                    raise DefinitionError("Duplicated filename {0} in definition.".format(filename))
                 if not os.path.exists(requirement_path):
                     raise DefinitionError("Dependency file {0} does not exist.".format(requirement_path))
-                bc_files.add(filename)
+
         additional_cmds = self.get_additional_commands()
         if additional_cmds:
             if not isinstance(additional_cmds, dict):
@@ -225,6 +239,12 @@ class Containerfile:
             dest = os.path.join(self.build_context, new_name)
             copy_file(requirement_path, dest)
 
+        # copy introspect.py file from source into build context
+        copy_file(
+            ansible_builder.introspect.__file__,
+            os.path.join(self.build_context, 'introspect.py')
+        )
+
     def prepare_prepended_steps(self):
         additional_prepend_steps = self.definition.get_additional_commands()
         if additional_prepend_steps:
@@ -243,34 +263,15 @@ class Containerfile:
 
         return False
 
-    def prepare_introspection_steps(self):
-        source = ansible_builder.introspect.__file__
-        dest = os.path.join(self.build_context, 'introspect.py')
-        copy_file(source, dest)
-
-        user_files = {'python': None, 'system': None}
-        for item, context_name in CONTEXT_FILES.items():
-            if self.definition.get_dep_abs_path(item):
-                user_files[item] = context_name
-
-        self.steps.extend(
-            IntrospectionSteps(
-                'introspect.py', user_files['python'], user_files['system'],
-                BINDEP_COMBINED
-            )
-        )
-
     def prepare_galaxy_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):
             self.steps.extend(GalaxySteps(CONTEXT_FILES['galaxy']))
         return self.steps
 
-    def prepare_pip_steps(self, collection_pip):
-        pip_list = sanitize_requirements(collection_pip)
-
-        if ''.join(pip_list).strip():  # only use file if it is non-blank
+    def prepare_pip_steps(self, pip_lines):
+        if ''.join(pip_lines).strip():  # only use file if it is non-blank
             pip_file = os.path.join(self.build_context, PIP_COMBINED)
-            write_file(pip_file, pip_list)
+            write_file(pip_file, pip_lines)
             self.steps.extend(PipSteps(PIP_COMBINED))
 
         return self.steps

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -41,18 +41,6 @@ class IntrospectionSteps(Steps):
             "RUN chmod +x /usr/local/bin/introspect",
         ])
 
-        to_run = ['introspect']
-        if user_pip:
-            self.steps.append("ADD {0} /build/".format(user_pip))
-            to_run.extend(['--user-pip', '/build/{0}'.format(user_pip)])
-        if user_bindep:
-            self.steps.append("ADD {0} /build/".format(user_bindep))
-            to_run.extend(['--user-bindep', '/build/{0}'.format(user_bindep)])
-
-        to_run.extend(['--write-bindep', '/build/{0}'.format(dest_bindep)])
-
-        self.steps.append("RUN {0}".format(' '.join(to_run)))
-
 
 class GalaxySteps(Steps):
     def __init__(self, requirements_naming):

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -33,15 +33,6 @@ class AdditionalBuildSteps(Steps):
         return iter(self.steps)
 
 
-class IntrospectionSteps(Steps):
-    def __init__(self, context_file, user_pip, user_bindep, dest_bindep):
-        self.steps = []
-        self.steps.extend([
-            "ADD {0} /usr/local/bin/introspect".format(context_file),
-            "RUN chmod +x /usr/local/bin/introspect",
-        ])
-
-
 class GalaxySteps(Steps):
     def __init__(self, requirements_naming):
         """Assumes given requirements file name has been placed in the build context

--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -1,11 +1,13 @@
 import subprocess
 import sys
 import os
+import filecmp
+import shutil
 
 from .colors import MessageColors
 
 
-def run_command(command, capture_output=False):
+def run_command(command, capture_output=False, allow_error=False):
     print(MessageColors.HEADER + 'Running command:' + MessageColors.ENDC)
     print(MessageColors.HEADER + '  {0}'.format(' '.join(command)) + MessageColors.ENDC)
 
@@ -21,7 +23,7 @@ def run_command(command, capture_output=False):
         sys.stdout.write(line)
 
     rc = process.poll()
-    if rc is not None and rc != 0:
+    if rc is not None and rc != 0 and (not allow_error):
         print(MessageColors.FAIL + f"An error occured (rc={rc}), see output line(s) above for details." + MessageColors.ENDC)
         sys.exit(1)
 
@@ -40,3 +42,11 @@ def write_file(filename: str, lines: list) -> bool:
     with open(filename, 'w') as f:
         f.write(new_text)
     return True
+
+
+def copy_file(source: str, dest: str):
+    exists = os.path.exists(dest)
+    if (not exists) or (not filecmp.cmp(source, dest, shallow=False)):
+        if exists:
+            print(MessageColors.WARNING + 'File {0} had modifications and will be rewritten'.format(dest) + MessageColors.ENDC)
+        shutil.copy(source, dest)

--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -44,9 +44,13 @@ def write_file(filename: str, lines: list) -> bool:
     return True
 
 
-def copy_file(source: str, dest: str):
+def copy_file(source: str, dest: str) -> bool:
     exists = os.path.exists(dest)
     if (not exists) or (not filecmp.cmp(source, dest, shallow=False)):
         if exists:
             print(MessageColors.WARNING + 'File {0} had modifications and will be rewritten'.format(dest) + MessageColors.ENDC)
         shutil.copy(source, dest)
+        return True
+    else:
+        print(MessageColors.OK + "File {0} is already up-to-date.".format(dest) + MessageColors.ENDC)
+        return False

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,11 +2,16 @@ import yaml
 from unittest import mock
 import pytest
 import os
+from ansible_builder.introspect import begin_delimiter, end_delimiter
 
 
 @pytest.fixture(autouse=True)
 def do_not_run_commands():
-    cmd_mock = mock.MagicMock(return_value=[1, ['python:', '  - foo', 'system: []']])
+    cmd_mock = mock.MagicMock(return_value=[1, [
+        begin_delimiter,
+        'python:', '  foo: []', 'system: {}',
+        end_delimiter
+    ]])
     with mock.patch('ansible_builder.main.run_command', new=cmd_mock):
         yield cmd_mock
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,15 +2,12 @@ import yaml
 from unittest import mock
 import pytest
 import os
-from ansible_builder.introspect import begin_delimiter, end_delimiter
 
 
 @pytest.fixture(autouse=True)
 def do_not_run_commands():
     cmd_mock = mock.MagicMock(return_value=[1, [
-        begin_delimiter,
         'python:', '  foo: []', 'system: {}',
-        end_delimiter
     ]])
     with mock.patch('ansible_builder.main.run_command', new=cmd_mock):
         yield cmd_mock

--- a/test/data/awx/bindep.txt
+++ b/test/data/awx/bindep.txt
@@ -1,5 +1,0 @@
-gcc
-python3-devel
-libcurl-devel
-openssl-devel
-libxml2-devel

--- a/test/data/awx/execution-environment.yml
+++ b/test/data/awx/execution-environment.yml
@@ -2,7 +2,6 @@
 version: 1
 dependencies:
   galaxy: requirements.yml
-  system: bindep.txt
 additional_build_steps:
   prepend:
     - RUN pip3 install --upgrade pip setuptools

--- a/test/data/awx/execution-environment.yml
+++ b/test/data/awx/execution-environment.yml
@@ -5,4 +5,3 @@ dependencies:
 additional_build_steps:
   prepend:
     - RUN pip3 install --upgrade pip setuptools
-    - ENV PYCURL_SSL_LIBRARY=openssl

--- a/test/data/awx/requirements.yml
+++ b/test/data/awx/requirements.yml
@@ -14,7 +14,7 @@ collections:
     type: git
   - name: community.vmware  # has requirements.txt, but may add pyvcloud
   - name: https://github.com/alancoding/ovirt-ansible-collection.git
-    version: ee_req  # had no requirements file, only needs single sdk lib
+    version: ee_req  # had no needs single sdk python lib and pycurl
     type: git
   - name: https://github.com/AlanCoding/community.kubernetes.git
     version: ee_req

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -117,6 +117,6 @@ class TestPytz:
             f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
         )
         assert 'Collecting pytz (from -r /build/' not in r.stdout, r.stdout
-        assert 'requirements.txt is already up-to-date' in r.stdout
+        assert 'requirements_combined.txt is already up-to-date' in r.stdout, r.stdout
         stdout_no_whitespace = r.stdout.replace('--->', '-->').replace('\n', ' ').replace('   ', ' ').replace('  ', ' ')
-        assert 'ADD requirements.txt /build/ --> Using cache' in stdout_no_whitespace, r.stdout
+        assert 'ADD requirements_combined.txt /build/ --> Using cache' in stdout_no_whitespace, r.stdout

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -69,6 +69,18 @@ def test_user_system_requirement(cli, container_runtime, ee_tag, tmpdir, data_di
     assert 'Subversion is a tool for version control' in result.stdout
 
 
+def test_collection_system_requirement(cli, container_runtime, ee_tag, tmpdir, data_dir):
+    bc = str(tmpdir)
+    ee_def = os.path.join(data_dir, 'ansible.posix.at', 'execution-environment.yml')
+    cli(
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+    )
+    result = cli(
+        f'{container_runtime} run --rm {ee_tag} at -V'
+    )
+    assert 'at version' in result.stderr
+
+
 def test_user_python_requirement(cli, container_runtime, ee_tag, tmpdir, data_dir):
     bc = str(tmpdir)
     ee_def = os.path.join(data_dir, 'pip', 'execution-environment.yml')

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -24,8 +24,8 @@ def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmpdir, data_dir):
         allow_error=True
     )
     assert r.rc != 0
-    assert 'RUN thisisnotacommand' in (r.stdout + r.stderr)
-    assert 'thisisnotacommand: command not found' in (r.stdout + r.stderr)
+    assert 'RUN thisisnotacommand' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+    assert 'thisisnotacommand: command not found' in (r.stdout + r.stderr), (r.stdout + r.stderr)
 
 
 def test_missing_python_requirements_file():
@@ -54,7 +54,7 @@ def test_blank_execution_environment(cli, container_runtime, ee_tag, tmpdir, dat
         f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
     )
     result = cli(f'{container_runtime} run --rm {ee_tag} echo "This is a simple test"')
-    assert 'This is a simple test' in result.stdout
+    assert 'This is a simple test' in result.stdout, result.stdout
 
 
 def test_user_system_requirement(cli, container_runtime, ee_tag, tmpdir, data_dir):
@@ -66,7 +66,7 @@ def test_user_system_requirement(cli, container_runtime, ee_tag, tmpdir, data_di
     result = cli(
         f'{container_runtime} run --rm {ee_tag} svn --help'
     )
-    assert 'Subversion is a tool for version control' in result.stdout
+    assert 'Subversion is a tool for version control' in result.stdout, result.stdout
 
 
 def test_collection_system_requirement(cli, container_runtime, ee_tag, tmpdir, data_dir):
@@ -78,7 +78,7 @@ def test_collection_system_requirement(cli, container_runtime, ee_tag, tmpdir, d
     result = cli(
         f'{container_runtime} run --rm {ee_tag} at -V'
     )
-    assert 'at version' in result.stderr
+    assert 'at version' in result.stderr, result.stderr
 
 
 def test_user_python_requirement(cli, container_runtime, ee_tag, tmpdir, data_dir):
@@ -90,7 +90,7 @@ def test_user_python_requirement(cli, container_runtime, ee_tag, tmpdir, data_di
     result = cli(
         f'{container_runtime} run --rm {ee_tag} pip3 show awxkit'
     )
-    assert 'The official command line interface for Ansible AWX' in result.stdout
+    assert 'The official command line interface for Ansible AWX' in result.stdout, result.stdout
 
 
 class TestPytz:
@@ -108,7 +108,7 @@ class TestPytz:
     def test_has_pytz(self, cli, container_runtime, pytz):
         ee_tag, bc_folder = pytz
         r = cli(f'{container_runtime} run --rm {ee_tag} pip3 show pytz')
-        assert 'World timezone definitions, modern and historical' in r.stdout
+        assert 'World timezone definitions, modern and historical' in r.stdout, r.stdout
 
     def test_build_layer_reuse(self, cli, container_runtime, data_dir, pytz):
         ee_tag, bc_folder = pytz

--- a/test/integration/test_introspect.py
+++ b/test/integration/test_introspect.py
@@ -1,0 +1,12 @@
+import os
+
+
+def test_introspect_write(cli, data_dir, tmpdir):
+    dest_file = os.path.join(str(tmpdir), 'req.txt')
+    cli(f'ansible-builder introspect {data_dir} --write-bindep={dest_file}')
+    with open(dest_file, 'r') as f:
+        assert f.read() == '\n'.join([
+            'subversion [platform:rpm]  # from collection test.bindep',
+            'subversion [platform:dpkg]  # from collection test.bindep',
+            ''
+        ])

--- a/test/integration/test_introspect.py
+++ b/test/integration/test_introspect.py
@@ -1,12 +1,19 @@
-import os
+import yaml
 
 
-def test_introspect_write(cli, data_dir, tmpdir):
-    dest_file = os.path.join(str(tmpdir), 'req.txt')
-    cli(f'ansible-builder introspect {data_dir} --write-bindep={dest_file}')
-    with open(dest_file, 'r') as f:
-        assert f.read() == '\n'.join([
-            'subversion [platform:rpm]  # from collection test.bindep',
-            'subversion [platform:dpkg]  # from collection test.bindep',
-            ''
-        ])
+def test_introspect_write(cli, data_dir):
+    r = cli(f'ansible-builder introspect {data_dir}')
+    print(r.stdout)
+    data = yaml.safe_load(r.stdout)  # assure that output is valid YAML
+    assert 'python' in data
+    assert 'system' in data
+    assert 'pytz' in data['python']['test.reqfile']
+
+
+def test_introspect_with_sanitize(cli, data_dir):
+    r = cli(f'ansible-builder introspect --sanitize {data_dir}')
+    print(r.stdout)
+    data = yaml.safe_load(r.stdout)  # assure that output is valid YAML
+    assert 'python' in data
+    assert 'system' in data
+    assert '# from collection test.bindep' in r.stdout  # should have comments

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -4,7 +4,7 @@ import pytest
 from ansible_builder import __version__
 from ansible_builder.exceptions import DefinitionError
 from ansible_builder.main import AnsibleBuilder, UserDefinition
-from ansible_builder.introspect import process
+from ansible_builder.introspect import process, simple_combine
 from ansible_builder.requirements import sanitize_requirements
 
 
@@ -93,13 +93,15 @@ def test_collection_metadata(data_dir):
 
     files = process(data_dir)
     files['python'] = sanitize_requirements(files['python'])
+    files['system'] = simple_combine(files['system'])
 
     assert files == {'python': [
-        'pyvcloud>=14,>=18.0.10',
-        'pytz',
-        'tacacs_plus'
+        'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
+        'pytz  # from collection test.reqfile',
+        'tacacs_plus  # from collection test.reqfile'
     ], 'system': [
-        'test/bindep/bindep.txt'
+        'subversion [platform:rpm]  # from collection test.bindep',
+        'subversion [platform:dpkg]  # from collection test.bindep'
     ]}
 
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -134,10 +134,6 @@ class TestDefinitionErrors:
     @pytest.mark.parametrize('yaml_text,expect', [
         ('1', 'Definition must be a dictionary, not int'),  # integer
         (
-            "{'version': 1, 'dependencies': {'python': 'Dockerfile'}}",
-            'Duplicated filename Dockerfile in definition.'
-        ),  # bad python file
-        (
             "{'version': 1, 'dependencies': {'python': 'foo/not-exists.yml'}}",
             'not-exists.yml does not exist'
         ),  # missing file
@@ -149,7 +145,7 @@ class TestDefinitionErrors:
         (
             "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",
             "Keys ('middle',) are not allowed in 'additional_build_steps'."
-        ),  # not right format for additional_build_steps
+        ),
     ])
     def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
         path = exec_env_definition_file(yaml_text)

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -2,22 +2,35 @@ from ansible_builder.requirements import sanitize_requirements
 
 
 def test_combine_entries():
-    assert sanitize_requirements([
-        'foo>1.0',
-        'foo>=2.0'
-    ]) == ['foo>1.0,>=2.0']
+    assert sanitize_requirements({
+        'foo.bar': ['foo>1.0'],
+        'bar.foo': ['foo>=2.0']
+    }) == ['foo>1.0,>=2.0  # from collection foo.bar,bar.foo']
 
 
 def test_remove_unwanted_requirements():
-    assert sanitize_requirements([
-        'foo',
-        'ansible',
-        'bar',
-        'pytest',
-        'bar',
-        'zoo'
-    ]) == [
-        'foo',
-        'bar',
-        'zoo'
+    assert sanitize_requirements({
+        'foo.bar': [
+            'foo',
+            'ansible',
+            'bar',
+        ],
+        'bar.foo': [
+            'pytest',
+            'bar',
+            'zoo'
+        ]
+    }) == [
+        'foo  # from collection foo.bar',
+        'bar  # from collection foo.bar,bar.foo',
+        'zoo  # from collection bar.foo'
     ]
+
+
+def test_skip_bad_formats():
+    """A single incorrectly formatted requirement should warn, but not block other reqs"""
+    assert sanitize_requirements({'foo.bar': [
+        'foo',
+        'bar'
+    ], 'foo.bad': ['zizzer zazzer zuzz']  # not okay
+    }) == ['foo  # from collection foo.bar', 'bar  # from collection foo.bar']

--- a/test/test_steps.py
+++ b/test/test_steps.py
@@ -26,10 +26,7 @@ def test_additional_build_steps(verb):
 
 
 def test_system_steps():
-    assert list(BindepSteps(
-        'bindep.txt'
-    )) == [
-        'ADD bindep.txt /build/',
-        'RUN pip3 install bindep',
-        'RUN dnf -y install $(bindep -b -f /build/bindep.txt)'
+    assert list(BindepSteps('bindep_output.txt')) == [
+        'ADD bindep_output.txt /build/',
+        'RUN dnf -y install $(cat /build/bindep_output.txt)'
     ]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,6 +1,6 @@
 import os
 
-from ansible_builder.utils import write_file
+from ansible_builder.utils import write_file, copy_file
 
 
 def test_write_file(tmpdir):
@@ -15,3 +15,16 @@ def test_write_file(tmpdir):
     ]
     assert write_file(path, text)  # does not exist, write
     assert not write_file(path, text)  # already correct, do not write
+
+
+def test_copy_file(tmpdir):
+    dest = os.path.join(tmpdir, 'foo.txt')
+    source = os.path.join(tmpdir, 'bar.txt')
+    with open(source, 'w') as f:
+        f.write('foo\nbar\n')
+    assert copy_file(source, dest)
+    assert not copy_file(source, dest)
+
+    with open(source, 'w') as f:
+        f.write('foo\nbar\nzoo')
+    assert copy_file(source, dest)


### PR DESCRIPTION
Connect #50

This still needs more cleanup, but I want people to know where I'm going.

This corresponds to a change to my `ovirt.ovrit` branch which adds the `bindep.txt` of:

```
gcc [platform:rpm]
python3-devel [platform:rpm]
libcurl-devel [platform:rpm]
openssl-devel [platform:rpm]
libxml2-devel [platform:rpm]
```

This produces the `Dockerfile`

```
FROM shanemcd/ansible-runner

RUN pip3 install --upgrade pip setuptools
ENV PYCURL_SSL_LIBRARY=openssl
ADD introspect.py /usr/local/bin/introspect
RUN chmod +x /usr/local/bin/introspect
ADD requirements.yml /build/

RUN ansible-galaxy role install -r /build/requirements.yml --roles-path /usr/share/ansible/roles
RUN ansible-galaxy collection install -r /build/requirements.yml --collections-path /usr/share/ansible/collections
RUN pip3 install bindep
RUN dnf -y install $(bindep -b -f /usr/share/ansible/collections/ansible_collections/ovirt/ovirt/bindep.txt)
ADD requirements.txt /build/
RUN pip3 install --upgrade -r /build/requirements.txt
```

For the awx case with the definition:

```
---
version: 1
dependencies:
  galaxy: requirements.yml
additional_build_steps:
  prepend:
    - RUN pip3 install --upgrade pip setuptools
    - ENV PYCURL_SSL_LIBRARY=openssl
```

And with that, it does run to completion with all the python requirements (particularly pycurl) installing.