### PR TITLE
Remove unnecessary mkdir in GalaxyInstallSteps

### DIFF
--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -45,9 +45,7 @@ class GalaxyInstallSteps(Steps):
             "RUN ansible-galaxy role install -r /build/{0} --roles-path {1}".format(
                 requirements_naming, constants.base_roles_path),
             "RUN ansible-galaxy collection install -r /build/{0} --collections-path {1}".format(
-                requirements_naming, constants.base_collections_path),
-            "",
-            "RUN mkdir -p {0} {1}".format(constants.base_roles_path, constants.base_collections_path),
+                requirements_naming, constants.base_collections_path)
         ])
 
 


### PR DESCRIPTION
This step no longer seems to be required, ansible-galaxy CLi will create
the directories as needed, and we copy them over in the last stage now,
which gets created by default.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>