### PR TITLE
Fix test race condition

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import time
 from pathlib import Path
 
 import pytest
@@ -49,6 +50,9 @@ def test_copy_file(dest_file, source_file):
 
 
 def test_copy_touched_file(dest_file, source_file):
+    # sleep for a miniscule amount of time, otherwise getmtime could be the same float value
+    time.sleep(0.002)
+
     # touch does not change contents but updates modification time
     Path(source_file).touch()
 


### PR DESCRIPTION
Process to justify the validity of this:

Added in print statement about the modification times:

```
File /tmp/pytest-of-alancoding/pytest-20/test_copy_touched_file0/foo.txt is up-to-date, modified 1602511504.7719164 required 1602511504.7719164
File /tmp/pytest-of-alancoding/pytest-23/test_copy_touched_file0/foo.txt is up-to-date, modified 1602511505.5479171 required 1602511505.5469172
```

In some cases, the modification time was the literal exact _same_ floating point value. In other cases, it could be 0.00099992752, but in the wrong direction.

Testing the fix, it seems that 0.001 was sufficient, but based on the observed delta, I opt for twice that to be conservative. How to test:

```
for i in $(seq 10); do py.test test/test_utils.py; done
```

Before this fix, my Fedora 32 computer was hitting this like 70% of the time, and now I can't get a failure anymore. Hopefully Zuul agrees.

