### PR TITLE
Run tests on all supported run times and fix `test_build_layer_reuse` test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     run_command: tests that use the run_command utility which runs a subprocess
+    test_all_runtimes: Generate a test for each supported container runtime
 testpaths = test
 addopts =
     -r a

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -106,8 +106,3 @@ class CompletedProcessProxy(object):
 @pytest.fixture
 def cli():
     return run
-
-
-@pytest.fixture(scope='class')
-def cli_class():
-    return run

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -72,13 +72,14 @@ def gen_image_name(request):
     ])
 
 
-def delete_image(container_runtime, image_name):
+@pytest.mark.test_all_runtimes
+def delete_image(runtime, image_name):
     if KEEP_IMAGES:
         return
     # delete given image, if the test happened to make one
     # allow error in case that image was not created
     regexp = re.compile(r'(no such image)|(image not known)|(image is in use by a container)', re.IGNORECASE)
-    r = run(f'{container_runtime} rmi -f {image_name}', allow_error=True)
+    r = run(f'{runtime} rmi -f {image_name}', allow_error=True)
     if r.rc != 0:
         if regexp.search(r.stdout) or regexp.search(r.stderr):
             return
@@ -86,18 +87,12 @@ def delete_image(container_runtime, image_name):
             raise Exception(f'Teardown failed (rc={r.rc}):\n{r.stdout}\n{r.stderr}')
 
 
-@pytest.fixture()
-def ee_tag(request, container_runtime):
+@pytest.fixture
+@pytest.mark.test_all_runtimes
+def ee_tag(request, runtime):
     image_name = gen_image_name(request)
     yield image_name
-    delete_image(container_runtime, image_name)
-
-
-@pytest.fixture(scope='class')
-def ee_tag_class(request, container_runtime):
-    image_name = gen_image_name(request)
-    yield image_name
-    delete_image(container_runtime, image_name)
+    delete_image(runtime, image_name)
 
 
 class CompletedProcessProxy(object):
@@ -108,7 +103,7 @@ class CompletedProcessProxy(object):
         return getattr(self.result, attr)
 
 
-@pytest.fixture()
+@pytest.fixture
 def cli():
     return run
 
@@ -116,11 +111,3 @@ def cli():
 @pytest.fixture(scope='class')
 def cli_class():
     return run
-
-
-@pytest.fixture(params=['docker', 'podman'], ids=['docker', 'podman'], scope='session')
-def container_runtime(request):
-    if run(f'{request.param} --version', check=False).returncode == 0:
-        return request.param
-    else:
-        pytest.skip(f'{request.param} runtime not available')

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -1,8 +1,8 @@
 import pytest
 import os
 
