### PR TITLE
Add `--no-cache` option to `container build`

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -124,6 +124,12 @@ def add_container_options(parser):
              'Internally ansible-builder makes use of {0}.'.format(
              ', '.join(constants.build_arg_defaults.keys())))
 
+    build_command_parser.add_argument(
+        '--no-cache',
+        action='store_true',
+        help='Do not use cache when building the image',
+    )
+
     for p in [create_command_parser, build_command_parser]:
 
         p.add_argument('-f', '--file',

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -39,6 +39,7 @@ class AnsibleBuilder:
                  tag=constants.default_tag,
                  container_runtime=constants.default_container_runtime,
                  output_filename=None,
+                 no_cache=False,
                  verbosity=constants.default_verbosity):
         self.action = action
         self.definition = UserDefinition(filename=filename)
@@ -49,6 +50,7 @@ class AnsibleBuilder:
             build_context, constants.user_content_subfolder)
         self.container_runtime = container_runtime
         self.build_args = build_args or {}
+        self.no_cache = no_cache
         self.containerfile = Containerfile(
             definition=self.definition,
             build_context=self.build_context,
@@ -110,6 +112,9 @@ class AnsibleBuilder:
             command.append(build_arg)
 
         command.append(self.build_context)
+
+        if self.no_cache:
+            command.append('--no-cache')
 
         return command
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -44,3 +44,14 @@ def test_build_context(good_exec_env_definition_path, tmp_path):
     # test without 'container' sub-command (defaulting to 'container')
     aee = prepare(['build', '-f', path, '-c', build_context])
     assert aee.build_context == build_context
+
+
+def test_build_no_cache(good_exec_env_definition_path, tmp_path):
+    path = str(good_exec_env_definition_path)
+    build_context = str(tmp_path)
+
+    aee = prepare(['container', 'build', '-f', path, '-c', build_context])
+    aee_no_cache = prepare(['container', 'build', '-f', path, '-c', build_context, '--no-cache'])
+
+    assert '--no-cache' not in aee.build_command
+    assert '--no-cache' in aee_no_cache.build_command


### PR DESCRIPTION
Fixes #307.

This will add the `--no-cache` flag to the build command, ignoring the build cache.