### PR TITLE
Add Back 'create' Command as an Option

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -22,7 +22,19 @@ def run():
     args = parse_args()
     configure_logger(args.verbosity)
 
-    if args.action in ['build']:
+    if args.action in ['create']:
+        logger.debug(f'Ansible Builder is creating a Containerfile for your execution environment image, "{args.tag}".')
+        ab = AnsibleBuilder(**vars(args))
+        action = getattr(ab, ab.action)
+        try:
+            if action():
+                print("Complete! Build context is at: {}".format(ab.build_context))
+                sys.exit(0)
+        except DefinitionError as e:
+            logger.error(e.args[0])
+            sys.exit(1)
+
+    elif args.action in ['build']:
         logger.debug(f'Ansible Builder is building your execution environment image, "{args.tag}".')
         ab = AnsibleBuilder(**vars(args))
         action = getattr(ab, ab.action)
@@ -36,6 +48,7 @@ def run():
         except DefinitionError as e:
             logger.error(e.args[0])
             sys.exit(1)
+
     elif args.action == 'introspect':
         data = process(args.folder, user_pip=args.user_pip, user_bindep=args.user_bindep)
         if args.sanitize:
@@ -82,6 +95,15 @@ def parse_args(args=sys.argv[1:]):
     subparsers = parser.add_subparsers(help='The command to invoke.', dest='action')
     subparsers.required = True # This can be a kwarg in python 3.7+
 
+    create_command_parser = subparsers.add_parser(
+        'create',
+        help='Creates a build context, which can be used by podman to build an image.',
+        description=(
+            'Creates a build context (including a Containerfile) from an execution environment spec. '
+            'This build context is populated with dependencies including requirements files.'
+        )
+    )
+
     build_command_parser = subparsers.add_parser(
         'build',
         help='Builds a container image.',
@@ -98,7 +120,7 @@ def parse_args(args=sys.argv[1:]):
                                       default=constants.default_tag,
                                       help='The name for the container image being built (default: %(default)s)')
 
-    for p in [build_command_parser]:
+    for p in [create_command_parser, build_command_parser]:
 
         p.add_argument('-f', '--file',
                        default=constants.default_file,

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -23,10 +23,6 @@ def run():
     configure_logger(args.verbosity)
 
     if args.action in ['create', 'build']:
-        if args.action == 'build':
-            logger.debug(f'Ansible Builder is building your execution environment image, "{args.tag}".')
-        else:
-            logger.debug('Ansible Builder is generating your execution environment build context.')
         ab = AnsibleBuilder(**vars(args))
         action = getattr(ab, ab.action)
         try:
@@ -111,6 +107,19 @@ def parse_args(args=sys.argv[1:]):
                                       default=constants.default_tag,
                                       help='The name for the container image being built (default: %(default)s)')
 
+    build_command_parser.add_argument('--container-runtime',
+                                      choices=list(constants.runtime_files.keys()),
+                                      default=constants.default_container_runtime,
+                                      help='Specifies which container runtime to use (default: %(default)s)')
+
+    build_command_parser.add_argument('--build-arg',
+                                      action=BuildArgAction,
+                                      default={},
+                                      dest='build_args',
+                                      help='Build-time variables to pass to any podman or docker calls. '
+                                           'Internally ansible-builder makes use of {0}.'.format(
+                                           ', '.join(constants.build_arg_defaults.keys())))
+
     for p in [create_command_parser, build_command_parser]:
 
         p.add_argument('-f', '--file',
@@ -122,20 +131,6 @@ def parse_args(args=sys.argv[1:]):
                        default=constants.default_build_context,
                        dest='build_context',
                        help='The directory to use for the build context (default: %(default)s)')
