### PR TITLE
Emit a More Helpful Message When Container Runtime Isn't Found

### DIFF
--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -63,10 +63,13 @@ def configure_logger(verbosity):
 def run_command(command, capture_output=False, allow_error=False):
     logger.info('Running command:')
     logger.info('  {0}'.format(' '.join(command)))
-
-    process = subprocess.Popen(command,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT)
+    try:
+        process = subprocess.Popen(command,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT)
+    except FileNotFoundError:
+        logger.error(f"You do not have {command[0]} installed, please specify a different container runtime for this command.")
+        sys.exit(1)
 
     output = []
     for line in iter(process.stdout.readline, b''):


### PR DESCRIPTION
Addressing Issue https://github.com/ansible/ansible-builder/issues/86; when a container runtime that isn't installed on the user's system is specified, an error like this will be emitted:

<img width="1118" alt="Screen Shot 2020-11-12 at 9 25 33 AM" src="https://user-images.githubusercontent.com/28930622/98952116-125c5700-24c9-11eb-8a54-e2f6eea1c6a0.png">

