### PR TITLE
Fix delete_image in integration testing

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -80,7 +80,7 @@ def delete_image(container_runtime, image_name):
     # allow error in case that image was not created
     r = run(f'{container_runtime} rmi -f {image_name}', allow_error=True)
     if r.rc != 0:
-        if 'no such image' in r.stdout or 'no such image' in r.stderr:
+        if 'no such image' in r.stdout or 'no such image' in r.stderr or 'image not known' in r.stdout or 'image not known' in r.stderr:
             return
         else:
             raise Exception(f'Teardown failed (rc={r.rc}):\n{r.stdout}\n{r.stderr}')


### PR DESCRIPTION
Something has changed with integration tests recently to cause us to now get a different error message when attempting to delete an image that does not exist. The new error is:

```
Error: quay.io/example/builder-test_test_base_image_build_arg_podman__936f36b9-e: image not known
```

This fixes the `delete_image()` cleanup method to now look for `image not known` as well.