### PR TITLE
Refactor to a single-phase process but keep the three-stage Containerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.tox
+docs
+packaging
+test

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -19,3 +19,33 @@
       tox_install_siblings: false
       tox_environment:
         KEEP_IMAGES: true
+
+# Jobs for the ansible-builder image
+- job:
+    name: ansible-builder-build-container-image
+    parent: ansible-build-container-image
+    description: Build ansible-builder container image
+    provides: ansible-builder-container-image
+    requires:
+      - ansible-runner-container-image
+      - python-builder-container-image
+    vars: &vars
+      container_images: &container_images
+        - context: .
+          container_filename: Containerfile
+          registry: quay.io
+          repository: quay.io/ansible/ansible-builder
+          tags:
+            # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
+            # Otherwise: ['latest']
+            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['latest']) }}"
+      docker_images: *container_images
+
+- job:
+    name: ansible-builder-upload-container-image
+    parent: ansible-upload-container-image
+    description: Build ansible-builder container image and upload to quay.io
+    timeout: 2700
+    provides: ansible-builder-container-image
+    requires: python-base-container-image
+    vars: *vars

--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -11,7 +11,7 @@
     parent: ansible-tox-py38
     timeout: 4500
     requires:
-      - ansible-runner-container-image
+      - python-base-container-image
       - python-builder-container-image
     nodeset: ubuntu-bionic-4vcpu
     vars:
@@ -27,7 +27,7 @@
     description: Build ansible-builder container image
     provides: ansible-builder-container-image
     requires:
-      - ansible-runner-container-image
+      - python-base-container-image
       - python-builder-container-image
     vars: &vars
       container_images: &container_images

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,6 +3,18 @@
     check:
       jobs:
         - ansible-builder-tox-integration
+        - ansible-builder-build-container-image
     gate:
       jobs:
         - ansible-builder-tox-integration
+        - ansible-builder-build-container-image
+    post:
+      jobs:
+        - ansible-builder-upload-container-image:
+            vars:
+              upload_container_image_promote: false
+    periodic:
+      jobs:
+        - ansible-builder-upload-container-image:
+            vars:
+              upload_container_image_promote: false

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ FROM $ANSIBLE_RUNNER_IMAGE
 # =============================================================================
 
 COPY --from=builder /output/ /output
-RUN /output/install-from-bindep rm -rf /output
+RUN /output/install-from-bindep && rm -rf /output
 
 # move the assemble scripts themselves into this container
 COPY --from=builder /usr/local/bin/assemble /usr/local/bin/assemble

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ARG ANSIBLE_RUNNER_IMAGE=quay.io/ansible/ansible-runner:devel
 ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
 
-FROM $PYTHON_BUILDER_IMAGE as builder
+FROM $PYTHON_BUILDER_IMAGE as python_builder
 # =============================================================================
 ARG ZUUL_SIBLINGS
 
@@ -13,9 +13,12 @@ RUN assemble
 FROM $ANSIBLE_RUNNER_IMAGE
 # =============================================================================
 
-COPY --from=builder /output/ /output
+COPY --from=python_builder /output/ /output
 RUN /output/install-from-bindep && rm -rf /output
 
 # move the assemble scripts themselves into this container
-COPY --from=builder /usr/local/bin/assemble /usr/local/bin/assemble
-COPY --from=builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages
+COPY --from=python_builder /usr/local/bin/assemble /usr/local/bin/assemble
+COPY --from=python_builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages
+
+# building EEs require the install-from-bindep script, but not the rest of the /output folder
+COPY --from=python_builder /output/install-from-bindep /output/install-from-bindep

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+ARG ANSIBLE_RUNNER_IMAGE=quay.io/ansible/ansible-runner:devel
+ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
+
+FROM $PYTHON_BUILDER_IMAGE as builder
+# =============================================================================
+ARG ZUUL_SIBLINGS
+
+# install this library (meaning ansible-builder)
+COPY . /tmp/src
+RUN assemble
+
+
+FROM $ANSIBLE_RUNNER_IMAGE
+# =============================================================================
+
+COPY --from=builder /output/ /output
+RUN /output/install-from-bindep rm -rf /output
+
+# move the assemble scripts themselves into this container
+COPY --from=builder /usr/local/bin/assemble /usr/local/bin/assemble
+COPY --from=builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages

