### PR TITLE
Simplify git / python38-wheel installs

### DIFF
--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -14,7 +14,7 @@ base_collections_path = '/usr/share/ansible/collections'
 
 build_arg_defaults = dict(
     ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='',
-    EE_BASE_IMAGE='quay.io/ansible/ansible-runner:devel',
+    ANSIBLE_RUNNER_IMAGE='quay.io/ansible/ansible-runner:devel',
     ANSIBLE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest'
 )
 

--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -15,7 +15,7 @@ base_collections_path = '/usr/share/ansible/collections'
 build_arg_defaults = dict(
     ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='',
     EE_BASE_IMAGE='quay.io/ansible/ansible-runner:devel',
-    EE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest'
+    ANSIBLE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest'
 )
 
 user_content_subfolder = '_build'

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -273,8 +273,8 @@ class Containerfile:
         self.tag = tag
         # Build args all need to go at top of file to avoid errors
         self.steps = [
-            "ARG EE_BASE_IMAGE={}".format(
-                self.definition.build_arg_defaults['EE_BASE_IMAGE']
+            "ARG ANSIBLE_RUNNER_IMAGE={}".format(
+                self.definition.build_arg_defaults['ANSIBLE_RUNNER_IMAGE']
             ),
             "ARG ANSIBLE_BUILDER_IMAGE={}".format(
                 self.definition.build_arg_defaults['ANSIBLE_BUILDER_IMAGE']
@@ -377,7 +377,7 @@ class Containerfile:
     def prepare_galaxy_stage_steps(self):
         self.steps.extend([
             "",
-            "FROM $EE_BASE_IMAGE as galaxy",
+            "FROM $ANSIBLE_RUNNER_IMAGE as galaxy",
             "ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS={}".format(
                 self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS']
             ),
@@ -399,7 +399,7 @@ class Containerfile:
     def prepare_final_stage_steps(self):
         self.steps.extend([
             "",
-            "FROM $EE_BASE_IMAGE",
+            "FROM $ANSIBLE_RUNNER_IMAGE",
             "USER root"
             "",
         ])

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -276,8 +276,8 @@ class Containerfile:
             "ARG EE_BASE_IMAGE={}".format(
                 self.definition.build_arg_defaults['EE_BASE_IMAGE']
             ),
-            "ARG EE_BUILDER_IMAGE={}".format(
-                self.definition.build_arg_defaults['EE_BUILDER_IMAGE']
+            "ARG ANSIBLE_BUILDER_IMAGE={}".format(
+                self.definition.build_arg_defaults['ANSIBLE_BUILDER_IMAGE']
             ),
         ]
 
@@ -390,7 +390,7 @@ class Containerfile:
     def prepare_build_stage_steps(self):
         self.steps.extend([
             "",
-            "FROM $EE_BUILDER_IMAGE as builder"
+            "FROM $ANSIBLE_BUILDER_IMAGE as builder"
             "",
         ])
 

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -42,7 +42,7 @@ the '--pre' flag to enable the installation of pre-releases collections.
 The ``EE_BASE_IMAGE`` build arg specifies the parent image
 for the execution environment.
 
-The ``EE_BUILDER_IMAGE`` build arg specifies the image used for
+The ``ANSIBLE_BUILDER_IMAGE`` build arg specifies the image used for
 compiling type tasks.
 
 Values given inside of ``default_build_args`` will be hard-coded into the

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -9,7 +9,7 @@ An example execution environment definition schema is as follows:
     version: 1
 
     build_arg_defaults:
-      EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.10-devel'
+      ANSIBLE_RUNNER_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.10-devel'
 
     ansible_config: 'ansible.cfg'
 
@@ -39,7 +39,7 @@ Build args used by ``ansible-builder`` are the following:
 The ``ANSIBLE_GALAXY_CLI_COLLECTION_OPTS`` build arg allows the user to pass
 the '--pre' flag to enable the installation of pre-releases collections.
 
-The ``EE_BASE_IMAGE`` build arg specifies the parent image
+The ``ANSIBLE_RUNNER_IMAGE`` build arg specifies the parent image
 for the execution environment.
 
 The ``ANSIBLE_BUILDER_IMAGE`` build arg specifies the image used for

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -87,7 +87,7 @@ directory. To specify another location:
 
 To use Podman or Docker's build-time variables, specify them the same way you would with ``podman build`` or ``docker build``.
 
-By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``EE_BASE_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
+By default, the Containerfile / Dockerfile outputted by Ansible Builder contains a build argument ``ANSIBLE_RUNNER_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
 
 .. code::
 
@@ -97,7 +97,7 @@ To use a custom base image:
 
 .. code::
 
-   $ ansible-builder build --build-arg EE_BASE_IMAGE=registry.example.com/another-ee
+   $ ansible-builder build --build-arg ANSIBLE_RUNNER_IMAGE=registry.example.com/another-ee
 
 
 ``--container-runtime``

--- a/test/data/build_args/base-image.yml
+++ b/test/data/build_args/base-image.yml
@@ -1,5 +1,5 @@
 ---
 additional_build_steps:
   prepend:
-    - ARG EE_BASE_IMAGE
-    - RUN echo $EE_BASE_IMAGE > /base_image
+    - ARG ANSIBLE_RUNNER_IMAGE
+    - RUN echo $ANSIBLE_RUNNER_IMAGE > /base_image

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -170,10 +170,10 @@ def test_base_image_build_arg(cli, container_runtime, ee_tag, tmpdir, data_dir):
     ee_def = os.path.join(data_dir, 'build_args', 'base-image.yml')
     os.environ['FOO'] = 'secretsecret'
 
-    # Build with custom image tag, then use that as input to --build-arg EE_BASE_IMAGE
+    # Build with custom image tag, then use that as input to --build-arg ANSIBLE_RUNNER_IMAGE
     cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {container_runtime} -v3')
     cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom '
-        f'--container-runtime {container_runtime} --build-arg EE_BASE_IMAGE={ee_tag}-custom -v3')
+        f'--container-runtime {container_runtime} --build-arg ANSIBLE_RUNNER_IMAGE={ee_tag}-custom -v3')
     result = cli(f"{container_runtime} run {ee_tag}-custom cat /base_image")
     assert f"{ee_tag}-custom" in result.stdout
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,9 +11,9 @@ def test_custom_image(exec_env_definition_file, tmpdir):
     content = {'version': 1}
     path = str(exec_env_definition_file(content=content))
 
-    aee = prepare(['build', '-f', path, '--build-arg', 'EE_BASE_IMAGE=my-custom-image', '-c', str(tmpdir)])
+    aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_RUNNER_IMAGE=my-custom-image', '-c', str(tmpdir)])
 
-    assert aee.build_args == {'EE_BASE_IMAGE': 'my-custom-image'}
+    assert aee.build_args == {'ANSIBLE_RUNNER_IMAGE': 'my-custom-image'}
 
 
 def test_custom_ansible_galaxy_cli_collection_opts(exec_env_definition_file, tmpdir):

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -62,7 +62,7 @@ def test_base_image_via_build_args(exec_env_definition_file, tmpdir):
     assert 'ansible-runner' in content
 
     aee = AnsibleBuilder(
-        filename=path, build_args={'EE_BASE_IMAGE': 'my-custom-image'},
+        filename=path, build_args={'ANSIBLE_RUNNER_IMAGE': 'my-custom-image'},
         build_context=tmpdir.mkdir('bc2')
     )
     aee.build()
@@ -70,14 +70,14 @@ def test_base_image_via_build_args(exec_env_definition_file, tmpdir):
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'EE_BASE_IMAGE' in content  # TODO: should we make user value default?
+    assert 'ANSIBLE_RUNNER_IMAGE' in content  # TODO: should we make user value default?
 
 
 def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmpdir):
     content = {
         'version': 1,
         'build_arg_defaults': {
-            'EE_BASE_IMAGE': 'my-other-custom-image'
+            'ANSIBLE_RUNNER_IMAGE': 'my-other-custom-image'
         }
     }
     path = exec_env_definition_file(content=content)
@@ -87,7 +87,7 @@ def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmpd
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'EE_BASE_IMAGE=my-other-custom-image' in content
+    assert 'ANSIBLE_RUNNER_IMAGE=my-other-custom-image' in content
 
 
 def test_build_command(exec_env_definition_file):
@@ -182,8 +182,8 @@ class TestDefinitionErrors:
             "Keys ('middle',) are not allowed in 'additional_build_steps'."
         ),  # there are no "middle" build steps
         (
-            "{'version': 1, 'build_arg_defaults': {'EE_BASE_IMAGE': ['foo']}}",
-            "Expected build_arg_defaults.EE_BASE_IMAGE to be a string; Found a <class 'list'> instead."
+            "{'version': 1, 'build_arg_defaults': {'ANSIBLE_RUNNER_IMAGE': ['foo']}}",
+            "Expected build_arg_defaults.ANSIBLE_RUNNER_IMAGE to be a string; Found a <class 'list'> instead."
         ),  # image itself is wrong type
         (
             "{'version': 1, 'build_arg_defaults': {'BUILD_ARRRRRG': 'swashbuckler'}}",


### PR DESCRIPTION
We don't need to modify our containerfile, we can add these dependencies
into bindep.txt to be installed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>