### PR TITLE
Register marker to get rid of pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    run_command: tests that use the run_command utility which runs a subprocess, had some historical issues


### PR DESCRIPTION
I saw the warnings in the test output, so I figured I would get rid of them

```
test/test_utils.py:64
  /home/alancoding/repos/ansible-builder/test/test_utils.py:64: PytestUnknownMarkWarning: Unknown pytest.mark.run_command - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.run_command

```

resolves those