--- a/Containerfile
+++ b/Containerfile
@@ -1,16 +1,16 @@
-ARG ANSIBLE_RUNNER_IMAGE=quay.io/ansible/ansible-runner:devel
+ARG PYTHON_BASE_IMAGE=quay.io/ansible/python-base:latest
 ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
 
 FROM $PYTHON_BUILDER_IMAGE as python_builder
 # =============================================================================
 ARG ZUUL_SIBLINGS
 
-# install this library (meaning ansible-builder)
+# build this library (meaning ansible-builder)
 COPY . /tmp/src
 RUN assemble
 
 
-FROM $ANSIBLE_RUNNER_IMAGE
+FROM $PYTHON_BASE_IMAGE
 # =============================================================================
 
 COPY --from=python_builder /output/ /output

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CONTAINER_ENGINE ?= docker
 NAME = ansible-builder
 IMAGE_NAME ?= quay.io/ansible/ansible-builder
 PIP_NAME = ansible_builder
-LONG_VERSION := $(shell poetry version)
+LONG_VERSION := latest
 VERSION := $(filter-out $(NAME), $(LONG_VERSION))
 ifeq ($(OFFICIAL),yes)
     RELEASE ?= 1
@@ -55,9 +55,11 @@ dist/$(NAME)-$(VERSION).tar.gz:
 	tox -e version
 	$(DIST_PYTHON) setup.py sdist
 
-image: sdist
+# TODO: implications need to be understood of sdist
+image:
+	python setup.py sdist
 	$(CONTAINER_ENGINE) build --rm=true -t $(IMAGE_NAME) -f Containerfile .
-	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME):$(GIT_BRANCH)
+	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME):$(VERSION)
 
 dev:
 	poetry install

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ CONTAINER_ENGINE ?= docker
 NAME = ansible-builder
 IMAGE_NAME ?= quay.io/ansible/ansible-builder
 PIP_NAME = ansible_builder
-LONG_VERSION := latest
-VERSION := $(filter-out $(NAME), $(LONG_VERSION))
+VERSION := $(shell git describe --tags)
 ifeq ($(OFFICIAL),yes)
     RELEASE ?= 1
 else
@@ -55,7 +54,7 @@ dist/$(NAME)-$(VERSION).tar.gz:
 	tox -e version
 	$(DIST_PYTHON) setup.py sdist
 
-# TODO: implications need to be understood of sdist
+# Used to make image for running tests
 image:
 	python setup.py sdist
 	$(CONTAINER_ENGINE) build --rm=true -t $(IMAGE_NAME) -f Containerfile .

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ else
     DIST_PYTHON ?= $(PYTHON)
 endif
 
+CONTAINER_ENGINE ?= docker
+
 NAME = ansible-builder
-IMAGE_NAME ?= $(NAME)
+IMAGE_NAME ?= quay.io/ansible/ansible-builder
 PIP_NAME = ansible_builder
 LONG_VERSION := $(shell poetry version)
 VERSION := $(filter-out $(NAME), $(LONG_VERSION))
@@ -52,6 +54,10 @@ sdist: dist/$(NAME)-$(VERSION).tar.gz
 dist/$(NAME)-$(VERSION).tar.gz:
 	tox -e version
 	$(DIST_PYTHON) setup.py sdist
+
+image: sdist
+	$(CONTAINER_ENGINE) build --rm=true -t $(IMAGE_NAME) -f Containerfile .
+	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME):$(GIT_BRANCH)
 
 dev:
 	poetry install

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -151,8 +151,9 @@ def parse_args(args=sys.argv[1:]):
             'This should have a folder named ansible_collections inside of it.'
         )
     )
-    # TODO: If we can allow python-builder scripts to be fed multiple files
-    # then we should prefer that over the --user-* options
+    # Combine user requirements and collection requirements into single file
+    # in the future, could look into passing multilple files to
+    # python-builder scripts to be fed multiple files as opposed to this
     introspect_parser.add_argument(
         '--user-pip', dest='user_pip',
         help='An additional file to combine with collection pip requirements.'

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -36,7 +36,7 @@ def run():
             logger.error(e.args[0])
             sys.exit(1)
     elif args.action == 'introspect':
-        data = process(args.folder)
+        data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
         if args.sanitize:
             data['python'] = sanitize_requirements(data['python'])
             data['system'] = simple_combine(data['system'])
@@ -150,6 +150,16 @@ def parse_args(args=sys.argv[1:]):
             'Ansible collections path(s) to introspect. '
             'This should have a folder named ansible_collections inside of it.'
         )
