### PR TITLE
Show last 20 lines of output in case of error

### DIFF
--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import sys
+from collections import deque
 
 from .colors import MessageColors
 
@@ -72,10 +73,12 @@ def run_command(command, capture_output=False, allow_error=False):
         sys.exit(1)
 
     output = []
+    trailing_output = deque(maxlen=20)
     for line in iter(process.stdout.readline, b''):
         line = line.decode(sys.stdout.encoding)
         if capture_output:
             output.append(line.rstrip())
+        trailing_output.append(line.rstrip())
         logger.debug(line.rstrip('\n'))  # line ends added by logger itself
     logger.debug('')
 
@@ -86,9 +89,16 @@ def run_command(command, capture_output=False, allow_error=False):
             logger.error('Command that had error:')
             logger.error('  {0}'.format(' '.join(command)))
         if main_logger.level > logging.DEBUG:
-            for line in output:
-                logger.error(line)
-            logger.error('')
+            if capture_output:
+                for line in output:
+                    logger.error(line)
+                logger.error('')
+            else:
+                if len(trailing_output) == 20:
+                    logger.error('...showing last 20 lines of output...')
+                for line in trailing_output:
+                    logger.error(line)
+                logger.error('')
         logger.error(f"An error occured (rc={rc}), see output line(s) above for details.")
         sys.exit(1)
 


### PR DESCRIPTION
Demo:

```
$ ansible-builder build -c alan -f test/data/pytz/execution-environment.yml -t alan --container-runtime=podman
Running command:
  podman build -f alan/Containerfile -t alan alan
Running command:
  podman run --rm -v /home/alancoding/repos/ansible-builder/alan:/context:Z alan python3 /context/_build/introspect.py
Running command:
  podman build -f alan/Containerfile -t alan alan
...showing last 20 lines of output...
--> 059611e0362
STEP 3: RUN ansible-galaxy role install -r /build/_build/requirements.yml --roles-path /usr/share/ansible/roles
--> Using cache 549ff53127e1b226c11eb3584e777f57b4e4466adce530bd4c8d4577783e57f3
--> 549ff53127e
STEP 4: RUN ansible-galaxy collection install -r /build/_build/requirements.yml --collections-path /usr/share/ansible/collections
--> Using cache 7d41130bc43cc7cf089c1207cf51133dafca44b600de54741f5b6efd1a49061a
--> 7d41130bc43
STEP 5: RUN mkdir -p /usr/share/ansible/roles /usr/share/ansible/collections
--> Using cache f92acc5e13b472885c71606a2a32c924825fe7a617f8a8fec8636fe98a408491
--> f92acc5e13b
STEP 6: FROM quay.io/ansible/python-builder:latest AS builder
STEP 7: ADD _build/requirements_combined.txt /tmp/src/requirements.txt
--> Using cache 5292a6c0827ff3e7b5185d60fed58a8e085de1cccdf69d289690207bd92c8071
--> 5292a6c0827
STEP 8: RUN assemble
--> Using cache f0bcc3a7ddff9235302d915bee88157aede0671c3b1369ad1b3cc00bb4b024b3
--> f0bcc3a7ddf
STEP 9: FROM quay.io/ansible/ansible-runner:devel
STEP 10: COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
Error: error building at STEP "COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles": error adding sources [/home/alancoding/.local/share/containers/storage/overlay/41054c5e53e0bdb2152ff1f66f0eb75b0b43f99a3232f35ecf4ee78e5baa538a/merged/usr/share/ansible/roles]: no items matching glob "/home/alancoding/.local/share/containers/storage/overlay/41054c5e53e0bdb2152ff1f66f0eb75b0b43f99a3232f35ecf4ee78e5baa538a/merged/usr/share/ansible/roles" copied (1 filtered out): no such file or directory

An error occured (rc=125), see output line(s) above for details.
```

Without this, it gives the incoherent output:

```
$ ansible-builder build -c alan -f test/data/pytz/execution-environment.yml -t alan --container-runtime=podman
Running command:
  podman build -f alan/Containerfile -t alan alan
Running command:
  podman run --rm -v /home/alancoding/repos/ansible-builder/alan:/context:Z alan python3 /context/_build/introspect.py
Running command:
  podman build -f alan/Containerfile -t alan alan

An error occured (rc=125), see output line(s) above for details.
```

Checked with `-v2` and `-v3`, and those still look good.