### PR TITLE
adding ansible-core to ignore list

### DIFF
--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 EXCLUDE_REQUIREMENTS = frozenset((
     # obviously already satisfied or unwanted
-    'ansible', 'ansible-base', 'python',
+    'ansible', 'ansible-base', 'python', 'ansible-core',
     # general python test requirements
     'tox', 'pycodestyle', 'yamllint', 'pylint',
     'flake8', 'pytest', 'pytest-xdist', 'coverage', 'mock',


### PR DESCRIPTION
Adding `ansible-core` to the unwanted list as ansible-base will be released as `ansible-core` going forward at release of 2.11.