### PR TITLE
Sanitize bindep content that we get

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -11,7 +11,7 @@ from .colors import MessageColors
 from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from .introspect import process, simple_combine, base_collections_path
-from .requirements import sanitize_requirements
+from .requirements import sanitize_python_requirements
 from .utils import configure_logger, write_file
 
 
@@ -41,7 +41,7 @@ def run():
         if args.sanitize:
             logger.info('# Sanitized dependencies for {0}'.format(args.folder))
             data_for_write = data
-            data['python'] = sanitize_requirements(data['python'])
+            data['python'] = sanitize_python_requirements(data['python'])
             data['system'] = simple_combine(data['system'])
         else:
             logger.info('# Dependency data for {0}'.format(args.folder))

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -11,7 +11,7 @@ from .colors import MessageColors
 from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from .introspect import process, simple_combine, base_collections_path
-from .requirements import sanitize_python_requirements
+from .requirements import sanitize_python_requirements, sanitize_system_requirements
 from .utils import configure_logger, write_file
 
 
@@ -42,7 +42,7 @@ def run():
             logger.info('# Sanitized dependencies for {0}'.format(args.folder))
             data_for_write = data
             data['python'] = sanitize_python_requirements(data['python'])
-            data['system'] = simple_combine(data['system'])
+            data['system'] = sanitize_system_requirements(data['system'])
         else:
             logger.info('# Dependency data for {0}'.format(args.folder))
             data_for_write = data.copy()

--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -1,5 +1,7 @@
 import logging
 
+from .exceptions import DefinitionError
+
 # python requirements-parser
 import requirements
 
@@ -116,10 +118,11 @@ def sanitize_system_requirements(collection_sys_reqs):
     for collection, lines in collection_sys_reqs.items():
         try:
             parsed_data = parse_bindep_lines(lines)
-        except Exception as e:
-            raise RuntimeError(
-                'Failed to parse system requirement from {}, lines: \n{}\nerror: \n{}'.format(
-                    collection, lines, str(e)
+        except Exception:
+            # The parent exception is printed to terminal due to how exception handling works
+            raise DefinitionError(
+                'Failed to parse system requirement from `{}`\nbindep lines that caused error: \n{}'.format(
+                    collection, '\n'.join(lines)
                 )
             )
         for entry in parsed_data:

--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -43,10 +43,11 @@ def sanitize_python_requirements(collection_py_reqs):
                 consolidated.append(req)
                 seen_pkgs.add(req.name)
         except Exception as e:
-            raise RuntimeError(
+            logger.warn(
                 'Failed to parse system requirement from {}, lines: \n{}\nerror: \n{}'.format(
                     collection, lines, str(e)
-                ))
+                )
+            )
 
     # removal of unwanted packages
     sanitized = []
@@ -70,7 +71,7 @@ def sanitize_python_requirements(collection_py_reqs):
 
 EXCLUDE_SYSTEM_REQUIREMENTS = frozenset((
     # obviously already satisfied or unwanted
-    'ansible', 'ansible-test',
+    'python', 'ansible', 'ansible-test',
 ))
 
 
@@ -82,23 +83,29 @@ def parse_bindep_lines(lines):
     return depends._rules
 
 
-def render_bindep_data(entry, collections):
+def render_bindep_data(entry):
     lines = []
     for entry in entry:
         name = entry[0]
+        this_line = name
 
         condition_strings = []
         for condition in entry[1]:
             negate_str = '' if condition[0] else '!'
             condition_strings.append(f'{negate_str}{condition[1]}')
         conditions = ' '.join(condition_strings)
+        if conditions:
+            this_line += f' [{conditions}]'
 
         version_strings = []
         for version_c in entry[2]:
             version_strings.append(''.join(version_c))
         versions = ','.join(version_strings)
+        if versions:
+            this_line += f' {versions}'
 
-        lines.append(f'{name} [{conditions}] {versions}'.strip())
+        lines.append(this_line)
+
     return '\n'.join(lines)
 
 
@@ -108,26 +115,32 @@ def sanitize_system_requirements(collection_sys_reqs):
     seen_entries = set()
     for collection, lines in collection_sys_reqs.items():
         try:
-            for entry in parse_bindep_lines(lines):
-                if not entry:
-                    continue
-
-                if entry in seen_entries:
-                    for prior_entry in consolidated:
-                        if entry == prior_entry:
-                            prior_entry[3].append(collection)
-                            break
-                    continue
-
-                entry_w_collection = entry + ([collection],)
-
-                consolidated.append(entry_w_collection)
-                seen_entries.add(entry)
+            parsed_data = parse_bindep_lines(lines)
         except Exception as e:
             raise RuntimeError(
                 'Failed to parse system requirement from {}, lines: \n{}\nerror: \n{}'.format(
                     collection, lines, str(e)
-                ))
+                )
+            )
+        for entry in parsed_data:
+            if not entry:
+                continue
+
+            if repr(entry[:3]) in seen_entries:  # TODO maybe find a better way of this...
+                for prior_entry in consolidated:
+                    if repr(entry[:3]) == repr(prior_entry[:3]):
+                        prior_entry[3].append(collection)
+                        break
+                else:
+                    print(repr(entry))
+                    print(seen_entries)
+                    raise Exception
+                continue
+
+            entry_w_collection = entry + ([collection],)
+
+            consolidated.append(entry_w_collection)
+            seen_entries.add(repr(entry[:3]))
 
     # removal of unwanted packages
     sanitized = []
