### PR TITLE
Fix editable installations using `pip install -e .`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,5 +46,5 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["poetry>=1.0.5"]
+requires = ["setuptools", "poetry>=1.0.5"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
When doing `pip install -e .`, the build process needs setuptools before reading setup.py,
which means it needs to be specified in pyproject.toml's `build-system` table.

This addresses the problem mentioned in https://github.com/pypa/pip/issues/8986

cc @AlanCoding 