### PR TITLE
Pre-create Ansible content directories before install and copy

### DIFF
--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -42,12 +42,12 @@ class GalaxyInstallSteps(Steps):
         )
         self.steps.extend([
             "",
+            "RUN mkdir -p {0} {1}".format(constants.base_roles_path, constants.base_collections_path),
             "RUN ansible-galaxy role install -r /build/{0} --roles-path {1}".format(
                 requirements_naming, constants.base_roles_path),
             "RUN ansible-galaxy collection install -r /build/{0} --collections-path {1}".format(
                 requirements_naming, constants.base_collections_path),
             "",
-            "RUN mkdir -p {0} {1}".format(constants.base_roles_path, constants.base_collections_path),
         ])
 
 
@@ -58,6 +58,7 @@ class GalaxyCopySteps(Steps):
         self.steps = []
         self.steps.extend([
             "",
+            "RUN mkdir -p {0} {1}".format(constants.base_roles_path, constants.base_collections_path),
             "COPY --from=galaxy {0} {0}".format(constants.base_roles_path),
             "COPY --from=galaxy {0} {0}".format(constants.base_collections_path),
             "",


### PR DESCRIPTION
running this in awx-ee repo

```
$ podman build -f awx-ee/Dockerfile awx-ee -t quay.io/ansible/awx-ee:latest
```

gives:

```
STEP 10: RUN assemble
--> Using cache 1d67b858dc6bc654b2098c4605f1b19aa0c776d73e1a97ebed77954f943ebe89
--> 1d67b858dc6
STEP 11: FROM quay.io/ansible/ansible-runner:devel
STEP 12: COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles
Error: error building at STEP "COPY --from=galaxy /usr/share/ansible/roles /usr/share/ansible/roles": error adding sources [/home/alancoding/.local/share/containers/storage/overlay/7ab81497e1d4bfeb2018a95785a719c9e92ed0a5fc96a41bf172e6592e88f0c4/merged/usr/share/ansible/roles]: no items matching glob "/home/alancoding/.local/share/containers/storage/overlay/7ab81497e1d4bfeb2018a95785a719c9e92ed0a5fc96a41bf172e6592e88f0c4/merged/usr/share/ansible/roles" copied (1 filtered out): no such file or directory
```

This apparently doesn't happen with older versions of podman, and this is suspected to be a bug, but I can't find any issues to this effect... and I'm skeptical that it would be received as a bug.

In fact, this was already before the `COPY` commands, and ba6c195c98664231b9d7b714b15ef0fe8f891bb7 moved it to _after_ the install. I can't make this make sense. Creating the directory _before_ doing other stuff has no hazards (it's not a problem for Ansible), and I can concretely confirm this fixes the bug.