### PR TITLE
Use `devel` tag for the development image

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -38,8 +38,8 @@
           repository: quay.io/ansible/ansible-builder
           tags:
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
-            # Otherwise: ['latest']
-            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['latest']) }}"
+            # Otherwise: ['devel']
+            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
       docker_images: *container_images
 
 - job:


### PR DESCRIPTION
The `devel` and `release_1.0` branches are publishing conflicting `latest` tagged images. Last merge wins.