### PR TITLE
Add log for excluded requirements

### DIFF
--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -44,6 +44,7 @@ def sanitize_requirements(collection_py_reqs):
     sanitized = []
     for req in consolidated:
         if req.name and req.name.lower() in EXCLUDE_REQUIREMENTS:
+            logger.debug(f'# Excluding requirement {req.name} from {req.collections}')
             continue
         if req.name is None and req.vcs:
             # A source control requirement like git+, return as-is


### PR DESCRIPTION
Connect https://github.com/ansible/ansible-builder/issues/187

applying the diff

```diff
diff --git a/test/data/ansible_collections/test/reqfile/extra_req.txt b/test/data/ansible_collections/test/reqfile/extra_req.txt
index 81a47c4..2a83201 100644
--- a/test/data/ansible_collections/test/reqfile/extra_req.txt
+++ b/test/data/ansible_collections/test/reqfile/extra_req.txt
@@ -1,2 +1,3 @@
 tacacs_plus
 pyvcloud>=18.0.10  # duplicate with test.metadata collection
+pytest
```

I can demo:

![Screenshot from 2021-05-27 14-18-02](https://user-images.githubusercontent.com/1385596/119876900-61faf100-bef6-11eb-9803-c12bbd5b7dca.png)

Right now, we don't have any means of applying `-vvv` on the introspect command in the Containerfile, but this idea still makes sense to me. I put `#` on so it will still be YAML.