### PR TITLE
Add ANSIBLE_GALAXY_CLI_COLLECTION_OPTS build-arg

### DIFF
--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -12,6 +12,7 @@ base_roles_path = '/usr/share/ansible/roles'
 base_collections_path = '/usr/share/ansible/collections'
 
 build_arg_defaults = dict(
+    ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='',
     ANSIBLE_RUNNER_IMAGE='quay.io/ansible/ansible-runner:devel',
     PYTHON_BUILDER_IMAGE='quay.io/ansible/python-builder:latest'
 )

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -383,6 +383,9 @@ class Containerfile:
     def prepare_galaxy_install_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):
             relative_galaxy_path = os.path.join(CONTEXT_BUILD_OUTPUTS_DIR, CONTEXT_FILES['galaxy'])
+            self.steps.append(
+                "ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS={}".format(
+                    self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS']))
             self.steps.extend(GalaxyInstallSteps(relative_galaxy_path))
         return self.steps
 

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -44,7 +44,7 @@ class GalaxyInstallSteps(Steps):
             "",
             "RUN ansible-galaxy role install -r /build/{0} --roles-path {1}".format(
                 requirements_naming, constants.base_roles_path),
-            "RUN ansible-galaxy collection install -r /build/{0} --collections-path {1}".format(
+            "RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r /build/{0} --collections-path {1}".format(
                 requirements_naming, constants.base_collections_path),
             "",
             "RUN mkdir -p {0} {1}".format(constants.base_roles_path, constants.base_collections_path),

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -36,6 +36,9 @@ to using the ``--build-arg`` CLI flag.
 
 Build args used by ansible-builder are the following.
 
+The ``ANSIBLE_GALAXY_CLI_COLLECTION_OPTS`` build arg allows the user to pass
+the '--pre' flag to enable the installation of pre-releases collections.
+
 The ``ANSIBLE_RUNNER_IMAGE`` build arg specifies the parent image
 for the execution environment.
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,6 +16,15 @@ def test_custom_image(exec_env_definition_file, tmpdir):
     assert aee.build_args == {'ANSIBLE_RUNNER_IMAGE': 'my-custom-image'}
 
 
+def test_custom_ansible_galaxy_cli_collection_opts(exec_env_definition_file, tmpdir):
+    content = {'version': 1}
+    path = str(exec_env_definition_file(content=content))
+
+    aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre', '-c', str(tmpdir)])
+
+    assert aee.build_args == {'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': '--pre'}
+
+
 def test_build_context(good_exec_env_definition_path, tmpdir):
     path = str(good_exec_env_definition_path)
     build_context = str(tmpdir)


### PR DESCRIPTION
This allows a user to use the --pre flag for ansible-galaxy collection
install. This will allow the installation of pre-release collections
from galaxy / AH.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>