### PR TITLE
Parse version directly from __init__ module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ endif
 NAME = ansible-builder
 IMAGE_NAME ?= $(NAME)
 PIP_NAME = ansible_builder
-LONG_VERSION := $(shell poetry version)
-VERSION := $(filter-out $(NAME), $(LONG_VERSION))
+VERSION := $(shell python -c "import ast; print(ast.parse(open('ansible_builder/__init__.py', 'r').read()).body[0].value.value)")
 ifeq ($(OFFICIAL),yes)
     RELEASE ?= 1
 else


### PR DESCRIPTION
Poetry isn't working for me

```
$ poetry version
  RuntimeError
  Poetry could not find a pyproject.toml file in /home/alancoding/repos/ansible-builder or its parents
  at ~/repos/awx/env/lib64/python3.9/site-packages/poetry/core/factory.py:367 in locate
      363│             if poetry_file.exists():
      364│                 return poetry_file
      365│ 
      366│         else:
    → 367│             raise RuntimeError(
      368│                 "Poetry could not find a pyproject.toml file in {} or its parents".format(
      369│                     cwd
      370│                 )
      371│             )
```

So... this just reads the version value from here:

https://github.com/ansible/ansible-builder/blob/b7cabd02c6e1ad4bf68a1cedad52d963a5b34682/ansible_builder/__init__.py#L1