### PR TITLE
WIP: Testing updates for zuul integration

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -2,5 +2,7 @@
 - project:
     check:
       jobs:
-        - ansible-builder-tox-integration:
-            voting: false
+        - ansible-builder-tox-integration
+    gate:
+      jobs:
+        - ansible-builder-tox-integration


### PR DESCRIPTION
We are looking to start using ansible-builder more in Zuul for content
collection testing.  This is a set of changes needed to allow us to
properly bootstrap ansible-builder.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>