### PR TITLE
Validate dependencies section

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -158,6 +158,15 @@ class UserDefinition(BaseDefinition):
         if not isinstance(self.raw, dict):
             raise DefinitionError("Definition must be a dictionary, not {0}".format(type(self.raw).__name__))
 
+        if not isinstance(self.raw.get('dependencies'), dict):
+            raise DefinitionError(textwrap.dedent(
+                f"""
+                Error: Unknown type {type(self.raw.get('dependencies'))} found for dependencies, must be a dict.\n
+                Allowed options are:
+                {CONTEXT_FILES.keys()}
+                """)
+            )
+
         # Populate build arg defaults, which are customizable in definition
         self.build_arg_defaults = {}
         user_build_arg_defaults = self.raw.get('build_arg_defaults', {})

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -163,7 +163,7 @@ class UserDefinition(BaseDefinition):
                 f"""
                 Error: Unknown type {type(self.raw.get('dependencies'))} found for dependencies, must be a dict.\n
                 Allowed options are:
-                {CONTEXT_FILES.keys()}
+                {list(CONTEXT_FILES.keys())}
                 """)
             )
 
@@ -207,6 +207,17 @@ class UserDefinition(BaseDefinition):
                 Error: Unknown yaml key(s), {invalid_keys}, found in the definition file.\n
                 Allowed options are:
                 {ALLOWED_KEYS}
+                """)
+            )
+        
+        dependencies_keys = set(self.raw.get('dependencies'))
+        invalid_dependencies_keys = dependencies_keys - set(CONTEXT_FILES.keys())
+        if invalid_dependencies_keys:
+            raise DefinitionError(textwrap.dedent(
+                f"""
+                Error: Unknown yaml key(s), {invalid_dependencies_keys}, found in dependencies.\n
+                Allowed options are:
+                {list(CONTEXT_FILES.keys())}
                 """)
             )
 


### PR DESCRIPTION
These changes fix #241.
A validation is added to check if the dependencies key has a dict as value.
A validation is added to check the provided keys in the dependencies section are keys from the CONTEXT_FILES variable.