### PR TITLE
Remove Unnecessary Return Code Check

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -236,20 +236,18 @@ class Containerfile:
 
         command = [self.container_runtime, "run", "--rm", self.tag, "introspect"]
         rc, output = run_command(command, capture_output=True)
-        if rc != 0:
-            print(MessageColors.WARNING + 'No collections requirements file found, skipping ansible-galaxy install...' + MessageColors.ENDC)
-        else:
-            data = yaml.load("\n".join(output))
-            if python_req_file:
-                with open(self.definition.get_dep_abs_path('python'), 'r') as f:
-                    user_py_reqs = f.read().split('\n')
-                data['python'].extend(user_py_reqs)
-            data['python'] = sanitize_requirements(data['python'])
-            pip_file = os.path.join(self.build_context, 'requirements.txt')
-            with open(pip_file, 'w') as f:
-                f.write('\n'.join(data['python']))
+        data = yaml.load("\n".join(output))
 
-            self.steps.extend(PipSteps('requirements.txt'))
+        if python_req_file:
+            with open(self.definition.get_dep_abs_path('python'), 'r') as f:
+                user_py_reqs = f.read().split('\n')
+            data['python'].extend(user_py_reqs)
+        data['python'] = sanitize_requirements(data['python'])
+        pip_file = os.path.join(self.build_context, 'requirements.txt')
+        with open(pip_file, 'w') as f:
+            f.write('\n'.join(data['python']))
+
+        self.steps.extend(PipSteps('requirements.txt'))
         return self.steps
 
     def prepare_system_steps(self):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def do_not_run_commands():
-    cmd_mock = mock.MagicMock(return_value=[1, []])
+    cmd_mock = mock.MagicMock(return_value=[1, ['python:', '  - foo', 'system: []']])
     with mock.patch('ansible_builder.main.run_command', new=cmd_mock):
         yield cmd_mock
 


### PR DESCRIPTION
In the case where Galaxy requirements are not present, the introspect command provides empty lists vs a non-zero return code; removing the `rc` check in the `prepare_pip_steps` method in `main.py` to match up with that expectation.