### PR TITLE
Correctly clean up podman images that start with localhost

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -58,7 +58,14 @@ def cleanup_ee_tags(container_runtime, request):
     def delete_images():
         r = run(f'{container_runtime} images --format="{{{{.Repository}}}}"')
         for image_name in r.stdout.split('\n'):
-            if image_name and image_name.startswith(TAG_PREFIX):
+            from_test = False
+            if not image_name:
+                pass
+            elif image_name.startswith('localhost/{0}'.format(TAG_PREFIX)):  # podman
+                from_test = True
+            elif image_name.startswith(TAG_PREFIX):  # docker
+                from_test = True
+            if from_test:
                 run(f'{container_runtime} rmi -f {image_name}')
                 logger.warning(f'Deleted image {image_name}')
 


### PR DESCRIPTION
I noticed that running on Fedora with podman, images were not getting cleaned up because podman prefixes them with `localhost/`. I looked into renaming them, but rafter eading https://github.com/containers/buildah/issues/1034 I have written that off as controversial. I don't care what the images are called, just clean them up.