### PR TITLE
Exit Build Process If an Error is Detected

### DIFF
--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -20,4 +20,8 @@ def run_command(command, capture_output=False):
         sys.stdout.write(line)
 
     rc = process.poll()
+    if rc != 0:
+        print(MessageColors.FAIL + "An error occured, see output line(s) above for details." + MessageColors.ENDC)
+        sys.exit(1)
+
     return (rc, output)


### PR DESCRIPTION
Addressing issue https://github.com/ansible/ansible-builder/issues/51

Previously, when building a container with incorrect commands like `bindep -q`, everything would run as normal:

![Screen Shot 2020-07-31 at 1 30 06 PM](https://user-images.githubusercontent.com/28930622/89061775-515c0780-d333-11ea-9c63-04c9cf5a6570.png)


Now, the tool will print an error message and exit out immediately:

![Screen Shot 2020-07-31 at 1 26 03 PM](https://user-images.githubusercontent.com/28930622/89061821-62a51400-d333-11ea-99fe-d483f042f8ec.png)


