### PR TITLE
Copy build context folder into galaxy layer

### DIFF
--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -18,6 +18,8 @@ build_arg_defaults = dict(
     PYTHON_BUILDER_IMAGE='quay.io/ansible/python-builder:latest'
 )
 
+user_content_subfolder = '_build'
+
 if shutil.which('podman'):
     default_container_runtime = 'podman'
 else:

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -39,13 +39,15 @@ class GalaxyInstallSteps(Steps):
         """
         self.steps = []
         self.steps.append(
-            "ADD {0} /build/{0}".format(requirements_naming)
+            "ADD {0} /build".format(
+                constants.user_content_subfolder)
         )
         self.steps.extend([
             "",
-            "RUN ansible-galaxy role install -r /build/{0} --roles-path {1}".format(
+            "WORKDIR /build",
+            "RUN ansible-galaxy role install -r {0} --roles-path {1}".format(
                 requirements_naming, constants.base_roles_path),
-            "RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r /build/{0} --collections-path {1}".format(
+            "RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r {0} --collections-path {1}".format(
                 requirements_naming, constants.base_collections_path),
         ])
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -2,9 +2,10 @@ import os
 import pytest
 
 from ansible_builder import __version__
+from ansible_builder import constants
 from ansible_builder.exceptions import DefinitionError
 from ansible_builder.main import (
-    AnsibleBuilder, UserDefinition, CONTEXT_BUILD_OUTPUTS_DIR
+    AnsibleBuilder, UserDefinition
 )
 
 
@@ -51,7 +52,7 @@ def test_galaxy_requirements(exec_env_definition_file, galaxy_requirements_file,
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert f'ADD {CONTEXT_BUILD_OUTPUTS_DIR}/requirements.yml' in content
+    assert f'ADD {constants.user_content_subfolder} /build' in content
 
 
 def test_base_image_via_build_args(exec_env_definition_file, tmpdir):
@@ -116,7 +117,7 @@ def test_nested_galaxy_file(data_dir, tmpdir):
     bc_folder = str(tmpdir)
     AnsibleBuilder(filename='test/data/nested-galaxy.yml', build_context=bc_folder).build()
 
-    req_in_bc = os.path.join(bc_folder, CONTEXT_BUILD_OUTPUTS_DIR, 'requirements.yml')
+    req_in_bc = os.path.join(bc_folder, constants.user_content_subfolder, 'requirements.yml')
     assert os.path.exists(req_in_bc)
 
     req_original = 'test/data/foo/requirements.yml'
@@ -141,7 +142,7 @@ def test_ansible_config_for_galaxy(exec_env_definition_file, tmpdir):
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert f'ADD {CONTEXT_BUILD_OUTPUTS_DIR}/ansible.cfg ~/.ansible.cfg' in content
+    assert f'ADD {constants.user_content_subfolder}/ansible.cfg ~/.ansible.cfg' in content
 
 
 class TestDefinitionErrors:


### PR DESCRIPTION
After looking at how to support offline tarballs, it might be as simple
as copying the full build context into the galaxy layer. This is okay,
becaue the layer is only used at build time.

It also allows a user to add their our data, like collection tarballs,
in the sub-folder.  Allowing for offline install of tarballs.

Depends-On: https://github.com/ansible/ansible-builder/pull/182
Signed-off-by: Paul Belanger <pabelanger@redhat.com>