### PR TITLE
Explicitly flip to root user during build process

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -2,7 +2,7 @@
 - job:
     name: ansible-builder-tox-integration
     parent: ansible-buildset-registry-consumer
-    timeout: 3600
+    timeout: 4500
     vars:
       container_command: podman
 

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -331,6 +331,7 @@ class Containerfile:
             ),
             "",
             "FROM $ANSIBLE_RUNNER_IMAGE as galaxy",
+            "USER root",
             ""
         ]
 
@@ -431,7 +432,8 @@ class Containerfile:
     def prepare_final_stage_steps(self):
         self.steps.extend([
             "",
-            "FROM $ANSIBLE_RUNNER_IMAGE"
+            "FROM $ANSIBLE_RUNNER_IMAGE",
+            "USER root"
             "",
         ])
         return self.steps


### PR DESCRIPTION
This fixes an issue where the parent image has set USER to something other than root

See https://github.com/ansible/awx/issues/9917