### PR TITLE
Write out files to _build dir in build context

### DIFF
--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -38,7 +38,7 @@ class GalaxyInstallSteps(Steps):
         """
         self.steps = []
         self.steps.append(
-            "ADD {0} /build/".format(requirements_naming)
+            "ADD {0} /build/{0}".format(requirements_naming)
         )
         self.steps.extend([
             "",
@@ -65,10 +65,10 @@ class GalaxyCopySteps(Steps):
 
 
 class AnsibleConfigSteps(Steps):
-    def __init__(self, ansible_config):
+    def __init__(self, context_file):
         """Copies a user's ansible.cfg file for accessing Galaxy server"""
         self.steps = []
         self.steps.extend([
-            "ADD ansible.cfg ~/.ansible.cfg",
+            f"ADD {context_file} ~/.ansible.cfg",
             "",
         ])

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -3,7 +3,9 @@ import pytest
 
 from ansible_builder import __version__
 from ansible_builder.exceptions import DefinitionError
-from ansible_builder.main import AnsibleBuilder, UserDefinition
+from ansible_builder.main import (
+    AnsibleBuilder, UserDefinition, CONTEXT_BUILD_OUTPUTS_DIR
+)
 
 
 def test_version():
@@ -49,7 +51,7 @@ def test_galaxy_requirements(exec_env_definition_file, galaxy_requirements_file,
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'ADD requirements.yml' in content
+    assert f'ADD {CONTEXT_BUILD_OUTPUTS_DIR}/requirements.yml' in content
 
 
 def test_base_image(exec_env_definition_file, tmpdir):
@@ -109,7 +111,7 @@ def test_nested_galaxy_file(data_dir, tmpdir):
     bc_folder = str(tmpdir)
     AnsibleBuilder(filename='test/data/nested-galaxy.yml', build_context=bc_folder).build()
 
-    req_in_bc = os.path.join(bc_folder, 'requirements.yml')
+    req_in_bc = os.path.join(bc_folder, CONTEXT_BUILD_OUTPUTS_DIR, 'requirements.yml')
     assert os.path.exists(req_in_bc)
 
     req_original = 'test/data/foo/requirements.yml'
@@ -134,7 +136,7 @@ def test_ansible_config_for_galaxy(exec_env_definition_file, tmpdir):
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'ADD ansible.cfg ~/.ansible.cfg' in content
+    assert f'ADD {CONTEXT_BUILD_OUTPUTS_DIR}/ansible.cfg ~/.ansible.cfg' in content
 
 
 class TestDefinitionErrors:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps = poetry >= 1.0.5
 commands =
     poetry install
     poetry env info
-    poetry run py.test -v test -k "not integration"
+    poetry run py.test -v test -k "not integration" {posargs}
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
This tidies the build context.

Before:

```
$ ls -1
bindep_combined.txt
bindep_output.txt
Containerfile
Dockerfile
introspect.py
LICENSE.md
README.md
requirements_combined.txt
requirements.txt
requirements.yml
tools
tox.ini
```

After:

```
$ ls -1
Containerfile
Dockerfile
execution-environment.yml
LICENSE.md
README.md
sources
tools
tox.ini
```