### PR TITLE
Remove extra double-spacing from subcommands

### DIFF
--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -76,12 +76,19 @@ def run_command(command, capture_output=False, allow_error=False):
         line = line.decode(sys.stdout.encoding)
         if capture_output:
             output.append(line.rstrip())
-        logger.debug(line)
+        logger.debug(line.rstrip('\n'))  # line ends added by logger itself
+    logger.debug('')
 
     rc = process.poll()
     if rc is not None and rc != 0 and (not allow_error):
-        for line in output:
-            logger.error(line)
+        main_logger = logging.getLogger('ansible_builder')
+        if main_logger.level > logging.INFO:
+            logger.error('Command that had error:')
+            logger.error('  {0}'.format(' '.join(command)))
+        if main_logger.level > logging.DEBUG:
+            for line in output:
+                logger.error(line)
+            logger.error('')
         logger.error(f"An error occured (rc={rc}), see output line(s) above for details.")
         sys.exit(1)
 


### PR DESCRIPTION
This had been driving me nuts, the subcommands had extra spaces inserted between every line.

With this fix, this is how output looks:

![Screenshot from 2020-12-10 21-42-23](https://user-images.githubusercontent.com/1385596/101855011-b8cf6280-3b30-11eb-88f8-e803e0b0ef9c.png)

The behavior in the case of `capture_output=True` gets a little bit wackier. The goal is to not print anything twice, or omit printing something important once. The important things are:

 - what command had an error and
 - what the output of that command was

Here is my manual testing, putting in `podman foo` for the first part of the build phase, which has its output captured.

![Screenshot from 2020-12-10 21-56-35](https://user-images.githubusercontent.com/1385596/101856090-9e968400-3b32-11eb-9e4d-2d2f85cae52b.png)


