### PR TITLE
[release_1.0] Remove github-workflows job (#312)

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,15 +3,9 @@
     check:
       jobs:
         - ansible-builder-build-container-image
-        - github-workflows:
-            files:
-              - .github/workflows/.*
     gate:
       jobs:
         - ansible-builder-build-container-image
-        - github-workflows:
-            files:
-              - .github/workflows/.*
     post:
       jobs:
         - ansible-builder-upload-container-image:


### PR DESCRIPTION
Backport of #312 for Ansible Builder 1.0.