### PR TITLE
Allow user to toggle image clean up for integration tests

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -16,3 +16,5 @@
     vars:
       tox_envlist: integration
       tox_install_siblings: false
+      tox_environment:
+        KEEP_IMAGES: true

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -7,11 +7,10 @@ import uuid
 import pytest
 import logging
 
-
 logger = logging.getLogger(__name__)
 
-
 TAG_PREFIX = 'quay.io/example/builder-test'
+KEEP_IMAGES = bool(os.environ.get('KEEP_IMAGES', False))
 
 
 @pytest.fixture
@@ -72,6 +71,8 @@ def gen_image_name(request):
 
 
 def delete_image(container_runtime, image_name):
+    if KEEP_IMAGES:
+        return
     # delete given image, if the test happened to make one
     # allow error in case that image was not created
     r = run(f'{container_runtime} rmi -f {image_name}', allow_error=True)

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,9 @@ commands=
 
 [testenv:integration]
 # rootless podman reads $HOME
-passenv = HOME
+passenv =
+  HOME
+  KEEP_IMAGES
 deps =
     pytest-xdist
 whitelist_externals =


### PR DESCRIPTION
It is possible, a user want to debug a container created via integration
tsts.  Also, we may want to disable clean ups, in the case of CI.

Either way, add a flag to toggle the deleting of images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>