### PR TITLE
Relax pyyaml version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Matthew Jones <matburt@redhat.com>",
 
 [tool.poetry.dependencies]
 python = "^3.6"
-pyyaml = "^3.12"     # Do not bump this version, its the minimum for el7 and el8 packaging
+pyyaml = ">=3.12.0"     # Minimum for compat for el7 and el8 packaging
 requirements-parser = "^0.2.0"
 
 [tool.poetry.scripts]

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
     packages=['ansible_builder'],
     package_dir={"": "."},
     package_data={},
-    install_requires=['pyyaml==3.*,>=3.12.0', 'requirements-parser==0.*,>=0.2.0'],
+    install_requires=['pyyaml>=3.12.0', 'requirements-parser==0.*,>=0.2.0'],
     extras_require={"dev": ["black==19.*,>=19.10.0.b0", "flake8==3.*,>=3.7.9", "pylint==2.*,>=2.4.4", "pytest==5.*,>=5.2.0", "pytest-xdist==1.*,>=1.34.0", "sphinx==3.*,>=3.2.1", "tox==3.*,>=3.14.5", "yamllint==1.*,>=1.20.0"]},
 )


### PR DESCRIPTION
This is so that this can be used without breaking on the constraint https://github.com/ansible/galaxy-importer/blob/a3cd9263440aa15ec8ba3462af7aa3aa65ebcef8/setup.cfg#L25, which is probably fairly common in other environments too.