### PR TITLE
Add docs tox target and Zuul job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ artifacts/
 /AUTHORS
 /ChangeLog
 /dist/
+docs/build/

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,6 +3,9 @@
     check:
       jobs:
         # - ansible-builder-tox-integration
+        - ansible-tox-docs:
+            vars:
+                sphinx_build_dir: docs/build
         - ansible-builder-build-container-image
         - github-workflows:
             files:
@@ -10,6 +13,9 @@
     gate:
       jobs:
         # - ansible-builder-tox-integration
+        - ansible-tox-docs:
+            vars:
+                sphinx_build_dir: docs/build
         - ansible-builder-build-container-image
         - github-workflows:
             files:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 pbr
+sphinx
+six

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,7 +6,7 @@ your Execution Environment.
 
 
 ``ansible-builder build``
-------------------------
+-------------------------
 
 The ``ansible-builder build`` command takes an execution environment
 definition as an input. It outputs the build context necessary for
@@ -83,7 +83,7 @@ directory. To specify another location:
 
 
 ``--build-arg``
-*************
+***************
 
 To use Podman or Docker's build-time variables, specify them the same way you would with ``podman build`` or ``docker build``.
 
@@ -121,7 +121,7 @@ To customize the level of verbosity:
 
 
 ``ansible-builder create``
-------------------------
+--------------------------
 
 The ``ansible-builder create`` command works similarly to the ``build``
 command in that it takes an execution environment definition as an input

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,8 @@ commands =
     podman build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
     docker build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
     bash -c 'pytest test/integration -v -n `python -c "import multiprocessing; print(int(multiprocessing.cpu_count()/2))"` --junitxml=artifacts/results.xml {posargs}'
+
+[testenv:docs]
+deps = -r{toxinidir}/docs/requirements.txt
+commands = 
+    sphinx-build -E -W -d docs/build/doctrees -b html docs docs/build/html


### PR DESCRIPTION
This adds a documentation build tox target that will build HTML formatted docs locally. E.g.,

`tox -e docs`

All doc build warnings are treated as errors. Because of this, a few warnings are fixed in the current docs.

This also adds a Zuul check and gate job to test documentation building.