### PR TITLE
add basic pattern for integration tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -34,6 +34,14 @@ version = "0.7.12"
 
 [[package]]
 category = "dev"
+description = "apipkg: namespace control and lazy-import mechanism"
+name = "apipkg"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.5"
+
+[[package]]
+category = "dev"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
 optional = false
@@ -401,6 +409,20 @@ name = "docutils"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.16"
+
+[[package]]
+category = "dev"
+description = "execnet: rapid multi-Python deployment"
+name = "execnet"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.7.1"
+
+[package.dependencies]
+apipkg = ">=1.4"
+
+[package.extras]
+testing = ["pre-commit"]
 
 [[package]]
 category = "dev"
@@ -824,6 +846,35 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 category = "dev"
+description = "run tests in isolated forked subprocesses"
+name = "pytest-forked"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.3.0"
+
+[package.dependencies]
+py = "*"
+pytest = ">=3.10"
+
+[[package]]
+category = "dev"
+description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
+name = "pytest-xdist"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.34.0"
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=4.4.0"
+pytest-forked = "*"
+six = "*"
+
+[package.extras]
+testing = ["filelock"]
+
+[[package]]
+category = "dev"
 description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
@@ -1201,7 +1252,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "35006568b62b9d710316c6f13e07263b6c11291d47d9ab3af0f12fe5f58343f8"
+content-hash = "139bdace6c499cb0f1c22b2cc1ba0563e80d4a31ba8e241d2834d898c9eb9d40"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1222,6 +1273,10 @@ aiohttp = [
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+apipkg = [
+    {file = "apipkg-1.5-py2.py3-none-any.whl", hash = "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"},
+    {file = "apipkg-1.5.tar.gz", hash = "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1344,6 +1399,10 @@ distlib = [
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
+]
+execnet = [
+    {file = "execnet-1.7.1-py2.py3-none-any.whl", hash = "sha256:d4efd397930c46415f62f8a31388d6be4f27a91d7550eb79bc64a756e0056547"},
+    {file = "execnet-1.7.1.tar.gz", hash = "sha256:cacb9df31c9680ec5f95553976c4da484d407e85e41c83cb812aa014f0eddc50"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
@@ -1546,6 +1605,14 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+]
+pytest-forked = [
+    {file = "pytest-forked-1.3.0.tar.gz", hash = "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca"},
+    {file = "pytest_forked-1.3.0-py2.py3-none-any.whl", hash = "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"},
+]
+pytest-xdist = [
+    {file = "pytest-xdist-1.34.0.tar.gz", hash = "sha256:340e8e83e2a4c0d861bdd8d05c5d7b7143f6eea0aba902997db15c2a86be04ee"},
+    {file = "pytest_xdist-1.34.0-py2.py3-none-any.whl", hash = "sha256:ba5d10729372d65df3ac150872f9df5d2ed004a3b0d499cc0164aafedd8c7b66"},
 ]
 pytz = [
     {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ black = "^19.10b0"
 sphinx = "^2.4.4"
 ipdb = "^0.13.2"
 dephell = "^0.8.3"
+pytest-xdist = "^1.34.0"
 
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     package_dir={"": "."},
     package_data={},
     install_requires=['pyyaml==3.*,>=3.12.0', 'requirements-parser==0.*,>=0.2.0'],
-    extras_require={"dev": ["black==19.*,>=19.10.0.b0", "dephell==0.*,>=0.8.3", "flake8==3.*,>=3.7.9", "ipdb==0.*,>=0.13.2", "pylint==2.*,>=2.4.4", "pyparsing==2.*,>=2.4.5", "pytest==5.*,>=5.2.0", "sphinx==2.*,>=2.4.4", "tox==3.*,>=3.14.5", "yamllint==1.*,>=1.20.0"]},
+    extras_require={"dev": ["black==19.*,>=19.10.0.b0", "dephell==0.*,>=0.8.3", "flake8==3.*,>=3.7.9", "ipdb==0.*,>=0.13.2", "pylint==2.*,>=2.4.4", "pyparsing==2.*,>=2.4.5", "pytest==5.*,>=5.2.0", "pytest-xdist==1.*,>=1.34.0", "sphinx==2.*,>=2.4.4", "tox==3.*,>=3.14.5", "yamllint==1.*,>=1.20.0"]},
 )

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -58,3 +58,11 @@ def cli(request):
         return ret
 
     return run
+
+
+@pytest.fixture(params=['docker', 'podman'], ids=['docker', 'podman'])
+def container_runtime(request, cli):
+    if cli(f'{request.param} --version', check=False).returncode == 0:
+        return request.param
+    else:
+        pytest.skip(f'{request.param} runtime not available')

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+
+import tempfile
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def build_dir_and_ee_yml():
+    """Fixture to return temporary file maker."""
+
+    def tmp_dir_and_file(ee_contents):
+        tmpdir = tempfile.mkdtemp(prefix="ansible-builder-test-")
+        with tempfile.NamedTemporaryFile(delete=False, dir=tmpdir) as tempf:
+            tempf.write(bytes(ee_contents, "UTF-8"))
+        return tmpdir, tempf.name
+
+    return tmp_dir_and_file
+
+
+@pytest.fixture()
+def ee_tag():
+    return str(uuid.uuid4())[:10]
+
+
+class CompletedProcessProxy(object):
+    def __init__(self, result):
+        self.result = result
+
+    def __getattr__(self, attr):
+        return getattr(self.result, attr)
+
+
+@pytest.fixture(scope="function")
+def cli(request):
+    def run(args, *a, **kw):
+        kw["encoding"] = "utf-8"
+        if "check" not in kw:
+            # By default we want to fail if a command fails to run. Tests that
+            # want to skip this can pass check=False when calling this fixture
+            kw["check"] = True
+        if "stdout" not in kw:
+            kw["stdout"] = subprocess.PIPE
+        if "stderr" not in kw:
+            kw["stderr"] = subprocess.PIPE
+
+        kw.setdefault("env", os.environ.copy()).update({"LANG": "en_US.UTF-8"})
+
+        try:
+            ret = CompletedProcessProxy(subprocess.run(args, shell=True, *a, **kw))
+        except subprocess.CalledProcessError as err:
+            pytest.fail(
+                f"Running {err.cmd} resulted in a non-zero return code: {err.returncode} - stdout: {err.stdout}, stderr: {err.stderr}"
+            )
+
+        return ret
+
+    return run

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -19,9 +19,9 @@ def test_missing_galaxy_requirements_file():
     pytest.skip("Not implemented")
 
 
-def test_build_streams_output(cli, build_dir_and_ee_yml, ee_tag):
+def test_build_streams_output(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
     """Test that 'ansible-builder build' streams build output."""
     tmpdir, eeyml = build_dir_and_ee_yml("")
-    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag}")
-    assert f"podman build -f {tmpdir}/Containerfile" in result.stdout
+    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime}")
+    assert f"{container_runtime} build -f {tmpdir}" in result.stdout
     assert f"The build context can be found at: {tmpdir}" in result.stdout

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+def test_build_fail_exitcode():
+    """Test that when a build fails, the ansible-builder exits with non-zero exit code.
+
+    Example: https://github.com/ansible/ansible-builder/issues/51
+    """
+    pytest.skip("Not implemented")
+
+
+def test_missing_python_requirements_file():
+    """If a user specifies a python requirements file, but we can't find it, fail sanely."""
+    pytest.skip("Not implemented")
+
+
+def test_missing_galaxy_requirements_file():
+    """If a user specifies a galaxy requirements file, but we can't find it, fail sanely."""
+    pytest.skip("Not implemented")
+
+
+def test_build_streams_output(cli, build_dir_and_ee_yml, ee_tag):
+    """Test that 'ansible-builder build' streams build output."""
+    tmpdir, eeyml = build_dir_and_ee_yml("")
+    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag}")
+    assert f"podman build -f {tmpdir}/Containerfile" in result.stdout
+    assert f"The build context can be found at: {tmpdir}" in result.stdout

--- a/test/integration/test_help.py
+++ b/test/integration/test_help.py
@@ -1,0 +1,21 @@
+import re
+
+
+def test_help(cli):
+    result = cli('ansible-builder --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder [-h] [--version] {build,introspect}' in help_text
+
+
+def test_no_args(cli):
+    result = cli('ansible-builder', check=False)
+    stderr = result.stderr
+    assert 'usage: ansible-builder [-h] [--version] {build,introspect}' in stderr
+    assert 'ansible-builder: error: the following arguments are required: action' in stderr
+
+
+def test_version(cli):
+    result = cli('ansible-builder --version')
+    version = result.stdout
+    matches = re.findall(r'\d.\d.\d', version)
+    assert matches

--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,4 @@ commands =
     mkdir -p artifacts
     poetry install
     poetry env info
-    poetry run pytest test/integration -v -n 4 --junitxml=artifacts/results.xml
+    poetry run pytest test/integration -v -n 4 --junitxml=artifacts/results.xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linters, py3, insync
+envlist = linters, py3, insync, integration
 isolated_build = True
 
 [tox:.package]
@@ -14,7 +14,7 @@ deps = poetry >= 1.0.5
 commands =
     poetry install
     poetry env info
-    poetry run py.test -v test
+    poetry run py.test -v test -k "not integration"
 
 [testenv:linters]
 basepython = python3
@@ -35,3 +35,13 @@ commands =
     poetry run dephell deps convert --from=pyproject.toml --to-format=setuppy --to-path=setup-to-compare.py
     diff setup.py setup-to-compare.py
     rm setup-to-compare.py
+
+# Tox target to ensure both pyproject.toml and setup.py are in sync
+[testenv:integration]
+whitelist_externals =
+    mkdir
+commands =
+    mkdir -p artifacts
+    poetry install
+    poetry env info
+    poetry run pytest test/integration -v -n 4 --junitxml=artifacts/results.xml

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,8 @@ commands =
 
 # Tox target to ensure both pyproject.toml and setup.py are in sync
 [testenv:integration]
+# rootless podman reads $HOME
+passenv = HOME
 whitelist_externals =
     mkdir
 commands =


### PR DESCRIPTION
@beeankha this is my first stab at getting tests running in a way that will work with our jenkins pipeline

I originally had suggested a script to call, but given that the only install method is pip I think tox is fine for now. I can add tox as a system dep to install prior to launching actual tests and tox will take care of setting up poetry and python deps etc.

I have included a few tests and I would like to add more stubs describing test cases we'd like to implement.