### PR TITLE
Do not skip requests library

### DIFF
--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -10,7 +10,7 @@ EXCLUDE_REQUIREMENTS = frozenset((
     # test requirements highly specific to Ansible testing
     'ansible-lint', 'molecule', 'galaxy-importer', 'voluptuous',
     # already present in image for py3 environments
-    'requests', 'yaml', 'pyyaml', 'json',
+    'yaml', 'pyyaml', 'json',
 ))
 
 


### PR DESCRIPTION
for whatever reason, I had the idea in my head that requests was in the standard library in python3

this is not the case, and collections need to request it if they need it (this may not be done for all relevant upstreams).