### PR TITLE
Remove unused entry point in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linters, py3, insync, integration
+envlist = linters, py3, integration
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This is no longer needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>