### PR TITLE
Revert "[release_1.0] Switch project to squash-merge mode"

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    merge-mode: squash-merge
     check:
       jobs:
         - ansible-builder-build-container-image


### PR DESCRIPTION
Reverts ansible/ansible-builder#301

Setting this in `project-config` since it doesn't seem to work in-repo: https://github.com/ansible/project-config/pull/971