### PR TITLE
Fix CI to use image from PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,29 +36,9 @@ jobs:
         run: tox
 
 
-  images:
-    name: Build Image - ${{ matrix.runtime }}
-    runs-on: ubuntu-20.04
-
-    strategy:
-      fail-fast: false
-      matrix:
-        runtime:
-          - docker
-          - podman
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Build Container Image
-        run: ${{ matrix.runtime }} build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
-
-
   integration:
     runs-on: ubuntu-20.04
     name: Integration - ${{ matrix.py_version.name }}
-    needs: images
 
     env:
       TOXENV: ${{ matrix.py_version.tox_env }}
@@ -97,6 +77,8 @@ jobs:
 
       - name: Run integration tests
         run: |
+          docker build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
+          podman build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
           tox
 
       - name: Upload coverage report

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -85,7 +85,7 @@ def test_user_python_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
         f'{runtime} run --rm {ee_tag} pip3 show awxkit'
     )
     assert 'The official command line interface for Ansible AWX' in result.stdout, result.stdout
-    for py_library in ('requirements-parser', 'voluptuous'):
+    for py_library in ('requirements-parser'):
         result = cli(
             f'{runtime} run --rm {ee_tag} pip3 show {py_library}', allow_error=True
         )


### PR DESCRIPTION
When we merged PR #336, this actually broke the `test_user_python_requirement` test because it tests to make sure that the `voluptuous` library is not installed (because it was sanitized away), but it actually _is_ installed now after that change. The tests in PR #336 did not catch it because it was using the builder container image from quay and NOT the image built from the PR change.

This changes the GHA CI to build an image locally (the current way it was trying to do that does not work as artifacts are not shared among GHA tests) before running the integration tests. Also fixes the broken test.