### PR TITLE
Add CLI type subcommand

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -30,7 +30,9 @@ ALLOWED_KEYS = [
 
 
 class AnsibleBuilder:
-    def __init__(self, action=None,
+    def __init__(self,
+                 command_type=None,
+                 action=None,
                  filename=constants.default_file,
                  build_args=None,
                  build_context=constants.default_build_context,

--- a/docs/collection_metadata.rst
+++ b/docs/collection_metadata.rst
@@ -16,9 +16,13 @@ If any of these files are in the ``build_ignore`` of the collection, it
 will not work correctly.
 
 Collection maintainers can verify that ``ansible-builder`` recognizes
-the requirements they expect by using the introspect command. Example:
+the requirements they expect by using the ``introspect`` command. Example:
 
 ::
+
+    ansible-builder container introspect --sanitize ~/.ansible/collections/
+
+The short-hand form of the command is also supported::
 
     ansible-builder introspect --sanitize ~/.ansible/collections/
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,11 +5,11 @@ Once you have created a :ref:`definition<Definition:Execution Environment Defini
 your Execution Environment.
 
 
-``ansible-builder build``
--------------------------
+Container ``build`` command
+---------------------------
 
-The ``ansible-builder build`` command takes an execution environment
-definition as an input. It outputs the build context necessary for
+The ``ansible-builder container build`` command (or ``ansible-builder build``, for short)
+takes an execution environment definition as an input. It outputs the build context necessary for
 building an execution environment image, and it builds that image. The
 image can be re-built with the build context elsewhere, and give the
 same result. By default, it looks for a file named ``execution-environment.yml``
@@ -39,7 +39,7 @@ To build an Execution Environment using the files above, run:
 
 .. code::
 
-   $ ansible-builder build
+   $ ansible-builder container build
    ...
    STEP 7: COMMIT my-awx-ee
    --> 09c930f5f6a
@@ -57,7 +57,7 @@ To customize the tagged name applied to the built image:
 
 .. code::
 
-   $ ansible-builder build --tag=my-custom-ee
+   $ ansible-builder container build --tag=my-custom-ee
 
 
 ``--file``
@@ -68,7 +68,7 @@ To use a definition file named something other than
 
 .. code::
 
-   $ ansible-builder build --file=my-ee.yml
+   $ ansible-builder container build --file=my-ee.yml
 
 
 ``--context``
@@ -79,7 +79,7 @@ directory. To specify another location:
 
 .. code::
 
-   $ ansible-builder build --context=/path/to/dir
+   $ ansible-builder container build --context=/path/to/dir
 
 
 ``--build-arg``
@@ -91,13 +91,13 @@ By default, the Containerfile / Dockerfile outputted by Ansible Builder contains
 
 .. code::
 
-   $ ansible-builder build --build-arg FOO=bar
+   $ ansible-builder container build --build-arg FOO=bar
 
 To use a custom base image:
 
 .. code::
 
-   $ ansible-builder build --build-arg EE_BASE_IMAGE=registry.example.com/another-ee
+   $ ansible-builder container build --build-arg EE_BASE_IMAGE=registry.example.com/another-ee
 
 
 ``--container-runtime``
@@ -107,7 +107,7 @@ Podman is used by default to build images. To use Docker:
 
 .. code::
 
-   $ ansible-builder build --container-runtime=docker
+   $ ansible-builder container build --container-runtime=docker
 
 
 ``--verbosity``
@@ -117,14 +117,14 @@ To customize the level of verbosity:
 
 .. code::
 
-   $ ansible-builder build --verbosity 2
+   $ ansible-builder container build --verbosity 2
 
 
-``ansible-builder create``
---------------------------
+Container ``create`` command
+----------------------------
 
-The ``ansible-builder create`` command works similarly to the ``build``
-command in that it takes an execution environment definition as an input
+The ``ansible-builder container create`` command (or ``ansible-builder create``, for short)
+works similarly to the ``build`` command in that it takes an execution environment definition as an input
 and outputs the build context necessary for building an execution environment
 image. However, the ``create`` command *will not* build the execution environment
 image; this is useful for creating just the build context and a ``Containerfile``

--- a/test/integration/test_help.py
+++ b/test/integration/test_help.py
@@ -4,14 +4,14 @@ import re
 def test_help(cli):
     result = cli('ansible-builder --help', check=False)
     help_text = result.stdout
-    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect}' in help_text
+    assert 'usage: ansible-builder [-h] [--version] {container} ...' in help_text
 
 
 def test_no_args(cli):
     result = cli('ansible-builder', check=False)
     stderr = result.stderr
-    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect}' in stderr
-    assert 'ansible-builder: error: the following arguments are required: action' in stderr
+    assert 'usage: ansible-builder [-h] [--version] {container} ...' in stderr
+    assert 'ansible-builder: error: the following arguments are required: command_type' in stderr
 
 
 def test_version(cli):
@@ -19,3 +19,54 @@ def test_version(cli):
     version = result.stdout
     matches = re.findall(r'\d.\d.\d', version)
     assert matches
+
+
+def test_container_help(cli):
+    result = cli('ansible-builder container --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container [-h] CONTAINER_ACTION ...' in help_text
+    assert re.search(r'create\s+Creates a build context', help_text)
+    assert re.search(r'build\s+Builds a container image', help_text)
+    assert re.search(r'introspect\s+Introspects collections in folder', help_text)
+
+
+def test_container_build_help(cli):
+    result = cli('ansible-builder container build --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container build [-h] [-t TAG]' in help_text
+    assert re.search(r'Creates a build context', help_text)
+
+
+def test_backward_compat_build_help(cli):
+    result = cli('ansible-builder build --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container build [-h] [-t TAG]' in help_text
+    assert re.search(r'Creates a build context', help_text)
+
+
+def test_container_create_help(cli):
+    result = cli('ansible-builder container create --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container create [-h]' in help_text
+    assert re.search(r'Creates a build context', help_text)
+
+
+def test_backward_compat_create_help(cli):
+    result = cli('ansible-builder create --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container create [-h]' in help_text
+    assert re.search(r'Creates a build context', help_text)
+
+
+def test_container_introspect_help(cli):
+    result = cli('ansible-builder container introspect --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container introspect [-h] [--sanitize]' in help_text
+    assert re.search(r'Loops over collections in folder', help_text)
+
+
+def test_backward_compat_introspect_help(cli):
+    result = cli('ansible-builder introspect --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder container introspect [-h] [--sanitize]' in help_text
+    assert re.search(r'Loops over collections in folder', help_text)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -11,8 +11,12 @@ def test_custom_image(exec_env_definition_file, tmpdir):
     content = {'version': 1}
     path = str(exec_env_definition_file(content=content))
 
-    aee = prepare(['build', '-f', path, '--build-arg', 'EE_BASE_IMAGE=my-custom-image', '-c', str(tmpdir)])
+    # test with 'container' sub-command
+    aee = prepare(['container', 'build', '-f', path, '--build-arg', 'EE_BASE_IMAGE=my-custom-image', '-c', str(tmpdir)])
+    assert aee.build_args == {'EE_BASE_IMAGE': 'my-custom-image'}
 
+    # test without 'container' sub-command (defaulting to 'container')
+    aee = prepare(['build', '-f', path, '--build-arg', 'EE_BASE_IMAGE=my-custom-image', '-c', str(tmpdir)])
     assert aee.build_args == {'EE_BASE_IMAGE': 'my-custom-image'}
 
 
@@ -20,14 +24,23 @@ def test_custom_ansible_galaxy_cli_collection_opts(exec_env_definition_file, tmp
     content = {'version': 1}
     path = str(exec_env_definition_file(content=content))
 
-    aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre', '-c', str(tmpdir)])
+    # test with 'container' sub-command
+    aee = prepare(['container', 'build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre', '-c', str(tmpdir)])
+    assert aee.build_args == {'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': '--pre'}
 
+    # test without 'container' sub-command (defaulting to 'container')
+    aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre', '-c', str(tmpdir)])
     assert aee.build_args == {'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': '--pre'}
 
 
 def test_build_context(good_exec_env_definition_path, tmpdir):
     path = str(good_exec_env_definition_path)
     build_context = str(tmpdir)
-    aee = prepare(['build', '-f', path, '-c', build_context])
 
+    # test with 'container' sub-command
+    aee = prepare(['container', 'build', '-f', path, '-c', build_context])
+    assert aee.build_context == build_context
+
+    # test without 'container' sub-command (defaulting to 'container')
+    aee = prepare(['build', '-f', path, '-c', build_context])
     assert aee.build_context == build_context


### PR DESCRIPTION
Preparation for adding new type subcommands (e.g., `srpm`, `ostree`, etc).

The following example invocations (still being supported):

- `ansible-build build -h`
- `ansible-build create -h`
- `ansible-build introspect -h`

are equivalent to the new format:

- `ansible-build container build -h`
- `ansible-build container create -h`
- `ansible-build container introspect -h`