-
-def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_build_fail_exitcode(cli, runtime, ee_tag, tmp_path, data_dir):
     """Test that when a build fails, the ansible-builder exits with non-zero exit code.
 
     Example: https://github.com/ansible/ansible-builder/issues/51
@@ -10,7 +10,7 @@ def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmp_path, data_dir)
     bc = tmp_path
     ee_def = data_dir / 'build_fail' / 'execution-environment.yml'
     r = cli(
-        f"ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} -v3",
+        f"ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3",
         allow_error=True
     )
     assert r.rc != 0, (r.stdout + r.stderr)
@@ -18,76 +18,82 @@ def test_build_fail_exitcode(cli, container_runtime, ee_tag, tmp_path, data_dir)
     assert 'thisisnotacommand: command not found' in (r.stdout + r.stderr), (r.stdout + r.stderr)
 
 
-def test_blank_execution_environment(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_blank_execution_environment(cli, runtime, ee_tag, tmp_path, data_dir):
     """Just makes sure that the buld process does not require any particular input"""
     bc = tmp_path
     ee_def = data_dir / 'blank' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     )
-    result = cli(f'{container_runtime} run --rm {ee_tag} echo "This is a simple test"')
+    result = cli(f'{runtime} run --rm {ee_tag} echo "This is a simple test"')
     assert 'This is a simple test' in result.stdout, result.stdout
 
 
-def test_user_system_requirement(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_user_system_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'subversion' / 'execution-environment.yml'
-    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     cli(command)
     result = cli(
-        f'{container_runtime} run --rm {ee_tag} svn --help'
+        f'{runtime} run --rm {ee_tag} svn --help'
     )
     assert 'Subversion is a tool for version control' in result.stdout, result.stdout
 
 
-def test_collection_system_requirement(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_collection_system_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} -v3'
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3'
     )
     result = cli(
-        f'{container_runtime} run --rm {ee_tag} at -V'
+        f'{runtime} run --rm {ee_tag} at -V'
     )
     assert 'at version' in result.stderr, result.stderr
 
 
-def test_user_python_requirement(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_user_python_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'pip' / 'execution-environment.yml'
-    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     cli(command)
     result = cli(
-        f'{container_runtime} run --rm {ee_tag} pip3 show awxkit'
+        f'{runtime} run --rm {ee_tag} pip3 show awxkit'
     )
     assert 'The official command line interface for Ansible AWX' in result.stdout, result.stdout
     for py_library in ('requirements-parser', 'voluptuous'):
         result = cli(
-            f'{container_runtime} run --rm {ee_tag} pip3 show {py_library}', allow_error=True
+            f'{runtime} run --rm {ee_tag} pip3 show {py_library}', allow_error=True
         )
         assert result.rc != 0, py_library
 
 
-def test_python_git_requirement(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_python_git_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'needs_git' / 'execution-environment.yml'
-    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     cli(command)
-    result = cli(f'{container_runtime} run --rm {ee_tag} pip3 freeze')
+    result = cli(f'{runtime} run --rm {ee_tag} pip3 freeze')
     assert 'flask' in result.stdout.lower(), result.stdout
 
 
-def test_prepended_steps(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_prepended_steps(cli, runtime, ee_tag, tmp_path, data_dir):
     """
     Tests that prepended steps are in final stage
     """
     bc = tmp_path
     ee_def = data_dir / 'prepend_steps' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime}'
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     )
 
-    _file = 'Dockerfile' if container_runtime == 'docker' else 'Containerfile'
+    _file = 'Dockerfile' if runtime == 'docker' else 'Containerfile'
     content = open(os.path.join(bc, _file), 'r').read()
 
     stages_content = content.split('FROM')
@@ -95,65 +101,71 @@ def test_prepended_steps(cli, container_runtime, ee_tag, tmp_path, data_dir):
     assert 'RUN whoami' in stages_content[-1]
 
 
-def test_build_args_basic(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_build_args_basic(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'build_args' / 'execution-environment.yml'
     result = cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} --build-arg FOO=bar -v3'
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} --build-arg FOO=bar -v3'
     )
     assert 'FOO=bar' in result.stdout
 
 
-def test_build_args_from_environment(cli, container_runtime, ee_tag, tmp_path, data_dir):
-    if container_runtime == 'podman':
+@pytest.mark.test_all_runtimes
+def test_build_args_from_environment(cli, runtime, ee_tag, tmp_path, data_dir):
+    if runtime == 'podman':
         pytest.skip('Skipped. Podman does not support this')
 
     bc = tmp_path
     ee_def = data_dir / 'build_args' / 'execution-environment.yml'
     os.environ['FOO'] = 'secretsecret'
     result = cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} --build-arg FOO -v3'
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} --build-arg FOO -v3'
     )
     assert 'secretsecret' in result.stdout
 
 
-def test_base_image_build_arg(cli, container_runtime, ee_tag, tmp_path, data_dir):
+@pytest.mark.test_all_runtimes
+def test_base_image_build_arg(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'build_args' / 'base-image.yml'
     os.environ['FOO'] = 'secretsecret'
 
     # Build with custom image tag, then use that as input to --build-arg EE_BASE_IMAGE
-    cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {container_runtime} -v3')
+    cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {runtime} -v3')
     cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom '
-        f'--container-runtime {container_runtime} --build-arg EE_BASE_IMAGE={ee_tag}-custom -v3')
-    result = cli(f"{container_runtime} run {ee_tag}-custom cat /base_image")
+        f'--container-runtime {runtime} --build-arg EE_BASE_IMAGE={ee_tag}-custom -v3')
+    result = cli(f"{runtime} run {ee_tag}-custom cat /base_image")
     assert f"{ee_tag}-custom" in result.stdout
 
 
 class TestPytz:
 
     @pytest.fixture(scope='class')
-    def pytz(self, cli_class, container_runtime, ee_tag_class, data_dir, tmp_path_factory):
+    @pytest.mark.test_all_runtimes
+    def pytz(self, cli_class, runtime, ee_tag_class, data_dir, tmp_path_factory):
         bc_folder = str(tmp_path_factory.mktemp('bc'))
         ee_def = data_dir / 'pytz' / 'execution-environment.yml'
         r = cli_class(
-            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag_class} --container-runtime {container_runtime} -v 3'
+            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag_class} --container-runtime {runtime} -v 3'
         )
         # Because of test multi-processing, this may or may not use cache, so allow either
         assert 'RUN /output/install-from-bindep && rm -rf /output/wheels' in r.stdout, r.stdout
         return (ee_tag_class, bc_folder)
 
-    def test_has_pytz(self, cli, container_runtime, pytz):
+    @pytest.mark.test_all_runtimes
+    def test_has_pytz(self, cli, runtime, pytz):
         ee_tag, bc_folder = pytz
-        r = cli(f'{container_runtime} run --rm {ee_tag} pip3 show pytz')
+        r = cli(f'{runtime} run --rm {ee_tag} pip3 show pytz')
         assert 'World timezone definitions, modern and historical' in r.stdout, r.stdout
 
+    @pytest.mark.test_all_runtimes
     @pytest.mark.skip("Concurrency issues plus output parsing is using the incorrect format")
-    def test_build_layer_reuse(self, cli, container_runtime, data_dir, pytz):
+    def test_build_layer_reuse(self, cli, runtime, data_dir, pytz):
         ee_tag, bc_folder = pytz
         ee_def = data_dir / 'pytz' / 'execution-environment.yml'
         r = cli(
-            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag} --container-runtime {container_runtime} -v 3'
+            f'ansible-builder build -c {bc_folder} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3'
         )
         assert 'Collecting pytz' not in r.stdout, r.stdout
         stdout_no_whitespace = r.stdout.replace('--->', '-->').replace('\n', ' ').replace('   ', ' ').replace('  ', ' ')

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -92,7 +92,8 @@ def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmp_
     assert 'EE_BASE_IMAGE=my-other-custom-image' in content
 
 
-def test_build_command(exec_env_definition_file):
+@pytest.mark.test_all_runtimes
+def test_build_command(exec_env_definition_file, runtime):
     content = {'version': 1}
     path = exec_env_definition_file(content=content)
 
@@ -100,7 +101,7 @@ def test_build_command(exec_env_definition_file):
     command = aee.build_command
     assert 'build' and 'my-custom-image' in command
 
-    aee = AnsibleBuilder(filename=path, build_context='foo/bar/path', container_runtime='docker')
+    aee = AnsibleBuilder(filename=path, build_context='foo/bar/path', container_runtime=runtime)
 
     command = aee.build_command
     assert 'foo/bar/path' in command
@@ -139,11 +140,12 @@ def test_ansible_config_for_galaxy(exec_env_definition_file, tmp_path):
     assert f'ADD {constants.user_content_subfolder}/ansible.cfg ~/.ansible.cfg' in content
 
 
-def test_use_dockerfile_with_podman(exec_env_definition_file, tmp_path):
+@pytest.mark.test_all_runtimes
+def test_use_dockerfile(exec_env_definition_file, tmp_path, runtime):
     path = exec_env_definition_file(content={'version': 1})
     aee = AnsibleBuilder(
         filename=path, build_context=tmp_path.joinpath('bc'),
-        container_runtime='podman', output_filename='Dockerfile'
+        container_runtime=runtime, output_filename='Dockerfile'
     )
     aee.build()
 


### PR DESCRIPTION
Docker maintains a separate build cache which needs to be purged prior to running the test.

Remove the `pytz` fixture and instead perform the commands within each test to remove concurrency issues and make 
the test easier to read.

Correctly parse the stdout from the command run. The stdout generate during the test can either be in `--progress plain` or `--progress tty` format (the default is `--progress auto`). I'm not sure what exactly about the environment changes the output format, so I changed the test to pass regardless of the output format.