### PR TITLE
Add support for build args

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import sys
 import yaml
-import os
 
 from . import __version__
 

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -311,8 +311,8 @@ class Containerfile:
         self.container_runtime = container_runtime
         self.tag = tag
         self.steps = [
-            "ARG BASE_IMAGE={}".format(self.base_image),
-            "FROM $BASE_IMAGE as galaxy",
+            "ARG ANSIBLE_RUNNER_IMAGE={}".format(self.base_image),
+            "FROM $ANSIBLE_RUNNER_IMAGE as galaxy",
             ""
         ]
 
@@ -413,7 +413,7 @@ class Containerfile:
     def prepare_final_stage_steps(self):
         self.steps.extend([
             "",
-            "FROM $BASE_IMAGE"
+            "FROM $ANSIBLE_RUNNER_IMAGE"
             "",
         ])
         return self.steps

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,6 +82,18 @@ directory. To specify another location:
    $ ansible-builder build --context=/path/to/dir
 
 
+``--build-arg``
+*************
+
+To use Podman or Docker's build-time variables, specify them the same way you would with ``podman build`` or ``docker build``.
+
+By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``BASE_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
+
+.. code::
+
+   $ ansible-builder build --build-arg FOO=bar
+
+
 ``--container-runtime``
 ***********************
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -97,7 +97,7 @@ To use a custom base image:
 
 To use Podman or Docker's build-time variables, specify them the same way you would with ``podman build`` or ``docker build``.
 
-By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``BASE_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
+By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``ANSIBLE_RUNNER_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
 
 .. code::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,6 +82,16 @@ directory. To specify another location:
    $ ansible-builder build --context=/path/to/dir
 
 
+``--base-image``
+*************
+
+To use a custom base image:
+
+.. code::
+
+   $ ansible-builder build --base-image=registry.example.com/another-ee
+
+
 ``--build-arg``
 *************
 

--- a/test/data/build_args/base-image.yml
+++ b/test/data/build_args/base-image.yml
@@ -1,0 +1,5 @@
+---
+additional_build_steps:
+  prepend:
+    - ARG BASE_IMAGE
+    - RUN echo $BASE_IMAGE > /base_image

--- a/test/data/build_args/base-image.yml
+++ b/test/data/build_args/base-image.yml
@@ -1,5 +1,5 @@
 ---
 additional_build_steps:
   prepend:
-    - ARG BASE_IMAGE
-    - RUN echo $BASE_IMAGE > /base_image
+    - ARG ANSIBLE_RUNNER_IMAGE
+    - RUN echo $ANSIBLE_RUNNER_IMAGE > /base_image

--- a/test/data/build_args/execution-environment.yml
+++ b/test/data/build_args/execution-environment.yml
@@ -1,0 +1,5 @@
+---
+additional_build_steps:
+  prepend:
+    - ARG FOO
+    - RUN echo $FOO

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -157,10 +157,10 @@ def test_base_image_build_arg(cli, container_runtime, ee_tag, tmpdir, data_dir):
     ee_def = os.path.join(data_dir, 'build_args', 'base-image.yml')
     os.environ['FOO'] = 'secretsecret'
 
-    # Build with custom image tag, then use that as input to --build-arg BASE_IMAGE
+    # Build with custom image tag, then use that as input to --build-arg ANSIBLE_RUNNER_IMAGE
     cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {container_runtime} -v3')
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {container_runtime} --build-arg BASE_IMAGE={ee_tag}-custom -v3'
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {container_runtime} --build-arg ANSIBLE_RUNNER_IMAGE={ee_tag}-custom -v3'
     )
     result = cli(f"{container_runtime} run {ee_tag}-custom cat /base_image")
     assert f"{ee_tag}-custom" in result.stdout


### PR DESCRIPTION
Also provides a `ANSIBLE_RUNNER_IMAGE` build arg that can be overridden.

I tried to develop the same functionality as `docker build`. 

Build args can be specified with `--build-arg KEY=value` or `--build-arg KEY` where `value` is set in the environment (this is only supported in Docker).

Example `Dockerfile`:


```
ARG ANSIBLE_RUNNER_IMAGE=quay.io/ansible/ansible-runner:devel
FROM $ANSIBLE_RUNNER_IMAGE as galaxy

ADD _build/requirements.yml /build/_build/requirements.yml

RUN ansible-galaxy role install -r /build/_build/requirements.yml --roles-path /usr/share/ansible/roles
RUN ansible-galaxy collection install -r /build/_build/requirements.yml --collections-path /usr/share/ansible/collections

RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections

FROM quay.io/ansible/python-builder:latest as builder

ADD _build/requirements_combined.txt /tmp/src/requirements.txt
ADD _build/bindep_combined.txt /tmp/src/bindep.txt
RUN assemble

FROM $ANSIBLE_RUNNER_IMAGE

COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
COPY --from=galaxy /usr/share/ansible/collections /usr/share/ansible/collections

COPY --from=builder /output/ /output/
RUN /output/install-from-bindep && rm -rf /output/wheels
RUN alternatives --set python /usr/bin/python3
```