### PR TITLE
Pre-pull some build images

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -26,6 +26,7 @@
     parent: ansible-build-container-image
     description: Build ansible-builder container image
     provides: ansible-builder-container-image
+    pre-run: .zuul.d/playbooks/ansible-builder-build-container-image/pre.yaml
     requires:
       - python-base-container-image
       - python-builder-container-image

--- a/.zuul.d/playbooks/ansible-builder-build-container-image/pre.yaml
+++ b/.zuul.d/playbooks/ansible-builder-build-container-image/pre.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  tasks:
+      - name: Pull container images
+        command: "{{ container_command }} pull {{ item }}"
+        delay: 30
+        retries: 3
+        register: result
+        until: result is success
+        loop:
+            - quay.io/ansible/python-builder:latest
+            - quay.io/ansible/python-base:latest


### PR DESCRIPTION
The `python-builder` and `python-base` images are used in the container building tests. If pulling these fail for some reason, the test will fail. A pre-run playbook is added to pull these images in advance, with retries built in to the process.