### PR TITLE
give sensible error when provide wrong type

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -204,8 +204,8 @@ class Containerfile:
         if additional_prepend_steps:
             if not isinstance(additional_prepend_steps, dict):
                 raise TypeError((
-                    "Expected 'additional_build_steps' to be a dictionary with keys 'prepend' and/or 'append',\n"
-                    f"found a {type(additional_prepend_steps)} instead"
+                    MessageColors.FAIL + "Expected 'additional_build_steps' to be a dictionary with keys 'prepend' and/or 'append',\n"
+                    f"found a {type(additional_prepend_steps)} instead" + MessageColors.ENDC
                 ))
             prepended_steps = additional_prepend_steps.get('prepend')
             if prepended_steps:
@@ -218,8 +218,8 @@ class Containerfile:
         if additional_append_steps:
             if not isinstance(additional_append_steps, dict):
                 raise TypeError((
-                    "Expected 'additional_build_steps' to be a dictionary with keys 'prepend' and/or 'append',\n"
-                    f"found a {type(additional_append_steps)} instead"
+                    MessageColors.FAIL + "Expected 'additional_build_steps' to be a dictionary with keys 'prepend' and/or 'append',\n"
+                    f"found a {type(additional_append_steps)} instead" + MessageColors.ENDC
                 ))
             appended_steps = additional_append_steps.get('append')
             if appended_steps:

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -126,6 +126,7 @@ class UserDefinition(BaseDefinition):
         if not req_file:
             return None
 
+        print(req_file)
         if os.path.isabs(req_file):
             return req_file
 
@@ -201,6 +202,11 @@ class Containerfile:
     def prepare_prepended_steps(self):
         additional_prepend_steps = self.definition.get_additional_commands()
         if additional_prepend_steps:
+            if not isinstance(additional_prepend_steps, dict):
+                raise TypeError((
+                    "Expected 'additional_build_steps' to be a dictionary with keys 'prepend' and/or 'append',\n"
+                    f"found a {type(additional_prepend_steps)} instead"
+                ))
             prepended_steps = additional_prepend_steps.get('prepend')
             if prepended_steps:
                 return self.steps.extend(AdditionalBuildSteps(prepended_steps))
@@ -210,6 +216,11 @@ class Containerfile:
     def prepare_appended_steps(self):
         additional_append_steps = self.definition.get_additional_commands()
         if additional_append_steps:
+            if not isinstance(additional_append_steps, dict):
+                raise TypeError((
+                    "Expected 'additional_build_steps' to be a dictionary with keys 'prepend' and/or 'append',\n"
+                    f"found a {type(additional_append_steps)} instead"
+                ))
             appended_steps = additional_append_steps.get('append')
             if appended_steps:
                 return self.steps.extend(AdditionalBuildSteps(appended_steps))

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -143,6 +143,15 @@ class TestDefinitionErrors:
             "{'version': 1, 'dependencies': {'python': 'foo/not-exists.yml'}}",
             'not-exists.yml does not exist'
         ),  # missing file
+        (
+            "{'version': 1, 'additional_build_steps': 'RUN me'}",
+            "Expected 'additional_build_steps' in the provided definition file to be a dictionary "
+            "with keys 'prepend' and/or 'append', found a <class 'str'> instead."
+        ),  # not right format for additional_build_steps
+        (
+            "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",
+            "Keys ('middle',) are not allowed in 'additional_build_steps'."
+        ),  # not right format for additional_build_steps
     ])
     def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
         path = exec_env_definition_file(yaml_text)


### PR DESCRIPTION
we exepect a dictionary with subkeys here, if it is a multiline string
as was given in an example it blows up in not so obvious way.

found this when looking at https://github.com/ansible/ansible-builder/issues/21