### PR TITLE
Try to keep less layer churn in the /output folder

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,11 +12,9 @@ FROM $PYTHON_BASE_IMAGE
 # =============================================================================
 
 COPY --from=builder /output/ /output
-RUN /output/install-from-bindep && rm -rf /output
+# building EEs require the install-from-bindep script, but not the rest of the /output folder
+RUN /output/install-from-bindep && find /output/* -not -name install-from-bindep -exec rm -rf {} +
 
 # move the assemble scripts themselves into this container
 COPY --from=builder /usr/local/bin/assemble /usr/local/bin/assemble
 COPY --from=builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages
-
-# building EEs require the install-from-bindep script, but not the rest of the /output folder
-COPY --from=builder /output/install-from-bindep /output/install-from-bindep


### PR DESCRIPTION
I have been encountering a lot of spooky action with local testing.

Basically, the `/tmp/src/requirements.txt` provably has the user content, but then after the assemble script runs, `/output/requirements.txt` contains the requirements for _ansible-builder_ itself, including requirements-parser.

This might not fix it, but it does avoid rewriting some files between multiple layers.