### PR TITLE
Add integration testing job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,0 +1,16 @@
+---
+- job:
+    name: ansible-builder-tox-integration
+    parent: ansible-buildset-registry-consumer
+    timeout: 3600
+    vars:
+      container_command: podman
+
+- job:
+    name: ansible-builder-tox-integration
+    parent: ansible-tox-py38
+    requires:
+      - ansible-runner-container-image
+    vars:
+      tox_envlist: integration
+      tox_install_siblings: false

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,0 +1,6 @@
+---
+- project:
+    check:
+      jobs:
+        - ansible-builder-tox-integration:
+            voting: false

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-TAG_PREFIX = 'builder-test'
+TAG_PREFIX = 'quay.io/example/builder-test'
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,10 @@ commands =
 # rootless podman reads $HOME
 passenv = HOME
 whitelist_externals =
+    bash
     mkdir
 commands =
     mkdir -p artifacts
     poetry install
     poetry env info
-    poetry run pytest test/integration -v -n 4 --junitxml=artifacts/results.xml {posargs}
+    bash -c 'poetry run pytest test/integration -v -n `python -c "import multiprocessing; print(int(multiprocessing.cpu_count()/2))"` --junitxml=artifacts/results.xml {posargs}'


### PR DESCRIPTION
This will allow us to use speculative ansible-runner containers,
allowing for better cross-project testing with ansible-runner.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>