### PR TITLE
Use --no-cache-dir for pip3

### DIFF
--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -91,7 +91,7 @@ class PipSteps(Steps):
         self.steps.append("ADD {0} /build/".format(context_file))
         container_path = os.path.join('/build/', context_file)
         self.steps.append(
-            "RUN pip3 install --upgrade -r {content}".format(content=container_path)
+            "RUN pip3 install --no-cache-dir --upgrade -r {content}".format(content=container_path)
         )
 
 


### PR DESCRIPTION
By using --no-cache-dir option for pip, we disable the ability for pip
to cache wheels inside the container. This will allow us to save some
space inside the container.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>