### PR TITLE
Use lastest image in docs

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -9,7 +9,7 @@ An example execution environment definition schema is as follows:
     version: 1
 
     build_arg_defaults:
-      EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.10-devel'
+      EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:latest'
 
     ansible_config: 'ansible.cfg'
 


### PR DESCRIPTION
Stop using `*-devel` in our examples since that is an unstable image and folks are just doing copy-pasta of it.