-
-        p.add_argument('--container-runtime',
-                       choices=list(constants.runtime_files.keys()),
-                       default=constants.default_container_runtime,
-                       help='Specifies which container runtime to use (default: %(default)s)')
-
-        p.add_argument('--build-arg',
-                       action=BuildArgAction,
-                       default={},
-                       dest='build_args',
-                       help='Build-time variables to pass to any podman or docker calls. '
-                            'Internally ansible-builder makes use of {0}.'.format(
-                                ', '.join(constants.build_arg_defaults.keys()))
-                       )
 
         p.add_argument('--output-filename',
                        choices=list(constants.runtime_files.values()),

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -22,20 +22,11 @@ def run():
     args = parse_args()
     configure_logger(args.verbosity)
 
-    if args.action in ['create']:
-        logger.debug(f'Ansible Builder is creating a Containerfile for your execution environment image, "{args.tag}".')
-        ab = AnsibleBuilder(**vars(args))
-        action = getattr(ab, ab.action)
-        try:
-            if action():
-                print("Complete! Build context is at: {}".format(ab.build_context))
-                sys.exit(0)
-        except DefinitionError as e:
-            logger.error(e.args[0])
-            sys.exit(1)
-
-    elif args.action in ['build']:
-        logger.debug(f'Ansible Builder is building your execution environment image, "{args.tag}".')
+    if args.action in ['create', 'build']:
+        if args.action == 'build':
+            logger.debug(f'Ansible Builder is building your execution environment image, "{args.tag}".')
+        else:
+            logger.debug('Ansible Builder is generating your execution environment build context.')
         ab = AnsibleBuilder(**vars(args))
         action = getattr(ab, ab.action)
         try:

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -64,6 +64,7 @@ class AnsibleBuilder:
         return self.definition.ansible_config
 
     def create(self):
+        logger.debug('Ansible Builder is generating your execution environment build context.')
         return self.write_containerfile()
 
     def write_containerfile(self):
@@ -111,6 +112,7 @@ class AnsibleBuilder:
         return command
 
     def build(self):
+        logger.debug(f'Ansible Builder is building your execution environment image, "{self.tag}".')
         self.write_containerfile()
         run_command(self.build_command)
         return True

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -63,27 +63,10 @@ class AnsibleBuilder:
     def ansible_config(self):
         return self.definition.ansible_config
 
-    @property
-    def build_command(self):
-        command = [
-            self.container_runtime, "build",
-            "-f", self.containerfile.path,
-            "-t", self.tag,
-        ]
+    def create(self):
+        return self.write_containerfile()
 
-        for key, value in self.build_args.items():
-            if value:
-                build_arg = f"--build-arg={key}={value}"
-            else:
-                build_arg = f"--build-arg={key}"
-
-            command.append(build_arg)
-
-        command.append(self.build_context)
-
-        return command
-
-    def build(self):
+    def write_containerfile(self):
         # File preparation
         self.containerfile.create_folder_copy_files()
         self.containerfile.prepare_ansible_config_file()
@@ -105,7 +88,30 @@ class AnsibleBuilder:
         self.containerfile.prepare_system_runtime_deps_steps()
         self.containerfile.prepare_appended_steps()
         logger.debug('Rewriting Containerfile to capture collection requirements')
-        self.containerfile.write()
+        return self.containerfile.write()
+
+    @property
+    def build_command(self):
+        command = [
+            self.container_runtime, "build",
+            "-f", self.containerfile.path,
+            "-t", self.tag,
+        ]
+
+        for key, value in self.build_args.items():
+            if value:
+                build_arg = f"--build-arg={key}={value}"
+            else:
+                build_arg = f"--build-arg={key}"
+
+            command.append(build_arg)
+
+        command.append(self.build_context)
+
+        return command
+
+    def build(self):
+        self.write_containerfile()
         run_command(self.build_command)
         return True
 

--- a/test/integration/test_help.py
+++ b/test/integration/test_help.py
@@ -4,13 +4,13 @@ import re
 def test_help(cli):
     result = cli('ansible-builder --help', check=False)
     help_text = result.stdout
-    assert 'usage: ansible-builder [-h] [--version] {build,introspect}' in help_text
+    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect}' in help_text
 
 
 def test_no_args(cli):
     result = cli('ansible-builder', check=False)
     stderr = result.stderr
-    assert 'usage: ansible-builder [-h] [--version] {build,introspect}' in stderr
+    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect}' in stderr
     assert 'ansible-builder: error: the following arguments are required: action' in stderr
 
 


### PR DESCRIPTION
Addressing issue https://github.com/ansible/ansible-builder/issues/212

Instead of requiring users to run a full build, this change will enable the creation of just a `Containerfile`.
