### PR TITLE
Support multiple tags

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -112,7 +112,7 @@ def add_container_options(parser):
         '-t', '--tag',
         action='extend',
         nargs='+',
-        help=f'The name for the container image being built (default: {constants.default_tag}')
+        help=f'The name(s) for the container image being built (default: {constants.default_tag})')
 
     build_command_parser.add_argument(
         '--container-runtime',
@@ -236,7 +236,7 @@ def parse_args(args=sys.argv[1:]):
     args = parser.parse_args(args)
 
     # Tag default must be handled differently. See comment for --tag option.
-    if not args.tag:
+    if 'tag' not in vars(args):
         args.tag = [constants.default_tag]
 
     return args

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -104,10 +104,15 @@ def add_container_options(parser):
         )
     )
 
+    # Because of the way argparse works, if we specify the default here, it would
+    # always be included in the value list if a tag value was supplied. We don't want
+    # that, so we must, instead, set the default AFTER the argparse.parse_args() call.
+    # See https://bugs.python.org/issue16399 for more info.
     build_command_parser.add_argument(
         '-t', '--tag',
-        default=constants.default_tag,
-        help='The name for the container image being built (default: %(default)s)')
+        action='extend',
+        nargs='+',
+        help=f'The name for the container image being built (default: {constants.default_tag}')
 
     build_command_parser.add_argument(
         '--container-runtime',
@@ -229,6 +234,11 @@ def parse_args(args=sys.argv[1:]):
     add_container_options(container_parser)
 
     args = parser.parse_args(args)
+
+    # Tag default must be handled differently. See comment for --tag option.
+    if not args.tag:
+        args.tag = [constants.default_tag]
+
     return args
 
 

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -36,7 +36,7 @@ class AnsibleBuilder:
                  filename=constants.default_file,
                  build_args=None,
                  build_context=constants.default_build_context,
-                 tag=constants.default_tag,
+                 tag=[constants.default_tag],
                  container_runtime=constants.default_container_runtime,
                  output_filename=None,
                  no_cache=False,
@@ -44,7 +44,7 @@ class AnsibleBuilder:
         self.action = action
         self.definition = UserDefinition(filename=filename)
 
-        self.tag = tag
+        self.tags = tag
         self.build_context = build_context
         self.build_outputs_dir = os.path.join(
             build_context, constants.user_content_subfolder)
@@ -55,8 +55,7 @@ class AnsibleBuilder:
             definition=self.definition,
             build_context=self.build_context,
             container_runtime=self.container_runtime,
-            output_filename=output_filename,
-            tag=self.tag)
+            output_filename=output_filename)
         self.verbosity = verbosity
 
     @property
@@ -99,9 +98,11 @@ class AnsibleBuilder:
     def build_command(self):
         command = [
             self.container_runtime, "build",
-            "-f", self.containerfile.path,
-            "-t", self.tag,
+            "-f", self.containerfile.path
         ]
+
+        for tag in self.tags:
+            command.extend(["-t", tag])
 
         for key, value in self.build_args.items():
             if value:
@@ -119,7 +120,7 @@ class AnsibleBuilder:
         return command
 
     def build(self):
-        logger.debug(f'Ansible Builder is building your execution environment image, "{self.tag}".')
+        logger.debug(f'Ansible Builder is building your execution environment image, "{self.tags}".')
         self.write_containerfile()
         run_command(self.build_command)
         return True
@@ -294,8 +295,7 @@ class Containerfile:
     def __init__(self, definition,
                  build_context=None,
                  container_runtime=None,
-                 output_filename=None,
-                 tag=None):
+                 output_filename=None):
 
         self.build_context = build_context
         self.build_outputs_dir = os.path.join(
@@ -307,7 +307,6 @@ class Containerfile:
             filename = output_filename
         self.path = os.path.join(self.build_context, filename)
         self.container_runtime = container_runtime
-        self.tag = tag
         # Build args all need to go at top of file to avoid errors
         self.steps = [
             "ARG EE_BASE_IMAGE={}".format(

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -36,7 +36,7 @@ class AnsibleBuilder:
                  filename=constants.default_file,
                  build_args=None,
                  build_context=constants.default_build_context,
-                 tag=[constants.default_tag],
+                 tag=None,
                  container_runtime=constants.default_container_runtime,
                  output_filename=None,
                  no_cache=False,
@@ -44,7 +44,7 @@ class AnsibleBuilder:
         self.action = action
         self.definition = UserDefinition(filename=filename)
 
-        self.tags = tag
+        self.tags = tag or []
         self.build_context = build_context
         self.build_outputs_dir = os.path.join(
             build_context, constants.user_content_subfolder)
@@ -120,7 +120,7 @@ class AnsibleBuilder:
         return command
 
     def build(self):
-        logger.debug(f'Ansible Builder is building your execution environment image, "{self.tags}".')
+        logger.debug(f'Ansible Builder is building your execution environment image. Tags: {", ".join(self.tags)}')
         self.write_containerfile()
         run_command(self.build_command)
         return True

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,6 +59,11 @@ To customize the tagged name applied to the built image:
 
    $ ansible-builder container build --tag=my-custom-ee
 
+More recent versions of ``ansible-builder`` support multiple tags:
+
+.. code::
+
+   $ ansible-builder container build --tag=tag1 --tag=tag2
 
 ``--file``
 **********

--- a/test/integration/test_help.py
+++ b/test/integration/test_help.py
@@ -33,14 +33,14 @@ def test_container_help(cli):
 def test_container_build_help(cli):
     result = cli('ansible-builder container build --help', check=False)
     help_text = result.stdout
-    assert 'usage: ansible-builder container build [-h] [-t TAG]' in help_text
+    assert 'usage: ansible-builder container build [-h]' in help_text
     assert re.search(r'Creates a build context', help_text)
 
 
 def test_backward_compat_build_help(cli):
     result = cli('ansible-builder build --help', check=False)
     help_text = result.stdout
-    assert 'usage: ansible-builder container build [-h] [-t TAG]' in help_text
+    assert 'usage: ansible-builder container build [-h]' in help_text
     assert re.search(r'Creates a build context', help_text)
 
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -55,3 +55,12 @@ def test_build_no_cache(good_exec_env_definition_path, tmp_path):
 
     assert '--no-cache' not in aee.build_command
     assert '--no-cache' in aee_no_cache.build_command
+
+
+def test_build_multiple_tags(exec_env_definition_file, tmp_path):
+    content = {'version': 1}
+    path = str(exec_env_definition_file(content=content))
+
+    # test with 'container' sub-command
+    aee = prepare(['container', 'build', '--tag', 'TAG1', '--tag', 'TAG2', '-f', path, '-c', str(tmp_path)])
+    assert aee.tags == ['TAG1', 'TAG2']


### PR DESCRIPTION
Fixes #295

Supports multiple image tags. Example:

`ansible-builder build -t TAG1 -t TAG2 ...`

or

`ansible-builder build -t TAG1 TAG2 ...`