+    )
+    # TODO: If we can allow python-builder scripts to be fed multiple files
+    # then we should prefer that over the --user-* options
+    parser.add_argument(
+        '--user-pip', dest='user_pip',
+        help='An additional file to combine with collection pip requirements.'
+    )
+    parser.add_argument(
+        '--user-bindep', dest='user_bindep',
+        help='An additional file to combine with collection bindep requirements.'
     )
     introspect_parser.add_argument(
         '--write-pip', dest='write_pip',

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -38,19 +38,23 @@ def run():
     elif args.action == 'introspect':
         data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
         if args.sanitize:
+            logger.info('# Sanitized dependencies for {0}'.format(args.folder))
+            data_for_write = data
             data['python'] = sanitize_requirements(data['python'])
             data['system'] = simple_combine(data['system'])
-            logger.info('# Sanitized dependencies for {0}'.format(args.folder))
         else:
-            print('# Dependency data for {0}'.format(args.folder))
+            logger.info('# Dependency data for {0}'.format(args.folder))
+            data_for_write = data.copy()
+            data_for_write['python'] = simple_combine(data['python'])
+            data_for_write['system'] = simple_combine(data['system'])
 
         print('---')
         print(yaml.dump(data, default_flow_style=False))
 
         if args.write_pip and data.get('python'):
-            write_file(args.write_pip, simple_combine(data.get('python')) + [''])
+            write_file(args.write_pip, data_for_write.get('python') + [''])
         if args.write_bindep and data.get('system'):
-            write_file(args.write_bindep, simple_combine(data.get('system')) + [''])
+            write_file(args.write_bindep, data_for_write.get('system') + [''])
 
         sys.exit(0)
 

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -153,11 +153,11 @@ def parse_args(args=sys.argv[1:]):
     )
     # TODO: If we can allow python-builder scripts to be fed multiple files
     # then we should prefer that over the --user-* options
