### PR TITLE
Add py38 job

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -10,6 +10,7 @@
         - github-workflows:
             files:
               - .github/workflows/.*
+        - ansible-tox-py38
     gate:
       jobs:
         # - ansible-builder-tox-integration
@@ -20,6 +21,7 @@
         - github-workflows:
             files:
               - .github/workflows/.*
+        - ansible-tox-py38
     post:
       jobs:
         - ansible-builder-upload-container-image:


### PR DESCRIPTION
In preparation for removing the py36 and py37 jobs from `ansible/project-config`, add a py38 job in-repo. This is necessary because the py37 job occasionally chooses an AWS Fedora34 image that does not have python 3.7 installed, and will fail.