### PR TITLE
Fix yaml Syntax Reference in Docs

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -93,4 +93,4 @@ section, either for before the main build steps (``prepend``) or after
 (``append``). The syntax needs to be one of the following:
 
 - a multi-line string (example shown in the ``prepend`` section above)
-- a dictionary (as shown via ``append``)
+- a list (as shown via ``append``)


### PR DESCRIPTION
The documentation says the following is a dictionary but it's actually a list:

![Screenshot from 2021-06-02 14-15-07](https://user-images.githubusercontent.com/28930622/120531748-f9f05300-c3ac-11eb-8222-31a57519c33e.png)
