### PR TITLE
Change Verbosity Default + Implementation

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -102,11 +102,12 @@ def parse_args(args=sys.argv[1:]):
 
         p.add_argument('-v', '--verbosity',
                        dest='verbosity',
-                       action='count',
-                       default=0,
+                       type=int,
+                       choices=[0, 1, 2, 3],
+                       default=2,
                        help='Increase the output verbosity, for up to three levels of verbosity '
-                            '(invoked via "--verbosity" (this will set it to level 1), "-v", "-vv", '
-                            'or "-vvv").')
+                            '(invoked via "--verbosity" or "-v" followed by an integer ranging '
+                            'in value from 0 to 3)')
 
     introspect_parser = subparsers.add_parser(
         'introspect',
@@ -127,8 +128,8 @@ def parse_args(args=sys.argv[1:]):
     introspect_parser.add_argument(
         '-v', '--verbosity', dest='verbosity', action='count', default=0, help=(
             'Increase the output verbosity, for up to three levels of verbosity '
-            '(invoked via "--verbosity" (this will set it to level 1), "-v", "-vv", '
-            'or "-vvv").'))
+            '(invoked via "--verbosity" or "-v" followed by an integer ranging '
+            'in value from 0 to 3)'))
 
     args = parser.parse_args(args)
 

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -29,7 +29,7 @@ class AnsibleBuilder:
                  build_context=constants.default_build_context,
                  tag=constants.default_tag,
                  container_runtime=constants.default_container_runtime,
-                 verbosity=0):
+                 verbosity=2):
         self.action = action
         self.definition = UserDefinition(filename=filename)
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -92,6 +92,16 @@ Podman is used by default to build images. To use Docker:
    $ ansible-builder build --container-runtime=docker
 
 
+ ``--verbosity``
+ ***************
+
+ To customize the level of verbosity:
+
+ .. code::
+
+    $ ansible-builder build --verbosity 2
+
+
 Examples
 --------
 

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -41,7 +41,7 @@ def test_missing_galaxy_requirements_file():
 def test_build_streams_output_with_verbosity_on(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
     """Test that 'ansible-builder build' streams build output."""
     tmpdir, eeyml = build_dir_and_ee_yml("")
-    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime} -vvv")
+    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime} -v 3")
     assert f'{container_runtime} build -f {tmpdir}' in result.stdout
     assert f'Ansible Builder is building your execution environment image, "{ee_tag}".' in result.stdout
     assert f'The build context can be found at: {tmpdir}' in result.stdout
@@ -49,13 +49,22 @@ def test_build_streams_output_with_verbosity_on(cli, container_runtime, build_di
 
 def test_build_streams_output_with_verbosity_off(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
     """
-    Like the test_build_streams_output_with_verbosity_on test but making sure less output is shown with default verbosity level.
+    Like the test_build_streams_output_with_verbosity_on test but making sure less output is shown with default verbosity level of 2.
     """
     tmpdir, eeyml = build_dir_and_ee_yml("")
     result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime}")
-    assert f'{container_runtime} build -f {tmpdir}' not in result.stdout
     assert f'Ansible Builder is building your execution environment image, "{ee_tag}".' not in result.stdout
     assert f'The build context can be found at: {tmpdir}' in result.stdout
+
+
+def test_build_streams_output_with_invalid_verbosity(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
+    """
+    Like the test_build_streams_output_with_verbosity_off test but making sure it errors out correctly with invalid verbosity level.
+    """
+    tmpdir, eeyml = build_dir_and_ee_yml("")
+    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime} -v 6", allow_error=True)
+    assert result.rc != 0
+    assert 'invalid choice: 6 (choose from 0, 1, 2, 3)' in (result.stdout + result.stderr)
 
 
 def test_blank_execution_environment(cli, container_runtime, ee_tag, tmpdir, data_dir):
@@ -112,7 +121,7 @@ class TestPytz:
         bc_folder = str(tmpdir_factory.mktemp('bc'))
         ee_def = os.path.join(data_dir, 'pytz', 'execution-environment.yml')
         r = cli_class(
-            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag_class} --container-runtime {container_runtime} -vvv'
+            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag_class} --container-runtime {container_runtime} -v 3'
         )
         assert 'Collecting pytz' in r.stdout, r.stdout
         return (ee_tag_class, bc_folder)
@@ -126,7 +135,7 @@ class TestPytz:
         ee_tag, bc_folder = pytz
         ee_def = os.path.join(data_dir, 'pytz', 'execution-environment.yml')
         r = cli(
-            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} -vvv'
+            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} -v 3'
         )
         assert 'Collecting pytz (from -r /build/' not in r.stdout, r.stdout
         assert 'requirements_combined.txt is already up-to-date' in r.stdout, r.stdout


### PR DESCRIPTION
Addressing Issue https://github.com/ansible/ansible-builder/issues/126

With this PR, instead of invoking verbosity via `-v` or `-vv` (i.e. using `action=count`), the user can now type `-v 3` or `--verbosity 1` etc. Any integer invoked that is out of the range of 0 - 3 will error out and show the valid choices available:

<img width="886" alt="Screen Shot 2020-12-07 at 12 46 01 PM" src="https://user-images.githubusercontent.com/28930622/101385740-30c82f00-388a-11eb-9f0b-cc3846834102.png">

The verbosity now defaults to `2` instead of `0` so that even if you don't specify verbosity, some minimal output will be displayed.

Also added information about the `--verbosity` option to the documentation, as well as a new integration test that checks the build fails and emits the error above when invalid verbosity level is used.