@@ -136,7 +149,7 @@ def sanitize_system_requirements(collection_sys_reqs):
         if name and name.lower() in EXCLUDE_SYSTEM_REQUIREMENTS:
             continue
 
-        new_line = render_bindep_data(entry)
+        new_line = render_bindep_data([entry])
 
         sanitized.append(new_line + '  # from collection {}'.format(','.join(entry[3])))
 

--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -114,7 +114,6 @@ def render_bindep_data(entry):
 def sanitize_system_requirements(collection_sys_reqs):
     # de-duplication
     consolidated = []
-    seen_entries = set()
     for collection, lines in collection_sys_reqs.items():
         try:
             parsed_data = parse_bindep_lines(lines)
@@ -129,21 +128,14 @@ def sanitize_system_requirements(collection_sys_reqs):
             if not entry:
                 continue
 
-            if repr(entry[:3]) in seen_entries:  # TODO maybe find a better way of this...
-                for prior_entry in consolidated:
-                    if repr(entry[:3]) == repr(prior_entry[:3]):
-                        prior_entry[3].append(collection)
-                        break
-                else:
-                    print(repr(entry))
-                    print(seen_entries)
-                    raise Exception
-                continue
-
-            entry_w_collection = entry + ([collection],)
-
-            consolidated.append(entry_w_collection)
-            seen_entries.add(repr(entry[:3]))
+            for prior_entry_w_collection in consolidated:
+                prior_entry = prior_entry_w_collection[:-1]
+                if entry == prior_entry:
+                    prior_entry_w_collection[-1].append(collection)
+                    break
+            else:
+                entry_w_collection = entry + ([collection],)
+                consolidated.append(entry_w_collection)
 
     # removal of unwanted packages
     sanitized = []

--- a/test/data/build_fail/bindep-fail1.yml
+++ b/test/data/build_fail/bindep-fail1.yml
@@ -1,0 +1,4 @@
+---
+version: 1
+dependencies:
+  system: bindep1.txt

--- a/test/data/build_fail/bindep1.txt
+++ b/test/data/build_fail/bindep1.txt
@@ -1,0 +1,1 @@
+at [platform:rpm

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -18,6 +18,17 @@ def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmpdir, data_dir):
     assert 'thisisnotacommand: command not found' in (r.stdout + r.stderr), (r.stdout + r.stderr)
 
 
+def test_build_bad_bindep_file(cli, container_runtime, ee_tag, tmpdir, data_dir):
+    bc = str(tmpdir)
+    ee_def = os.path.join(data_dir, 'build_fail', 'bindep-fail1.yml')
+    r = cli(
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}',
+        allow_error=True
+    )
+    assert r.rc != 0
+    assert 'Error processing combined bindep file at' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+
+
 def test_blank_execution_environment(cli, container_runtime, ee_tag, tmpdir, data_dir):
     """Just makes sure that the buld process does not require any particular input"""
     bc = str(tmpdir)

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -18,17 +18,6 @@ def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmpdir, data_dir):
     assert 'thisisnotacommand: command not found' in (r.stdout + r.stderr), (r.stdout + r.stderr)
 
 
-def test_build_bad_bindep_file(cli, container_runtime, ee_tag, tmpdir, data_dir):
-    bc = str(tmpdir)
-    ee_def = os.path.join(data_dir, 'build_fail', 'bindep-fail1.yml')
-    r = cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}',
-        allow_error=True
-    )
-    assert r.rc != 0
-    assert 'Error processing combined bindep file at' in (r.stdout + r.stderr), (r.stdout + r.stderr)
-
-
 def test_blank_execution_environment(cli, container_runtime, ee_tag, tmpdir, data_dir):
     """Just makes sure that the buld process does not require any particular input"""
     bc = str(tmpdir)

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -54,3 +54,13 @@ def test_introspect_write_python_and_sanitize(cli, data_dir, tmpdir):
             'tacacs_plus  # from collection test.reqfile',
             ''
         ])
