### PR TITLE
Split build and create integration tests

### DIFF
--- a/test/data/definition_files/no_galaxy.yml
+++ b/test/data/definition_files/no_galaxy.yml
@@ -1,0 +1,4 @@
+---
+version: 1
+dependencies:
+  galaxy: doesnotexist.yml

--- a/test/data/definition_files/no_python.yml
+++ b/test/data/definition_files/no_python.yml
@@ -1,0 +1,4 @@
+---
+version: 1
+dependencies:
+  python: doesnotexist.txt

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -2,16 +2,6 @@ import pytest
 import os
 
 
-def test_definition_syntax_error(cli, data_dir):
-    ee_def = os.path.join(data_dir, 'definition_files', 'invalid.yml')
-    r = cli(
-        f'ansible-builder build -f {ee_def} --container-runtime podman',
-        allow_error=True
-    )
-    assert r.rc != 0
-    assert 'An error occured while parsing the definition file' in (r.stdout + r.stderr), (r.stdout + r.stderr)
-
-
 def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmpdir, data_dir):
     """Test that when a build fails, the ansible-builder exits with non-zero exit code.
 
@@ -26,45 +16,6 @@ def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmpdir, data_dir):
     assert r.rc != 0, (r.stdout + r.stderr)
     assert 'RUN thisisnotacommand' in (r.stdout + r.stderr), (r.stdout + r.stderr)
     assert 'thisisnotacommand: command not found' in (r.stdout + r.stderr), (r.stdout + r.stderr)
-
-
-def test_missing_python_requirements_file():
-    """If a user specifies a python requirements file, but we can't find it, fail sanely."""
-    pytest.skip("Not implemented")
-
-
-def test_missing_galaxy_requirements_file():
-    """If a user specifies a galaxy requirements file, but we can't find it, fail sanely."""
-    pytest.skip("Not implemented")
-
-
-def test_build_streams_output_with_verbosity_on(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
-    """Test that 'ansible-builder build' streams build output."""
-    tmpdir, eeyml = build_dir_and_ee_yml("")
-    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime} -v 3")
-    assert f'{container_runtime} build -f {tmpdir}' in result.stdout
-    assert f'Ansible Builder is building your execution environment image, "{ee_tag}".' in result.stdout
-    assert f'The build context can be found at: {tmpdir}' in result.stdout
-
-
-def test_build_streams_output_with_verbosity_off(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
-    """
-    Like the test_build_streams_output_with_verbosity_on test but making sure less output is shown with default verbosity level of 2.
-    """
-    tmpdir, eeyml = build_dir_and_ee_yml("")
-    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime}")
-    assert f'Ansible Builder is building your execution environment image, "{ee_tag}".' not in result.stdout
-    assert f'The build context can be found at: {tmpdir}' in result.stdout
-
-
-def test_build_streams_output_with_invalid_verbosity(cli, container_runtime, build_dir_and_ee_yml, ee_tag):
-    """
-    Like the test_build_streams_output_with_verbosity_off test but making sure it errors out correctly with invalid verbosity level.
-    """
-    tmpdir, eeyml = build_dir_and_ee_yml("")
-    result = cli(f"ansible-builder build -c {tmpdir} -f {eeyml} -t {ee_tag} --container-runtime {container_runtime} -v 6", allow_error=True)
-    assert result.rc != 0
-    assert 'invalid choice: 6 (choose from 0, 1, 2, 3)' in (result.stdout + result.stderr)
 
 
 def test_blank_execution_environment(cli, container_runtime, ee_tag, tmpdir, data_dir):

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -1,0 +1,52 @@
+import os
+
+
+def test_definition_syntax_error(cli, data_dir):
+    ee_def = os.path.join(data_dir, 'definition_files', 'invalid.yml')
+    r = cli(f'ansible-builder create -f {ee_def}', allow_error=True)
+    assert r.rc != 0
+    assert 'An error occured while parsing the definition file' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+
+
+def test_missing_python_requirements_file(cli, data_dir):
+    """If a user specifies a python requirements file, but we can't find it, fail sanely."""
+    ee_def = os.path.join(data_dir, 'definition_files', 'no_python.yml')
+    r = cli(f'ansible-builder create -f {ee_def}', allow_error=True)
+    assert r.rc != 0
+    assert 'does not exist' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+
+
+def test_missing_galaxy_requirements_file(cli, data_dir):
+    """If a user specifies a galaxy requirements file, but we can't find it, fail sanely."""
+    ee_def = os.path.join(data_dir, 'definition_files', 'no_galaxy.yml')
+    r = cli(f'ansible-builder create -f {ee_def}', allow_error=True)
+    assert r.rc != 0
+    assert 'does not exist' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+
+
+def test_create_streams_output_with_verbosity_on(cli, build_dir_and_ee_yml):
+    """Test that 'ansible-builder build' streams build output."""
+    tmpdir, eeyml = build_dir_and_ee_yml("")
+    result = cli(f"ansible-builder create -c {tmpdir} -f {eeyml} -v 3")
+    assert 'Ansible Builder is generating your execution environment build context.' in result.stdout
+    assert f'The build context can be found at: {tmpdir}' in result.stdout
+
+
+def test_create_streams_output_with_verbosity_off(cli, build_dir_and_ee_yml):
+    """
+    Like the test_create_streams_output_with_verbosity_on test but making sure less output is shown with default verbosity level of 2.
+    """
+    tmpdir, eeyml = build_dir_and_ee_yml("")
+    result = cli(f"ansible-builder create -c {tmpdir} -f {eeyml}")
+    assert 'Ansible Builder is generating your execution environment build context.' not in result.stdout
+    assert f'The build context can be found at: {tmpdir}' in result.stdout
+
+
+def test_create_streams_output_with_invalid_verbosity(cli, build_dir_and_ee_yml):
+    """
+    Like the test_create_streams_output_with_verbosity_off test but making sure it errors out correctly with invalid verbosity level.
+    """
+    tmpdir, eeyml = build_dir_and_ee_yml("")
+    result = cli(f"ansible-builder create -c {tmpdir} -f {eeyml} -v 6", allow_error=True)
+    assert result.rc != 0
+    assert 'invalid choice: 6 (choose from 0, 1, 2, 3)' in (result.stdout + result.stderr)


### PR DESCRIPTION
Since we have this new create command, it makes sense to use that instead of build for all the cases that don't actually need a build to happen.

Running `py.test test/integration/test_create.py` finishes in 1.10 seconds, so these are the lightweight ones.

The test_build.py module now becomes basically a walk-through of real features relevant to the final EE image.