### PR TITLE
Do not use dash to separate keys in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = ansible-builder
 author = Ansible, Inc.
-author-email = info@ansible.com
+author_email = info@ansible.com
 summary = "A tool for building Ansible Execution Environments"
-home-page = https://ansible-builder.readthedocs.io
-description-file = README.md
+home_page = https://ansible-builder.readthedocs.io
+description_file = README.md
 
 [flake8]
 # W503 - Line break occurred before a binary operator


### PR DESCRIPTION
Use of dash-separate keys is deprecated by `setuptools.`.