### PR TITLE
Move to bindep.txt for Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,24 +1,22 @@
 ARG PYTHON_BASE_IMAGE=quay.io/ansible/python-base:latest
 ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
 
-FROM $PYTHON_BUILDER_IMAGE as python_builder
+FROM $PYTHON_BUILDER_IMAGE as builder
 # =============================================================================
 ARG ZUUL_SIBLINGS
 
 # build this library (meaning ansible-builder)
 COPY . /tmp/src
 RUN assemble
-
-
 FROM $PYTHON_BASE_IMAGE
 # =============================================================================
 
-COPY --from=python_builder /output/ /output
+COPY --from=builder /output/ /output
 RUN /output/install-from-bindep && rm -rf /output
 
 # move the assemble scripts themselves into this container
-COPY --from=python_builder /usr/local/bin/assemble /usr/local/bin/assemble
-COPY --from=python_builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages
+COPY --from=builder /usr/local/bin/assemble /usr/local/bin/assemble
+COPY --from=builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages
 
 # building EEs require the install-from-bindep script, but not the rest of the /output folder
-COPY --from=python_builder /output/install-from-bindep /output/install-from-bindep
+COPY --from=builder /output/install-from-bindep /output/install-from-bindep

--- a/Containerfile
+++ b/Containerfile
@@ -16,13 +16,6 @@ FROM $PYTHON_BASE_IMAGE
 COPY --from=python_builder /output/ /output
 RUN /output/install-from-bindep && rm -rf /output
 
-RUN dnf update -y \
-  && dnf install -y python38-wheel git \
-  && dnf clean all \
-  && rm -rf /var/cache/{dnf,yum} \
-  && rm -rf /var/lib/dnf/history.* \
-  && rm -rf /var/log/*
-
 # move the assemble scripts themselves into this container
 COPY --from=python_builder /usr/local/bin/assemble /usr/local/bin/assemble
 COPY --from=python_builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,5 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+git
+python38-wheel [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
We can leverage the assemble script to deal with package dependencies.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>