### PR TITLE
Copy the entire Ansible share dir for bug workaround

### DIFF
--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 from . import constants
 from .exceptions import DefinitionError
@@ -58,8 +59,9 @@ class GalaxyCopySteps(Steps):
         self.steps = []
         self.steps.extend([
             "",
-            "COPY --from=galaxy {0} {0}".format(constants.base_roles_path),
-            "COPY --from=galaxy {0} {0}".format(constants.base_collections_path),
+            "COPY --from=galaxy {0} {0}".format(
+                os.path.dirname(constants.base_collections_path.rstrip('/'))  # /usr/share/ansible
+            ),
             "",
         ])
 

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -47,8 +47,6 @@ class GalaxyInstallSteps(Steps):
                 requirements_naming, constants.base_roles_path),
             "RUN ansible-galaxy collection install -r /build/{0} --collections-path {1}".format(
                 requirements_naming, constants.base_collections_path),
-            "",
-            "RUN mkdir -p {0} {1}".format(constants.base_roles_path, constants.base_collections_path),
         ])
 
 


### PR DESCRIPTION
I'm still testing this locally with the awx-ee, but the hope is that it is a workaround for https://github.com/containers/podman/issues/8948

replaces prior attempt https://github.com/ansible/ansible-builder/pull/171

Credit to @pabelanger for seeing the obvious solution I didn't.