### PR TITLE
Reformat Definition File-Related Error Messages, Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The `ansible-builder build` command takes an execution environment definition as
 It outputs the build context necessary for building an execution environment image,
 and it builds that image.
 The image can be re-built with the build context elsewhere, and give the same result.
+The execution environment definition file needs to be in YAML format with the `.yml` file extension.
 
-The schema of the execution environment definition looks like:
+An example execution environment definition schema is as follows:
 
 ```yaml
 ---

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -18,10 +18,10 @@ def run():
         action = getattr(ab, ab.action)
         try:
             if action():
-                print(MessageColors.OKGREEN + "Complete! The build context can be found at: {}".format(ab.build_context) + MessageColors.ENDC)
+                print(MessageColors.OKGREEN + "Complete! The build context can be found at: {0}".format(ab.build_context) + MessageColors.ENDC)
                 sys.exit(0)
         except DefinitionError as e:
-            print(MessageColors.FAIL + e.args[0] + MessageColors.ENDC)
+            print(e.args[0])
             sys.exit(1)
     elif args.action == 'introspect':
         for folder in args.folders:

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -5,7 +5,8 @@ import yaml
 from . import __version__
 
 from .colors import MessageColors
-from .main import AnsibleBuilder, DefinitionError
+from .exceptions import DefinitionError
+from .main import AnsibleBuilder
 from . import constants
 from .introspect import add_introspect_options, process
 from .requirements import sanitize_requirements

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -4,6 +4,7 @@ from .colors import MessageColors
 
 
 class DefinitionError(RuntimeError):
+    # Eliminate the output of traceback before our custom error message prints out
     sys.tracebacklimit = 0
 
     def __init__(self, msg):

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -1,0 +1,11 @@
+import sys
+
+from .colors import MessageColors
+
+
+class DefinitionError(RuntimeError):
+    sys.tracebacklimit = 0
+
+    def __init__(self, msg):
+        super(DefinitionError, self).__init__(MessageColors.FAIL + ("%s" % msg) + MessageColors.ENDC)
+        self.msg = msg

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -92,10 +92,10 @@ class UserDefinition(BaseDefinition):
                 y = yaml.safe_load(f)
                 self.raw = y if y else {}
         except FileNotFoundError:
-            raise DefinitionError("""
+            raise DefinitionError(textwrap.dedent("""
             Could not detect '{0}' file in this directory.
             Use -f to specify a different location.
-            """.format(filename))
+            """).format(filename))
         except yaml.parser.ParserError as e:
             raise DefinitionError(textwrap.dedent("""
             An error occured while parsing the definition file:

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -1,6 +1,7 @@
 import filecmp
 import os
 import shutil
+import sys
 import textwrap
 import yaml
 
@@ -17,6 +18,7 @@ CONTEXT_FILES = ['galaxy', 'python', 'system']
 
 
 class DefinitionError(RuntimeError):
+    sys.tracebacklimit = 0
     pass
 
 
@@ -95,10 +97,10 @@ class UserDefinition(BaseDefinition):
                 y = yaml.safe_load(f)
                 self.raw = y if y else {}
         except FileNotFoundError:
-            raise DefinitionError("""
+            raise DefinitionError(MessageColors.FAIL + """
             Could not detect '{0}' file in this directory.
             Use -f to specify a different location.
-            """.format(constants.default_file))
+            """.format(constants.default_file) + MessageColors.ENDC)
         except yaml.parser.ParserError as e:
             raise DefinitionError(textwrap.dedent(MessageColors.FAIL + """
             An error occured while parsing the definition file:
@@ -107,8 +109,9 @@ class UserDefinition(BaseDefinition):
 
         if not isinstance(self.raw, dict):
             raise DefinitionError(
-                MessageColors.FAIL + 'Definition must be a dictionary, not {}'.format(type(self.raw).__name__) + MessageColors.ENDC
-            )
+                MessageColors.FAIL + """
+                Definition must be a dictionary, not {}
+                """.format(type(self.raw).__name__) + MessageColors.ENDC)
 
     def get_additional_commands(self):
         """Gets additional commands from the exec env file, if any are specified.

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -19,7 +19,10 @@ CONTEXT_FILES = ['galaxy', 'python', 'system']
 
 class DefinitionError(RuntimeError):
     sys.tracebacklimit = 0
-    pass
+
+    def __init__(self, msg):
+        super(DefinitionError, self).__init__(MessageColors.FAIL + ("%s" % msg) + MessageColors.ENDC)
+        self.msg = msg
 
 
 class AnsibleBuilder:
@@ -97,21 +100,18 @@ class UserDefinition(BaseDefinition):
                 y = yaml.safe_load(f)
                 self.raw = y if y else {}
         except FileNotFoundError:
-            raise DefinitionError(MessageColors.FAIL + """
+            raise DefinitionError("""
             Could not detect '{0}' file in this directory.
             Use -f to specify a different location.
-            """.format(constants.default_file) + MessageColors.ENDC)
+            """.format(filename))
         except yaml.parser.ParserError as e:
-            raise DefinitionError(textwrap.dedent(MessageColors.FAIL + """
+            raise DefinitionError(textwrap.dedent("""
             An error occured while parsing the definition file:
             {0}
-            """).format(str(e)) + MessageColors.ENDC)
+            """).format(str(e)))
 
         if not isinstance(self.raw, dict):
-            raise DefinitionError(
-                MessageColors.FAIL + """
-                Definition must be a dictionary, not {}
-                """.format(type(self.raw).__name__) + MessageColors.ENDC)
+            raise DefinitionError("Definition must be a dictionary, not {0}".format(type(self.raw).__name__))
 
     def get_additional_commands(self):
         """Gets additional commands from the exec env file, if any are specified.
@@ -149,20 +149,18 @@ class UserDefinition(BaseDefinition):
             if requirement_path:
                 filename = os.path.basename(requirement_path)
                 if filename in bc_files:
-                    raise DefinitionError(
-                        MessageColors.WARNING + 'Duplicated filename {} in definition.'.format(filename) + MessageColors.ENDC
-                    )
+                    raise DefinitionError("Duplicated filename {0} in definition.".format(filename))
                 if not os.path.exists(requirement_path):
-                    raise DefinitionError(
-                        MessageColors.WARNING + 'Dependency file {} does not exist.'.format(requirement_path) + MessageColors.ENDC
-                    )
+                    raise DefinitionError("Dependency file {0} does not exist.".format(requirement_path))
                 bc_files.add(filename)
         additional_cmds = self.get_additional_commands()
         if additional_cmds:
             if not isinstance(additional_cmds, dict):
-                raise DefinitionError(
-                    "Expected 'additional_build_steps' in the provided definition file to be a dictionary "
-                    f"with keys 'prepend' and/or 'append', found a {type(additional_cmds)} instead.")
+                raise DefinitionError(textwrap.dedent("""
+                    Expected 'additional_build_steps' in the provided definition file to be a dictionary
+                    with keys 'prepend' and/or 'append'; found a {0} instead.
+                    """).format(type(additional_cmds).__name__))
+
             expected_keys = frozenset(('append', 'prepend'))
             unexpected_keys = set(additional_cmds.keys()) - expected_keys
             if unexpected_keys:
@@ -188,7 +186,7 @@ class Containerfile:
         self.container_runtime = container_runtime
         self.tag = tag
         self.steps = [
-            "FROM {}".format(self.base_image),
+            "FROM {0}".format(self.base_image),
             ""
         ]
 

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -1,12 +1,12 @@
 import filecmp
 import os
 import shutil
-import sys
 import textwrap
 import yaml
 
 from . import constants
 from .colors import MessageColors
+from .exceptions import DefinitionError
 from .steps import AdditionalBuildSteps, GalaxySteps, PipSteps, IntrospectionSteps, BindepSteps
 from .utils import run_command
 from .requirements import sanitize_requirements
@@ -15,14 +15,6 @@ import ansible_builder.introspect
 
 # Files that need to be moved into the build context
 CONTEXT_FILES = ['galaxy', 'python', 'system']
-
-
-class DefinitionError(RuntimeError):
-    sys.tracebacklimit = 0
-
-    def __init__(self, msg):
-        super(DefinitionError, self).__init__(MessageColors.FAIL + ("%s" % msg) + MessageColors.ENDC)
-        self.msg = msg
 
 
 class AnsibleBuilder:

--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -42,9 +42,9 @@ def sanitize_requirements(py_reqs):
             # A source control requirement like git+, return as-is
             sanitized.append(req.line)
         elif req.name:
-            specs = ['{}{}'.format(cmp, ver) for cmp, ver in req.specs]
+            specs = ['{0}{1}'.format(cmp, ver) for cmp, ver in req.specs]
             sanitized.append(req.name + ','.join(specs))
         else:
-            raise RuntimeError('Could not process {}'.format(req.line))
+            raise RuntimeError('Could not process {0}'.format(req.line))
 
     return sanitized

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from . import constants
-from .colors import MessageColors
+from .exceptions import DefinitionError
 
 
 class Steps:

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -21,8 +21,11 @@ class AdditionalBuildSteps(Steps):
         elif isinstance(additional_steps, list):
             lines = additional_steps
         else:
-            print(MessageColors.FAIL + "Error: Unknown type found for additional_build_steps; "
-                  "must be list or multi-line string." + MessageColors.ENDC)
+            raise DefinitionError(
+                """
+                Error: Unknown type found for additional_build_steps; must be list or multi-line string.
+                """
+            )
             sys.exit(1)
         self.steps.extend(lines)
 
@@ -34,7 +37,7 @@ class IntrospectionSteps(Steps):
     def __init__(self, context_file):
         self.steps = []
         self.steps.extend([
-            "ADD {} /usr/local/bin/introspect".format(context_file),
+            "ADD {0} /usr/local/bin/introspect".format(context_file),
             "RUN chmod +x /usr/local/bin/introspect"
         ])
 
@@ -45,7 +48,7 @@ class GalaxySteps(Steps):
         """
         self.steps = []
         self.steps.append(
-            "ADD {} /build/".format(requirements_naming)
+            "ADD {0} /build/".format(requirements_naming)
         )
         self.steps.extend([
             "",
@@ -64,7 +67,7 @@ class BindepSteps(Steps):
             # requirements file added to build context
             file_naming = os.path.basename(context_file)
             self.steps.append(
-                "ADD {} /build/".format(file_naming)
+                "ADD {0} /build/".format(file_naming)
             )
             sanitized_files.append(os.path.join('/build/', file_naming))
 
@@ -75,7 +78,7 @@ class BindepSteps(Steps):
 
         for file in sanitized_files:
             self.steps.append(
-                "RUN dnf -y install $(bindep -b -f {})".format(file)
+                "RUN dnf -y install $(bindep -b -f {0})".format(file)
             )
 
 
@@ -87,7 +90,7 @@ class PipSteps(Steps):
             return
 
         # requirements file added to build context
-        self.steps.append("ADD {} /build/".format(context_file))
+        self.steps.append("ADD {0} /build/".format(context_file))
         container_path = os.path.join('/build/', context_file)
         self.steps.append(
             "RUN pip3 install --upgrade -r {content}".format(content=container_path)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -161,3 +161,11 @@ class TestDefinitionErrors:
             definition.validate()
         if expect:
             assert expect in exc.value.args[0]
+
+    def test_file_not_found_error(good_exec_env_definition_path, tmpdir):
+        path = "exec_env.txt"
+
+        with pytest.raises(DefinitionError) as error:
+            AnsibleBuilder(filename=path)
+
+        assert "Could not detect 'exec_env.txt' file in this directory.\nUse -f to specify a different location." in str(error.value.args[0])

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -145,8 +145,8 @@ class TestDefinitionErrors:
         ),  # missing file
         (
             "{'version': 1, 'additional_build_steps': 'RUN me'}",
-            "Expected 'additional_build_steps' in the provided definition file to be a dictionary "
-            "with keys 'prepend' and/or 'append', found a <class 'str'> instead."
+            "Expected 'additional_build_steps' in the provided definition file to be a dictionary\n"
+            "with keys 'prepend' and/or 'append'; found a str instead."
         ),  # not right format for additional_build_steps
         (
             "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -2,7 +2,8 @@ import os
 import pytest
 
 from ansible_builder import __version__
-from ansible_builder.main import AnsibleBuilder, UserDefinition, DefinitionError
+from ansible_builder.exceptions import DefinitionError
+from ansible_builder.main import AnsibleBuilder, UserDefinition
 from ansible_builder.introspect import process
 from ansible_builder.requirements import sanitize_requirements
 


### PR DESCRIPTION
Updated the `DefinitionError` custom class to no longer show a traceback (plus added color to the output error messages), edited the README to show more specific definition file-related information.