-    parser.add_argument(
+    introspect_parser.add_argument(
         '--user-pip', dest='user_pip',
         help='An additional file to combine with collection pip requirements.'
     )
-    parser.add_argument(
+    introspect_parser.add_argument(
         '--user-bindep', dest='user_bindep',
         help='An additional file to combine with collection bindep requirements.'
     )

--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -14,8 +14,8 @@ base_collections_path = '/usr/share/ansible/collections'
 
 build_arg_defaults = dict(
     ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='',
-    ANSIBLE_RUNNER_IMAGE='quay.io/ansible/ansible-runner:devel',
-    PYTHON_BUILDER_IMAGE='quay.io/ansible/python-builder:latest'
+    EE_BASE_IMAGE='quay.io/ansible/ansible-runner:devel',
+    EE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest'
 )
 
 user_content_subfolder = '_build'

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -3,7 +3,7 @@ import sys
 
 class DefinitionError(RuntimeError):
     # Eliminate the output of traceback before our custom error message prints out
-    sys.tracebacklimit = 0
+    #sys.tracebacklimit = 0
 
     def __init__(self, msg):
         super(DefinitionError, self).__init__("%s" % msg)

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -1,8 +1,9 @@
+import sys
 
 
 class DefinitionError(RuntimeError):
     # Eliminate the output of traceback before our custom error message prints out
-    #sys.tracebacklimit = 0
+    sys.tracebacklimit = 0
 
     def __init__(self, msg):
         super(DefinitionError, self).__init__("%s" % msg)

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -1,4 +1,3 @@
-import sys
 
 
 class DefinitionError(RuntimeError):

--- a/ansible_builder/introspect.py
+++ b/ansible_builder/introspect.py
@@ -10,9 +10,16 @@ def line_is_empty(line):
     return bool((not line.strip()) or line.startswith('#'))
 
 
-def pip_file_data(path):
+def read_req_file(path):
+    """Provide some minimal error and display handling for file reading"""
+    if not os.path.exists(path):
+        print('Expected requirements file not present at: {0}'.format(os.path.abspath(path)))
     with open(path, 'r') as f:
-        pip_content = f.read()
+        return f.read()
+
+
+def pip_file_data(path):
+    pip_content = read_req_file(path)
 
     pip_lines = []
     for line in pip_content.split('\n'):
@@ -29,8 +36,7 @@ def pip_file_data(path):
 
 
 def bindep_file_data(path):
-    with open(path, 'r') as f:
-        sys_content = f.read()
+    sys_content = read_req_file(path)
 
     sys_lines = []
     for line in sys_content.split('\n'):

--- a/ansible_builder/introspect.py
+++ b/ansible_builder/introspect.py
@@ -63,7 +63,7 @@ def process_collection(path):
     return (pip_lines, bindep_lines)
 
 
-def process(data_dir=base_collections_path):
+def process(data_dir=base_collections_path, user_pip=None, user_bindep=None):
     paths = []
     path_root = os.path.join(data_dir, 'ansible_collections')
 
@@ -94,6 +94,16 @@ def process(data_dir=base_collections_path):
 
         if col_sys_lines:
             sys_req[key] = col_sys_lines
+
+    # add on entries from user files, if they are given
+    if user_pip:
+        col_pip_lines = pip_file_data(user_pip)
+        if col_pip_lines:
+            py_req['user'] = col_pip_lines
+    if user_bindep:
+        col_sys_lines = bindep_file_data(user_bindep)
+        if col_sys_lines:
+            sys_req['user'] = col_sys_lines
 
     return {
         'python': py_req,

--- a/ansible_builder/introspect.py
+++ b/ansible_builder/introspect.py
@@ -1,9 +1,5 @@
-#!/usr/bin/env python3
-
 import os
-import sys
 import yaml
-import argparse
 
 
 base_collections_path = '/usr/share/ansible/collections'
@@ -188,28 +184,3 @@ def simple_combine(reqs):
                 fancy_lines.append(fancy_line)
 
     return fancy_lines
-
-
-def add_introspect_options(parser):
-    parser.add_argument(
-        'folder', default=base_collections_path, nargs='?',
-        help=(
-            'Ansible collections path(s) to introspect. '
-            'This should have a folder named ansible_collections inside of it.'
-        )
-    )
-
-
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        prog='ansible-builder-introspector',
-        description=(
-            'This is for programmatic use. '
-            'Use ansible-builder introspect instead.'
-        )
-    )
-    add_introspect_options(parser)
-    args = parser.parse_args()
-    data = process(args.folder)
-    print(yaml.dump(data, default_flow_style=False))
-    sys.exit(0)

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -336,9 +336,6 @@ class Containerfile:
 
     def prepare_galaxy_install_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):
-            self.steps.append(
-                "ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS={}".format(
-                    self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS']))
             self.steps.extend(GalaxyInstallSteps(CONTEXT_FILES['galaxy']))
         return self.steps
 
@@ -381,6 +378,9 @@ class Containerfile:
         self.steps.extend([
             "",
             "FROM $EE_BASE_IMAGE as galaxy",
+            "ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS={}".format(
+                self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS']
+            ),
             "USER root",
             ""
         ])

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -356,7 +356,7 @@ class Containerfile:
     def prepare_system_runtime_deps_steps(self):
         self.steps.extend([
             "COPY --from=builder /output/ /output/",
-            "RUN install-from-bindep && rm -rf /output/wheels",
+            "RUN /output/install-from-bindep && rm -rf /output/wheels",
         ])
 
         return self.steps

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -343,7 +343,7 @@ class Containerfile:
         # The introspect/assemble block is valid if there are any form of requirements
         if any(self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')):
 
-            introspect_cmd = "RUN ansible-builder introspect"
+            introspect_cmd = "RUN ansible-builder introspect --sanitize"
 
             requirements_file_exists = os.path.exists(os.path.join(
                 self.build_outputs_dir, CONTEXT_FILES['python']

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -84,28 +84,16 @@ class AnsibleBuilder:
 
         return command
 
-    def run_in_container(self, command, **kwargs):
-        wrapped_command = [self.container_runtime, 'run', '--rm']
-
-        # ansible builder root on the controller machine
-        ab_lib_path = os.path.dirname(ansible_builder.introspect.__file__)
-
-        wrapped_command.extend(['-v', f"{ab_lib_path}:/ansible_builder_mount:Z"])
-
-        wrapped_command.extend([self.tag] + command)
-
-        return run_command(wrapped_command, **kwargs)
-
     def build(self):
-        # Phase 1 of Containerfile
+        # File preparation
         self.containerfile.create_folder_copy_files()
         self.containerfile.prepare_ansible_config_file()
+
+        # First stage, builder
         self.containerfile.prepare_galaxy_install_steps()
         self.containerfile.prepare_assemble_steps()
 
-
-
-
+        # Second stage
         self.containerfile.prepare_final_stage_steps()
         self.containerfile.prepare_prepended_steps()
         self.containerfile.prepare_galaxy_copy_steps()

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -6,7 +6,7 @@ import yaml
 from . import constants
 from .exceptions import DefinitionError
 from .steps import (
-    AdditionalBuildSteps, GalaxyInstallSteps, GalaxyCopySteps, AnsibleConfigSteps
+    AdditionalBuildSteps, BuildContextSteps, GalaxyInstallSteps, GalaxyCopySteps, AnsibleConfigSteps
 )
 from .utils import run_command, copy_file
 
@@ -89,6 +89,7 @@ class AnsibleBuilder:
         self.containerfile.prepare_ansible_config_file()
 
         # First stage, builder
+        self.containerfile.prepare_build_context()
         self.containerfile.prepare_galaxy_install_steps()
         self.containerfile.prepare_introspect_assemble_steps()
 
@@ -326,6 +327,10 @@ class Containerfile:
                 return self.steps.extend(AdditionalBuildSteps(appended_steps))
 
         return False
+
+    def prepare_build_context(self):
+        self.steps.extend(BuildContextSteps())
+        return self.steps
 
     def prepare_galaxy_install_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -268,14 +268,14 @@ class Containerfile:
         self.tag = tag
         # Build args all need to go at top of file to avoid errors
         self.steps = [
-            "ARG ANSIBLE_RUNNER_IMAGE={}".format(
-                self.definition.build_arg_defaults['ANSIBLE_RUNNER_IMAGE']
+            "ARG EE_BASE_IMAGE={}".format(
+                self.definition.build_arg_defaults['EE_BASE_IMAGE']
             ),
-            "ARG PYTHON_BUILDER_IMAGE={}".format(
-                self.definition.build_arg_defaults['PYTHON_BUILDER_IMAGE']
+            "ARG EE_BUILDER_IMAGE={}".format(
+                self.definition.build_arg_defaults['EE_BUILDER_IMAGE']
             ),
             "",
-            "FROM $ANSIBLE_RUNNER_IMAGE as builder",
+            "FROM $EE_BASE_IMAGE as builder",
             "USER root",
             ""
         ]
@@ -364,7 +364,7 @@ class Containerfile:
     def prepare_final_stage_steps(self):
         self.steps.extend([
             "",
-            "FROM $ANSIBLE_RUNNER_IMAGE",
+            "FROM $EE_BASE_IMAGE",
             "USER root"
             "",
         ])

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -8,8 +8,7 @@ from .exceptions import DefinitionError
 from .steps import (
     AdditionalBuildSteps, GalaxyInstallSteps, GalaxyCopySteps, AnsibleConfigSteps
 )
-from .utils import run_command, write_file, copy_file
-from .requirements import sanitize_requirements
+from .utils import run_command, copy_file
 import ansible_builder.introspect
 
 

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -59,7 +59,7 @@ class GalaxyCopySteps(Steps):
         self.steps = []
         self.steps.extend([
             "",
-            "COPY --from=galaxy {0} {0}".format(
+            "COPY --from=builder {0} {0}".format(
                 os.path.dirname(constants.base_collections_path.rstrip('/'))  # /usr/share/ansible
             ),
             "",

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -33,23 +33,25 @@ class AdditionalBuildSteps(Steps):
         return iter(self.steps)
 
 
+class BuildContextSteps(Steps):
+    def __init__(self):
+        self.steps = [
+            "ADD {0} /build".format(constants.user_content_subfolder),
+            "WORKDIR /build",
+            "",
+        ]
+
+
 class GalaxyInstallSteps(Steps):
     def __init__(self, requirements_naming):
         """Assumes given requirements file name has been placed in the build context
         """
-        self.steps = []
-        self.steps.append(
-            "ADD {0} /build".format(
-                constants.user_content_subfolder)
-        )
-        self.steps.extend([
-            "",
-            "WORKDIR /build",
+        self.steps = [
             "RUN ansible-galaxy role install -r {0} --roles-path {1}".format(
                 requirements_naming, constants.base_roles_path),
             "RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r {0} --collections-path {1}".format(
                 requirements_naming, constants.base_collections_path),
-        ])
+        ]
 
 
 class GalaxyCopySteps(Steps):

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -61,7 +61,7 @@ class GalaxyCopySteps(Steps):
         self.steps = []
         self.steps.extend([
             "",
-            "COPY --from=builder {0} {0}".format(
+            "COPY --from=galaxy {0} {0}".format(
                 os.path.dirname(constants.base_collections_path.rstrip('/'))  # /usr/share/ansible
             ),
             "",

--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -122,6 +122,10 @@ def run_command(command, capture_output=False, allow_error=False):
 
 
 def write_file(filename: str, lines: list) -> bool:
+    parent_dir = os.path.dirname(filename)
+    if parent_dir and not os.path.exists(parent_dir):
+        logger.warning('Creating parent directory for {0}'.format(filename))
+        os.makedirs(parent_dir)
     new_text = '\n'.join(lines)
     if os.path.exists(filename):
         with open(filename, 'r') as f:

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -9,7 +9,7 @@ An example execution environment definition schema is as follows:
     version: 1
 
     build_arg_defaults:
-      ANSIBLE_RUNNER_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.10-devel'
+      EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.10-devel'
 
     ansible_config: 'ansible.cfg'
 
@@ -39,10 +39,10 @@ Build args used by ``ansible-builder`` are the following:
 The ``ANSIBLE_GALAXY_CLI_COLLECTION_OPTS`` build arg allows the user to pass
 the '--pre' flag to enable the installation of pre-releases collections.
 
-The ``ANSIBLE_RUNNER_IMAGE`` build arg specifies the parent image
+The ``EE_BASE_IMAGE`` build arg specifies the parent image
 for the execution environment.
 
-The ``PYTHON_BUILDER_IMAGE`` build arg specifies the image used for
+The ``EE_BUILDER_IMAGE`` build arg specifies the image used for
 compiling type tasks.
 
 Values given inside of ``default_build_args`` will be hard-coded into the

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,7 +87,7 @@ directory. To specify another location:
 
 To use Podman or Docker's build-time variables, specify them the same way you would with ``podman build`` or ``docker build``.
 
-By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``ANSIBLE_RUNNER_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
+By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``EE_BASE_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
 
 .. code::
 
@@ -97,7 +97,7 @@ To use a custom base image:
 
 .. code::
 
-   $ ansible-builder build --build-arg ANSIBLE_RUNNER_IMAGE=registry.example.com/another-ee
+   $ ansible-builder build --build-arg EE_BASE_IMAGE=registry.example.com/another-ee
 
 
 ``--container-runtime``

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 requirements-parser
+bindep

--- a/test/data/build_args/base-image.yml
+++ b/test/data/build_args/base-image.yml
@@ -1,5 +1,5 @@
 ---
 additional_build_steps:
   prepend:
-    - ARG ANSIBLE_RUNNER_IMAGE
-    - RUN echo $ANSIBLE_RUNNER_IMAGE > /base_image
+    - ARG EE_BASE_IMAGE
+    - RUN echo $EE_BASE_IMAGE > /base_image

--- a/test/data/pip/project/requirements.txt
+++ b/test/data/pip/project/requirements.txt
@@ -1,1 +1,2 @@
 awxkit>=13.0.0
+voluptuous

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -50,9 +50,12 @@ def run(args, *a, allow_error=False, **kw):
     except subprocess.CalledProcessError as err:
         if not allow_error:
             # Previously used pytest.fail here, but that missed some error details
-            print(
-                f"Running {err.cmd} resulted in a non-zero return code: {err.returncode} - stdout: {err.stdout}, stderr: {err.stderr}"
-            )
+            print(f"Running following command resulted in a non-zero return code: {err.returncode}")
+            print(err.cmd)
+            print('stdout:')
+            print(err.stdout)
+            print('stderr:')
+            print(err.stderr)
             raise
         err.rc = err.returncode  # lazyily make it look like a CompletedProcessProxy
         return err

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -190,6 +190,5 @@ class TestPytz:
             f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} -v 3'
         )
         assert 'Collecting pytz' not in r.stdout, r.stdout
-        assert 'requirements_combined.txt is already up-to-date' in r.stdout, r.stdout
         stdout_no_whitespace = r.stdout.replace('--->', '-->').replace('\n', ' ').replace('   ', ' ').replace('  ', ' ')
         assert 'RUN /output/install-from-bindep && rm -rf /output/wheels --> Using cache' in stdout_no_whitespace, r.stdout

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -157,10 +157,10 @@ def test_base_image_build_arg(cli, container_runtime, ee_tag, tmpdir, data_dir):
     ee_def = os.path.join(data_dir, 'build_args', 'base-image.yml')
     os.environ['FOO'] = 'secretsecret'
 
-    # Build with custom image tag, then use that as input to --build-arg ANSIBLE_RUNNER_IMAGE
+    # Build with custom image tag, then use that as input to --build-arg EE_BASE_IMAGE
     cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {container_runtime} -v3')
     cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom '
-        f'--container-runtime {container_runtime} --build-arg ANSIBLE_RUNNER_IMAGE={ee_tag}-custom -v3')
+        f'--container-runtime {container_runtime} --build-arg EE_BASE_IMAGE={ee_tag}-custom -v3')
     result = cli(f"{container_runtime} run {ee_tag}-custom cat /base_image")
     assert f"{ee_tag}-custom" in result.stdout
 

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -110,6 +110,10 @@ def test_user_python_requirement(cli, container_runtime, ee_tag, tmpdir, data_di
         f'{container_runtime} run --rm {ee_tag} pip3 show awxkit'
     )
     assert 'The official command line interface for Ansible AWX' in result.stdout, result.stdout
+    result = cli(
+        f'{container_runtime} run --rm {ee_tag} pip3 show voluptuous', allow_error=True
+    )
+    assert result.rc != 0
 
 
 def test_prepended_steps(cli, container_runtime, ee_tag, tmpdir, data_dir):

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -42,3 +42,15 @@ def test_introspect_write_python(cli, data_dir, tmpdir):
             'pyvcloud>=18.0.10  # from collection test.reqfile',
             ''
         ])
+
+
+def test_introspect_write_python_and_sanitize(cli, data_dir, tmpdir):
+    dest_file = os.path.join(str(tmpdir), 'req.txt')
+    cli(f'ansible-builder introspect {data_dir} --write-pip={dest_file} --sanitize')
+    with open(dest_file, 'r') as f:
+        assert f.read() == '\n'.join([
+            'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
+            'pytz  # from collection test.reqfile',
+            'tacacs_plus  # from collection test.reqfile',
+            ''
+        ])

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -1,4 +1,5 @@
 import yaml
+import os
 
 
 def test_introspect_write(cli, data_dir):
@@ -17,3 +18,27 @@ def test_introspect_with_sanitize(cli, data_dir):
     assert 'python' in data
     assert 'system' in data
     assert '# from collection test.bindep' in r.stdout  # should have comments
+
+
+def test_introspect_write_bindep(cli, data_dir, tmpdir):
+    dest_file = os.path.join(str(tmpdir), 'req.txt')
+    cli(f'ansible-builder introspect {data_dir} --write-bindep={dest_file}')
+    with open(dest_file, 'r') as f:
+        assert f.read() == '\n'.join([
+            'subversion [platform:rpm]  # from collection test.bindep',
+            'subversion [platform:dpkg]  # from collection test.bindep',
+            ''
+        ])
+
+
+def test_introspect_write_python(cli, data_dir, tmpdir):
+    dest_file = os.path.join(str(tmpdir), 'req.txt')
+    cli(f'ansible-builder introspect {data_dir} --write-pip={dest_file}')
+    with open(dest_file, 'r') as f:
+        assert f.read() == '\n'.join([
+            'pyvcloud>=14  # from collection test.metadata',
+            'pytz  # from collection test.reqfile',
+            'tacacs_plus  # from collection test.reqfile',
+            'pyvcloud>=18.0.10  # from collection test.reqfile',
+            ''
+        ])

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,9 +11,9 @@ def test_custom_image(exec_env_definition_file, tmpdir):
     content = {'version': 1}
     path = str(exec_env_definition_file(content=content))
 
-    aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_RUNNER_IMAGE=my-custom-image', '-c', str(tmpdir)])
+    aee = prepare(['build', '-f', path, '--build-arg', 'EE_BASE_IMAGE=my-custom-image', '-c', str(tmpdir)])
 
-    assert aee.build_args == {'ANSIBLE_RUNNER_IMAGE': 'my-custom-image'}
+    assert aee.build_args == {'EE_BASE_IMAGE': 'my-custom-image'}
 
 
 def test_custom_ansible_galaxy_cli_collection_opts(exec_env_definition_file, tmpdir):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -67,7 +67,7 @@ def test_base_image_via_build_args(exec_env_definition_file, tmpdir):
     assert 'ansible-runner' in content
 
     aee = AnsibleBuilder(
-        filename=path, build_args={'ANSIBLE_RUNNER_IMAGE': 'my-custom-image'},
+        filename=path, build_args={'EE_BASE_IMAGE': 'my-custom-image'},
         build_context=tmpdir.mkdir('bc2')
     )
     aee.build()
@@ -75,14 +75,14 @@ def test_base_image_via_build_args(exec_env_definition_file, tmpdir):
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'ANSIBLE_RUNNER_IMAGE' in content  # TODO: should we make user value default?
+    assert 'EE_BASE_IMAGE' in content  # TODO: should we make user value default?
 
 
 def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmpdir):
     content = {
         'version': 1,
         'build_arg_defaults': {
-            'ANSIBLE_RUNNER_IMAGE': 'my-other-custom-image'
+            'EE_BASE_IMAGE': 'my-other-custom-image'
         }
     }
     path = exec_env_definition_file(content=content)
@@ -92,7 +92,7 @@ def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmpd
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'ANSIBLE_RUNNER_IMAGE=my-other-custom-image' in content
+    assert 'EE_BASE_IMAGE=my-other-custom-image' in content
 
 
 def test_build_command(exec_env_definition_file):
@@ -187,8 +187,8 @@ class TestDefinitionErrors:
             "Keys ('middle',) are not allowed in 'additional_build_steps'."
         ),  # there are no "middle" build steps
         (
-            "{'version': 1, 'build_arg_defaults': {'ANSIBLE_RUNNER_IMAGE': ['foo']}}",
-            "Expected build_arg_defaults.ANSIBLE_RUNNER_IMAGE to be a string; Found a <class 'list'> instead."
+            "{'version': 1, 'build_arg_defaults': {'EE_BASE_IMAGE': ['foo']}}",
+            "Expected build_arg_defaults.EE_BASE_IMAGE to be a string; Found a <class 'list'> instead."
         ),  # image itself is wrong type
         (
             "{'version': 1, 'build_arg_defaults': {'BUILD_ARRRRRG': 'swashbuckler'}}",

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,5 @@ commands =
     mkdir -p artifacts
     python setup.py sdist
     podman build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
+    docker build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
     bash -c 'pytest test/integration -v -n `python -c "import multiprocessing; print(int(multiprocessing.cpu_count()/2))"` --junitxml=artifacts/results.xml {posargs}'

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,6 @@ whitelist_externals =
     mkdir
 commands =
     mkdir -p artifacts
+    python setup.py sdist
+    podman build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
     bash -c 'pytest test/integration -v -n `python -c "import multiprocessing; print(int(multiprocessing.cpu_count()/2))"` --junitxml=artifacts/results.xml {posargs}'


### PR DESCRIPTION
Slightly revised version of https://github.com/ansible/ansible-builder/pull/216

When you run `ansible-builder build`, you get a `Containerfile`. Before any of this refactor, that was a 3-phase process.

With #216, you get a 2-phase process where `ansible-galaxy collection install`, `ansible-builder introspect`, and `assemble` happen in the same stage.

This PR changes it so that we keep the `galaxy` and then `builder` stages. The `galaxy` stage uses the user-specified base image to do the galaxy install. The `builder` stage uses the new ansible-builder image to run both `ansible-builder introspect` and `assemble`.

### Pro arguments

 - By removing Ansible core from the `ansible/ansible-builder` image, we avoid situations where its version differs from the `ansible/ansible-runner` image. There are several known cases where the version of Ansible affects the behavior of the `ansible-galaxy` CLI.
 - This makes the new `ansible/ansible-builder` image smaller
 - If we, at some point, we combine ansible-builder and python-builder images, it would be a smaller change to do that

### Con arguments

 - This makes the `Containerfile` output for EEs more complex and harder to explain