### PR TITLE
Show all defaults in help text, consolidate some

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -3,12 +3,11 @@ import logging
 import sys
 import yaml
 
-from . import __version__
+from . import __version__, constants
 
 from .colors import MessageColors
 from .exceptions import DefinitionError
 from .main import AnsibleBuilder
-from . import constants
 from .introspect import add_introspect_options, process, simple_combine
 from .requirements import sanitize_requirements
 from .utils import configure_logger
@@ -77,38 +76,42 @@ def parse_args(args=sys.argv[1:]):
 
     build_command_parser.add_argument('-t', '--tag',
                                       default=constants.default_tag,
-                                      help='The name for the container image being built.')
+                                      help='The name for the container image being built (default: %(default)s)')
 
     for p in [build_command_parser]:
 
         p.add_argument('-f', '--file',
                        default=constants.default_file,
                        dest='filename',
-                       help='The definition of the execution environment.')
+                       help='The definition of the execution environment (default: %(default)s)')
 
         p.add_argument('-c', '--context',
                        default=constants.default_build_context,
                        dest='build_context',
-                       help='The directory to use for the build context. Defaults to $PWD/context.')
+                       help='The directory to use for the build context (default: %(default)s)')
 
         p.add_argument('--container-runtime',
                        choices=list(constants.runtime_files.keys()),
                        default=constants.default_container_runtime,
-                       help='Specifies which container runtime to use. Defaults to {0}.'.format(constants.default_container_runtime))
+                       help='Specifies which container runtime to use (default: %(default)s)')
 
         p.add_argument('--build-arg',
                        action=BuildArgAction,
                        default={},
-                       dest='build_args')
+                       dest='build_args',
+                       help='Build-time variables to pass to any podman or docker calls. '
+                            'Internally ansible-builder makes use of {0}.'.format(
+                                ', '.join(constants.build_arg_defaults.keys()))
+                       )
 
         p.add_argument('-v', '--verbosity',
                        dest='verbosity',
                        type=int,
                        choices=[0, 1, 2, 3],
-                       default=2,
+                       default=constants.default_verbosity,
                        help='Increase the output verbosity, for up to three levels of verbosity '
                             '(invoked via "--verbosity" or "-v" followed by an integer ranging '
-                            'in value from 0 to 3)')
+                            'in value from 0 to 3) (default: %(default)s)')
 
     introspect_parser = subparsers.add_parser(
         'introspect',

--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -3,6 +3,7 @@ import shutil
 default_file = 'execution-environment.yml'
 default_tag = 'ansible-execution-env:latest'
 default_build_context = 'context'
+default_verbosity = 2
 runtime_files={
     'podman': 'Containerfile',
     'docker': 'Dockerfile'

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -42,7 +42,7 @@ class AnsibleBuilder:
                  build_context=constants.default_build_context,
                  tag=constants.default_tag,
                  container_runtime=constants.default_container_runtime,
-                 verbosity=2):
+                 verbosity=constants.default_verbosity):
         self.action = action
         self.definition = UserDefinition(filename=filename)
 


### PR DESCRIPTION
I noticed that the default `--tag` was not showing up. This is very high up there on the scale of user impact, so I really want the help text to show it.

I also tried to have all options share a common pattern for printing their default value.

```
$ ansible-builder build --help
usage: ansible-builder build [-h] [-t TAG] [-f FILENAME] [-c BUILD_CONTEXT]
                             [--container-runtime {podman,docker}] [--build-arg BUILD_ARGS]
                             [-v {0,1,2,3}]

Creates a build context (including a Containerfile) from an execution environment spec. The build
context will be populated from the execution environment spec. After that, the specified container
runtime podman/docker will be invoked to build an image from that definition. After building the image,
it can be used locally or published using the supplied tag.

optional arguments:
  -h, --help            show this help message and exit
  -t TAG, --tag TAG     The name for the container image being built (default: ansible-execution-
                        env:latest)
  -f FILENAME, --file FILENAME
                        The definition of the execution environment (default: execution-environment.yml)
  -c BUILD_CONTEXT, --context BUILD_CONTEXT
                        The directory to use for the build context (default: context)
  --container-runtime {podman,docker}
                        Specifies which container runtime to use (default: podman)
  --build-arg BUILD_ARGS
                        Build-time variables to pass to any podman or docker calls. Internally ansible-
                        builder makes use of ANSIBLE_GALAXY_CLI_COLLECTION_OPTS, ANSIBLE_RUNNER_IMAGE,
                        PYTHON_BUILDER_IMAGE.
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Increase the output verbosity, for up to three levels of verbosity (invoked via
                        "--verbosity" or "-v" followed by an integer ranging in value from 0 to 3)
                        (default: 2)
```