### PR TITLE
Add integration test for subversion test case

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 import yaml
 from unittest import mock
 import pytest
+import os
 
 
 @pytest.fixture(autouse=True)
@@ -8,6 +9,11 @@ def do_not_run_commands():
     cmd_mock = mock.MagicMock(return_value=[1, ['python:', '  - foo', 'system: []']])
     with mock.patch('ansible_builder.main.run_command', new=cmd_mock):
         yield cmd_mock
+
+
+@pytest.fixture
+def data_dir():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
 
 @pytest.fixture

--- a/test/data/subversion/bindep.txt
+++ b/test/data/subversion/bindep.txt
@@ -1,0 +1,2 @@
+subversion [platform:rpm]
+subversion [platform:dpkg]

--- a/test/data/subversion/execution-environment.yml
+++ b/test/data/subversion/execution-environment.yml
@@ -1,0 +1,4 @@
+---
+version: 1
+dependencies:
+  system: bindep.txt

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -21,8 +21,14 @@ def build_dir_and_ee_yml():
 
 
 @pytest.fixture()
-def ee_tag():
-    return str(uuid.uuid4())[:10]
+def ee_tag(request, cli, container_runtime):
+    image_name = 'builder-test-' + str(uuid.uuid4())[:10]
+
+    def delete_image():
+        cli(f'{container_runtime} rmi {image_name}')
+
+    request.addfinalizer(delete_image)
+    return image_name
 
 
 class CompletedProcessProxy(object):

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -25,7 +25,7 @@ def ee_tag(request, cli, container_runtime):
     image_name = 'builder-test-' + str(uuid.uuid4())[:10]
 
     def delete_image():
-        cli(f'{container_runtime} rmi {image_name}')
+        cli(f'{container_runtime} rmi -f {image_name}')
 
     request.addfinalizer(delete_image)
     return image_name

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 
 def test_build_fail_exitcode():
@@ -25,3 +26,16 @@ def test_build_streams_output(cli, container_runtime, build_dir_and_ee_yml, ee_t
     result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime}")
     assert f"{container_runtime} build -f {tmpdir}" in result.stdout
     assert f"The build context can be found at: {tmpdir}" in result.stdout
+
+
+def test_user_system_requirement(cli, container_runtime, ee_tag, tmpdir, data_dir):
+    bc = str(tmpdir)
+    ee_def = os.path.join(data_dir, 'subversion', 'execution-environment.yml')
+    cli(
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+    )
+    result = cli(
+        f'{container_runtime} run --rm {ee_tag} svn --help'
+    )
+    assert 'Subversion is a tool for version control' in result.stdout
+

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -88,11 +88,6 @@ def test_build_command(exec_env_definition_file):
     assert 'foo/bar/path/Dockerfile' in " ".join(command)
 
 
-@pytest.fixture
-def data_dir():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
-
-
 def test_collection_metadata(data_dir):
 
     files = process(data_dir)


### PR DESCRIPTION
This is migrating 1 case from https://github.com/ansible/ansible-builder/pull/44 to the new integration testing system.

I also added cleanup for the images that get created. This may or may not work entirely right.