### PR TITLE
Add a Patchback config

### DIFF
--- a/.github/patchback.yml
+++ b/.github/patchback.yml
@@ -1,0 +1,4 @@
+---
+backport_branch_prefix: patchback/backports/
+backport_label_prefix: backport-
+target_branch_prefix: release_


### PR DESCRIPTION
Similar to the `ansible-runner` change (https://github.com/ansible/ansible-runner/pull/778), let's make use of the patchback bot in `ansible-builder`.