### PR TITLE
Check for Invalid Keys in the Definition File

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -24,6 +24,14 @@ BINDEP_COMBINED = 'bindep_combined.txt'
 BINDEP_OUTPUT = 'bindep_output.txt'
 PIP_COMBINED = 'requirements_combined.txt'
 
+ALLOWED_KEYS = [
+    'version',
+    'base_image',
+    'dependencies',
+    'ansible_config',
+    'additional_build_steps',
+]
+
 
 class AnsibleBuilder:
     def __init__(self, action=None,
@@ -213,6 +221,19 @@ class UserDefinition(BaseDefinition):
             raise DefinitionError("Dependency file {0} does not exist.".format(requirement_path))
 
     def validate(self):
+        # Check that all specified keys in the definition file are valid.
+        def_file_dict = self.raw
+        yaml_keys = set(def_file_dict.keys())
+        invalid_keys = yaml_keys - set(ALLOWED_KEYS)
+        if invalid_keys:
+            raise DefinitionError(textwrap.dedent(
+                f"""
+                Error: Unknown yaml key(s), {invalid_keys}, found in the definition file.\n
+                Allowed options are:
+                {ALLOWED_KEYS}
+                """)
+            )
+
         for item in CONTEXT_FILES:
             requirement_path = self.get_dep_abs_path(item)
             if requirement_path:

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -171,6 +171,10 @@ class TestDefinitionErrors:
             "Expected 'ansible_config' in the provided definition file to\n"
             "be a string; found a list instead."
         ),
+        (
+            "{'version': 1, 'foo': 'bar'}",
+            "Error: Unknown yaml key(s), {'foo'}, found in the definition file."
+        ),
     ])
     def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
         path = exec_env_definition_file(yaml_text)


### PR DESCRIPTION
Addressing issue https://github.com/ansible/ansible-builder/issues/136

* * *
Previously, if an invalid key such as `requirements` was listed in the `execution-environment.yml` definition file, Builder would proceed without erroring and just skip over the invalid keys.  With the changes in this PR, an error like this will pop up:

```
$ ansible-builder build --container-runtime docker

Error: Unknown yaml key(s), {'requirements'}, found in the definition file.

Allowed options are:
['version', 'base_image', 'dependencies', 'ansible_config', 'additional_build_steps']
```
and Builder will exit.