### PR TITLE
Provide Same Verbosity Functionality for Create, Build, and Introspect

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -140,15 +140,6 @@ def parse_args(args=sys.argv[1:]):
                                 ' and '.join([' for '.join([v, k]) for k, v in constants.runtime_files.items()]))
                        )
 
-        p.add_argument('-v', '--verbosity',
-                       dest='verbosity',
-                       type=int,
-                       choices=[0, 1, 2, 3],
-                       default=constants.default_verbosity,
-                       help='Increase the output verbosity, for up to three levels of verbosity '
-                            '(invoked via "--verbosity" or "-v" followed by an integer ranging '
-                            'in value from 0 to 3) (default: %(default)s)')
-
     introspect_parser = subparsers.add_parser(
         'introspect',
         help='Introspects collections in folder.',
@@ -188,10 +179,16 @@ def parse_args(args=sys.argv[1:]):
         help='Write the combined bindep file to this location.'
     )
 
-    introspect_parser.add_argument('-v', '--verbosity', dest='verbosity', action='count', default=0,
-                                   help=('Increase the output verbosity, for up to three levels of verbosity '
-                                         '(invoked via "--verbosity" or "-v" followed by an integer ranging '
-                                         'in value from 0 to 3)'))
+    for n in [create_command_parser, build_command_parser, introspect_parser]:
+
+        n.add_argument('-v', '--verbosity',
+                       dest='verbosity',
+                       type=int,
+                       choices=[0, 1, 2, 3],
+                       default=constants.default_verbosity,
+                       help='Increase the output verbosity, for up to three levels of verbosity '
+                            '(invoked via "--verbosity" or "-v" followed by an integer ranging '
+                            'in value from 0 to 3) (default: %(default)s)')
 
 
     args = parser.parse_args(args)


### PR DESCRIPTION
Addressing issue https://github.com/ansible/ansible-builder/issues/218 

Before:

```
$ ansible-builder introspect -vvvvv
KeyError: '5'
```


With this PR:

```
$ ansible-builder introspect -vvvvv
usage: ansible-builder introspect [-h] [--sanitize] [--user-pip USER_PIP]
                                  [--user-bindep USER_BINDEP]
                                  [--write-pip WRITE_PIP]
                                  [--write-bindep WRITE_BINDEP] [-v {0,1,2,3}]
                                  [folder]
ansible-builder introspect: error: argument -v/--verbosity: invalid int value: 'vvvv'
```
```
$ ansible-builder introspect -v 3
# Dependency data for /usr/share/ansible/collections
---
python: {}
system: {}
```