+
+
+def test_introspect_bad_bindep_file(cli, data_dir):
+    r = cli(
+        f'ansible-builder introspect {data_dir} '
+        f'--user-bindep={data_dir}/build_fail/bindep1.txt --sanitize',
+        allow_error=True
+    )
+    assert 'Failed to parse system requirement from `user`' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+    assert 'at [platform:rpm' in (r.stdout + r.stderr), (r.stdout + r.stderr)

--- a/test/test_introspect.py
+++ b/test/test_introspect.py
@@ -1,13 +1,13 @@
 import os
 
 from ansible_builder.introspect import process, process_collection, simple_combine
-from ansible_builder.requirements import sanitize_requirements
+from ansible_builder.requirements import sanitize_python_requirements
 
 
 def test_multiple_collection_metadata(data_dir):
 
     files = process(data_dir)
-    files['python'] = sanitize_requirements(files['python'])
+    files['python'] = sanitize_python_requirements(files['python'])
     files['system'] = simple_combine(files['system'])
 
     assert files == {'python': [

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -1,15 +1,15 @@
-from ansible_builder.requirements import sanitize_requirements
+from ansible_builder.requirements import sanitize_python_requirements
 
 
 def test_combine_entries():
-    assert sanitize_requirements({
+    assert sanitize_python_requirements({
         'foo.bar': ['foo>1.0'],
         'bar.foo': ['foo>=2.0']
     }) == ['foo>1.0,>=2.0  # from collection foo.bar,bar.foo']
 
 
 def test_remove_unwanted_requirements():
-    assert sanitize_requirements({
+    assert sanitize_python_requirements({
         'foo.bar': [
             'foo',
             'ansible',
@@ -29,7 +29,7 @@ def test_remove_unwanted_requirements():
 
 def test_skip_bad_formats():
     """A single incorrectly formatted requirement should warn, but not block other reqs"""
-    assert sanitize_requirements({'foo.bar': [
+    assert sanitize_python_requirements({'foo.bar': [
         'foo',
         'bar'
     ], 'foo.bad': ['zizzer zazzer zuzz']  # not okay

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -62,6 +62,7 @@ def test_sanitize_system_requirements():
     input = {
         'test.bindep': [
             '# this is a comment',
+            '',
             'subversion [platform:rpm]',
             'subversion [platform:dpkg]'
         ],

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -1,4 +1,11 @@
-from ansible_builder.requirements import sanitize_python_requirements
+import pytest
+
+from ansible_builder.requirements import (
+    sanitize_python_requirements,
+    sanitize_system_requirements,
+    parse_bindep_lines,
+    render_bindep_data
+)
 
 
 def test_combine_entries():
@@ -34,3 +41,49 @@ def test_skip_bad_formats():
         'bar'
     ], 'foo.bad': ['zizzer zazzer zuzz']  # not okay
     }) == ['foo  # from collection foo.bar', 'bar  # from collection foo.bar']
+
+
+@pytest.mark.parametrize('lines,expect', [
+    ([], []),
+    (['subversion'], [('subversion', [], [])]),
+    (['subversion', ''], [('subversion', [], [])]),
+    (['python [platform:brew] ==3.7.3,>2.0'], [
+        ('python', [(True, 'platform:brew')], [('==', '3.7.3'), ('>', '2.0')])
+    ]),
+
+])
+def test_parse_bindep_lines(lines, expect):
+    data = parse_bindep_lines(lines)
+    assert data == expect
+    assert render_bindep_data(data) == '\n'.join(lines).strip()
+
+
+def test_sanitize_system_requirements():
+    input = {
+        'test.bindep': [
+            '# this is a comment',
+            'subversion [platform:rpm]',
+            'subversion [platform:dpkg]'
+        ],
+        'repeat.collection': [
+            'subversion [platform:rpm]',
+        ],
+        'notgood.collection': [
+            'python [platform:rpm]'
+        ]
+    }
+    sanitized = sanitize_system_requirements(input)
+    assert sanitized == [
+        'subversion [platform:rpm]  # from collection test.bindep,repeat.collection',
+        'subversion [platform:dpkg]  # from collection test.bindep'
+    ]
+
+
+def test_incorrect_bindep():
+    input = {
+        'test.bindep': [
+            'at [platform:rpm'  # unbalanced brackets
+        ]
+    }
+    with pytest.raises(Exception):
+        sanitize_system_requirements(input)


### PR DESCRIPTION
Connect https://github.com/ansible/ansible-builder/issues/201

Connect https://github.com/ansible/ansible-builder/issues/90

This should resolve both of those when complete. Right now it still needs a little more testing via an integration test. The failure cases won't come up until some time into the build process.

This also has more risk than most other things for collections concerned with execution environments. So I would like to see about gathering a list of relevant collections and then running the introspect script to assure I'm getting sane content.