### PR TITLE
Add another python test requirement to skip

### DIFF
--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -9,7 +9,7 @@ EXCLUDE_REQUIREMENTS = frozenset((
     'ansible', 'ansible-base', 'python', 'ansible-core',
     # general python test requirements
     'tox', 'pycodestyle', 'yamllint', 'pylint',
-    'flake8', 'pytest', 'pytest-xdist', 'coverage', 'mock',
+    'flake8', 'pytest', 'pytest-xdist', 'coverage', 'mock', 'testinfra',
     # test requirements highly specific to Ansible testing
     'ansible-lint', 'molecule', 'galaxy-importer', 'voluptuous',
     # already present in image for py3 environments


### PR DESCRIPTION
After looking at https://github.com/RedHatInsights/ansible-collections-insights/pull/20, I _think_ I need to do this.

We can do it better later, filed https://github.com/ansible/ansible-builder/issues/228 for this.