### PR TITLE
Support collection signing verification

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -80,6 +80,19 @@ def add_container_options(parser):
         )
     )
 
+    # Keyring option copied over from ansible-galaxy. Gets passed to the invocations of it verbatim.
+    create_command_parser.add_argument(
+        '--keyring',
+        help='The keyring used during signature verification when installing collections from a Galaxy server')
+    # Disable-gpg-verify option copied over from ansible-galaxy. Gets passed to the invocations of it verbatim.
+    create_command_parser.add_argument(
+        '--disable-gpg-verify',
+        dest='disable_gpg_verify',
+        action='store_true',
+        help='Disable GPG signature verification when installing collections from a Galaxy server')
+    # Would also have copied over the signature option from ansible-galaxy but since it can't be specified
+    # with requirements-file set (we set that in any case) it is left out.
+
     build_command_parser = parser.add_parser(
         'build',
         help='Builds a container image.',

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -143,10 +143,16 @@ def add_container_options(parser):
                                 ' and '.join([' for '.join([v, k]) for k, v in constants.runtime_files.items()]))
                        )
 
-        # Keyring option copied over from ansible-galaxy. Gets passed to the invocations of it verbatim.
-        # If this is not supplied, no verification is performed.
-        p.add_argument('--keyring',
-                       help='The keyring used for collection signature verification during installation from Galaxy.')
+        p.add_argument('--galaxy-keyring',
+                       help='Keyring for collection signature verification during installs from Galaxy. '
+                            'Will be copied into images. Verification is disabled if unset.')
+        p.add_argument('--galaxy-ignore-signature-status-codes',
+                       action="append",
+                       help='A gpg status code to ignore during signature verification when installing with '
+                       'ansible-galaxy. May be specified multiple times. See ansible-galaxy doc for more info.')
+        p.add_argument('--galaxy-required-valid-signature-count',
+                       help='The number of signatures that must successfully verify collections from '
+                       'ansible-galaxy ~if there are any signatures provided~. See ansible-galaxy doc for more info.')
 
     introspect_parser = parser.add_parser(
         'introspect',

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -80,19 +80,6 @@ def add_container_options(parser):
         )
     )
 
-    # Keyring option copied over from ansible-galaxy. Gets passed to the invocations of it verbatim.
-    create_command_parser.add_argument(
-        '--keyring',
-        help='The keyring used during signature verification when installing collections from a Galaxy server')
-    # Disable-gpg-verify option copied over from ansible-galaxy. Gets passed to the invocations of it verbatim.
-    create_command_parser.add_argument(
-        '--disable-gpg-verify',
-        dest='disable_gpg_verify',
-        action='store_true',
-        help='Disable GPG signature verification when installing collections from a Galaxy server')
-    # Would also have copied over the signature option from ansible-galaxy but since it can't be specified
-    # with requirements-file set (we set that in any case) it is left out.
-
     build_command_parser = parser.add_parser(
         'build',
         help='Builds a container image.',
@@ -155,6 +142,11 @@ def add_container_options(parser):
                             '(default depends on --container-runtime, {0})'.format(
                                 ' and '.join([' for '.join([v, k]) for k, v in constants.runtime_files.items()]))
                        )
+
+        # Keyring option copied over from ansible-galaxy. Gets passed to the invocations of it verbatim.
+        # If this is not supplied, no verification is performed.
+        p.add_argument('--keyring',
+                       help='The keyring used for collection signature verification during installation from Galaxy.')
 
     introspect_parser = parser.add_parser(
         'introspect',

--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -33,4 +33,3 @@ CONTEXT_FILES = {
     'python': 'requirements.txt',
     'system': 'bindep.txt',
 }
-

--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -24,3 +24,5 @@ if shutil.which('podman'):
     default_container_runtime = 'podman'
 else:
     default_container_runtime = 'docker'
+
+default_keyring_name = 'keyring.gpg'

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -314,7 +314,8 @@ class Containerfile:
             filename = output_filename
         self.path = os.path.join(self.build_context, filename)
         self.container_runtime = container_runtime
-        self.keyring = keyring
+        self.original_keyring = keyring
+        self.keyring_copy = None
 
         # Build args all need to go at top of file to avoid errors
         self.steps = [
@@ -343,8 +344,9 @@ class Containerfile:
                 self.build_context, constants.user_content_subfolder, new_name)
             copy_file(requirement_path, dest)
 
-        if self.keyring:
-            copy_file(self.keyring, os.path.join(self.build_outputs_dir, 'keyring.gpg'))
+        if self.original_keyring:
+            self.keyring_copy = constants.default_keyring_name
+            copy_file(self.original_keyring, os.path.join(self.build_outputs_dir, self.keyring_copy))
 
         if self.definition.ansible_config:
             copy_file(
@@ -384,7 +386,7 @@ class Containerfile:
 
     def prepare_galaxy_install_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):
-            self.steps.extend(GalaxyInstallSteps(CONTEXT_FILES['galaxy'], self.keyring))
+            self.steps.extend(GalaxyInstallSteps(CONTEXT_FILES['galaxy'], self.keyring_copy))
         return self.steps
 
     def prepare_introspect_assemble_steps(self):

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -40,10 +40,8 @@ class AnsibleBuilder:
                  output_filename=None,
                  no_cache=False,
                  verbosity=constants.default_verbosity,
-                 disable_gpg_verify=False,
                  keyring=None):
         """
-        :param bool disable_gpg_verify: Always disable signature verification of collections installed by ansible-galaxy.
         :param str keyring: GPG keyring file used by ansible-galaxy to opportunistically validate collection signatures.
         """
         self.action = action
@@ -61,8 +59,7 @@ class AnsibleBuilder:
             build_context=self.build_context,
             container_runtime=self.container_runtime,
             output_filename=output_filename,
-            keyring=keyring,
-            disable_gpg_verify=disable_gpg_verify)
+            keyring=keyring)
         self.verbosity = verbosity
 
     @property
@@ -303,10 +300,8 @@ class Containerfile:
                  build_context=None,
                  container_runtime=None,
                  output_filename=None,
-                 disable_gpg_verify=False,
                  keyring=None):
         """
-        :param bool disable_gpg_verify: Always disable signature verification of collections installed by ansible-galaxy.
         :param str keyring: GPG keyring file used by ansible-galaxy to opportunistically validate collection signatures.
         """
         self.build_context = build_context
@@ -320,7 +315,6 @@ class Containerfile:
         self.path = os.path.join(self.build_context, filename)
         self.container_runtime = container_runtime
         self.keyring = keyring
-        self.disable_gpg_verify = disable_gpg_verify
 
         # Build args all need to go at top of file to avoid errors
         self.steps = [
@@ -390,7 +384,7 @@ class Containerfile:
 
     def prepare_galaxy_install_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):
-            self.steps.extend(GalaxyInstallSteps(CONTEXT_FILES['galaxy'], self.keyring, self.disable_gpg_verify))
+            self.steps.extend(GalaxyInstallSteps(CONTEXT_FILES['galaxy'], self.keyring))
         return self.steps
 
     def prepare_introspect_assemble_steps(self):

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -43,14 +43,19 @@ class BuildContextSteps(Steps):
 
 
 class GalaxyInstallSteps(Steps):
-    def __init__(self, requirements_naming):
+    def __init__(self, requirements_naming, keyring, disable_gpg_verify):
         """Assumes given requirements file name has been placed in the build context
         """
+
+        install_opts = f"-r {requirements_naming} --collections-path {constants.base_collections_path}"
+        if keyring:
+            install_opts += " --keyring ./keyring.gog"
+        if disable_gpg_verify:
+            install_opts += " --disable-gpg-verify"
+
         self.steps = [
-            "RUN ansible-galaxy role install -r {0} --roles-path {1}".format(
-                requirements_naming, constants.base_roles_path),
-            "RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r {0} --collections-path {1}".format(
-                requirements_naming, constants.base_collections_path),
+            f"RUN ansible-galaxy role install -r {requirements_naming} --roles-path {constants.base_roles_path}",
+            f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS {install_opts}",
         ]
 
 

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -47,16 +47,20 @@ class GalaxyInstallSteps(Steps):
         """Assumes given requirements file name has been placed in the build context
         """
 
+        self.steps = []
         install_opts = f"-r {requirements_naming} --collections-path {constants.base_collections_path}"
         if keyring:
             install_opts += " --keyring ./keyring.gpg"
         else:
-            install_opts += " --disable-gpg-verify"
+            # We have to use the environment variable to disable signature
+            # verification because older versions (<2.13) of ansible-galaxy do
+            # not support the --disable-gpg-verify option.
+            self.steps.extend(["ENV ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1"])
 
-        self.steps = [
+        self.steps.extend([
             f"RUN ansible-galaxy role install -r {requirements_naming} --roles-path {constants.base_roles_path}",
             f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS {install_opts}",
-        ]
+        ])
 
 
 class GalaxyCopySteps(Steps):

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -43,14 +43,26 @@ class BuildContextSteps(Steps):
 
 
 class GalaxyInstallSteps(Steps):
-    def __init__(self, requirements_naming, keyring):
-        """Assumes given requirements file name and keyring has been placed in the build context
+    def __init__(self, requirements_naming, galaxy_keyring, galaxy_ignore_signature_status_codes, galaxy_required_valid_signature_count):
+        """Assumes given requirements file name and keyring has been placed in the build context.
+
+        :param str galaxy_keyring: GPG keyring file used by ansible-galaxy to opportunistically validate collection signatures.
+        :param str galaxy_required_valid_signature_count: Number of sigs (prepend + to disallow no sig) required for ansible-galaxy to accept collections.
+        :param str galaxy_ignore_signature_status_codes: GPG Status codes to ignore when validating galaxy collections.
         """
 
         env = ""
-        install_opts = f"-r {requirements_naming} --collections-path {constants.base_collections_path}"
-        if keyring:
-            install_opts += f" --keyring {keyring}"
+        install_opts = f"-r {requirements_naming} --collections-path \"{constants.base_collections_path}\""
+
+        if galaxy_ignore_signature_status_codes:
+            for code in galaxy_ignore_signature_status_codes:
+                install_opts += f" --ignore-signature-status-code {code}"
+
+        if galaxy_required_valid_signature_count:
+            install_opts += f" --required-valid-signature-count {galaxy_required_valid_signature_count}"
+
+        if galaxy_keyring:
+            install_opts += f" --keyring \"{galaxy_keyring}\""
         else:
             # We have to use the environment variable to disable signature
             # verification because older versions (<2.13) of ansible-galaxy do
@@ -60,7 +72,7 @@ class GalaxyInstallSteps(Steps):
             env = "ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 "
 
         self.steps = [
-            f"RUN ansible-galaxy role install -r {requirements_naming} --roles-path {constants.base_roles_path}",
+            f"RUN ansible-galaxy role install -r {requirements_naming} --roles-path \"{constants.base_roles_path}\"",
             f"RUN {env}ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS {install_opts}",
         ]
 

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -43,14 +43,14 @@ class BuildContextSteps(Steps):
 
 
 class GalaxyInstallSteps(Steps):
-    def __init__(self, requirements_naming, keyring, disable_gpg_verify):
+    def __init__(self, requirements_naming, keyring):
         """Assumes given requirements file name has been placed in the build context
         """
 
         install_opts = f"-r {requirements_naming} --collections-path {constants.base_collections_path}"
         if keyring:
-            install_opts += " --keyring ./keyring.gog"
-        if disable_gpg_verify:
+            install_opts += " --keyring ./keyring.gpg"
+        else:
             install_opts += " --disable-gpg-verify"
 
         self.steps = [

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -44,13 +44,13 @@ class BuildContextSteps(Steps):
 
 class GalaxyInstallSteps(Steps):
     def __init__(self, requirements_naming, keyring):
-        """Assumes given requirements file name has been placed in the build context
+        """Assumes given requirements file name and keyring has been placed in the build context
         """
 
         env = ""
         install_opts = f"-r {requirements_naming} --collections-path {constants.base_collections_path}"
         if keyring:
-            install_opts += " --keyring ./keyring.gpg"
+            install_opts += f" --keyring {keyring}"
         else:
             # We have to use the environment variable to disable signature
             # verification because older versions (<2.13) of ansible-galaxy do

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -47,20 +47,22 @@ class GalaxyInstallSteps(Steps):
         """Assumes given requirements file name has been placed in the build context
         """
 
-        self.steps = []
+        env = ""
         install_opts = f"-r {requirements_naming} --collections-path {constants.base_collections_path}"
         if keyring:
             install_opts += " --keyring ./keyring.gpg"
         else:
             # We have to use the environment variable to disable signature
             # verification because older versions (<2.13) of ansible-galaxy do
-            # not support the --disable-gpg-verify option.
-            self.steps.extend(["ENV ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1"])
+            # not support the --disable-gpg-verify option. We don't use ENV in
+            # the Containerfile since we need it only during the build and not
+            # in the final image.
+            env = "ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 "
 
-        self.steps.extend([
+        self.steps = [
             f"RUN ansible-galaxy role install -r {requirements_naming} --roles-path {constants.base_roles_path}",
-            f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS {install_opts}",
-        ])
+            f"RUN {env}ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS {install_opts}",
+        ]
 
 
 class GalaxyCopySteps(Steps):

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,6 +75,21 @@ To use a definition file named something other than
 
    $ ansible-builder build --file=my-ee.yml
 
+``--keyring``
+*************
+
+With more recent versions of Ansible, it is possible to have the ``ansible-galaxy``
+utility verify collection signatures during installation. This requires a keyring to
+be provided (can be built with GnuPG tooling) to use during verification. Provide
+the path to this keyring with the ``--keyring`` option. If this option is not
+supplied, no signature verification will be performed. If it is provided, and the
+version of Ansible is not recent enough to support this feature, an error will
+occur during the image build process.
+
+.. code::
+
+   $ ansible-builder create --keyring=/path/to/pubring.kbx
+   $ ansible-builder build --keyring=/path/to/pubring.kbx
 
 ``--context``
 *************

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,21 +75,46 @@ To use a definition file named something other than
 
    $ ansible-builder build --file=my-ee.yml
 
-``--keyring``
-*************
+``--galaxy-keyring``
+********************
 
 With more recent versions of Ansible, it is possible to have the ``ansible-galaxy``
 utility verify collection signatures during installation. This requires a keyring to
 be provided (can be built with GnuPG tooling) to use during verification. Provide
-the path to this keyring with the ``--keyring`` option. If this option is not
+the path to this keyring with the ``--galaxy-keyring`` option. If this option is not
 supplied, no signature verification will be performed. If it is provided, and the
 version of Ansible is not recent enough to support this feature, an error will
 occur during the image build process.
 
 .. code::
 
-   $ ansible-builder create --keyring=/path/to/pubring.kbx
-   $ ansible-builder build --keyring=/path/to/pubring.kbx
+   $ ansible-builder create --galaxy-keyring=/path/to/pubring.kbx
+   $ ansible-builder build --galaxy-keyring=/path/to/pubring.kbx
+
+``--galaxy-ignore-signature-status-code``
+*****************************************
+
+With ``--galaxy-keyring`` set it is possible to ignore certain errors that may occur while verifying collections.
+It is passed unmodified to ``ansible-galaxy`` calls via the option ``--ignore-signature-status-code``.
+See the ``ansible-galaxy`` documentation for more information.
+
+.. code::
+
+   $ ansible-builder create --galaxy-keyring=/path/to/pubring.kbx --galaxy-ignore-signature-status-code 500
+   $ ansible-builder build --galaxy-keyring=/path/to/pubring.kbx --galaxy-ignore-signature-status-code 500
+
+``--galaxy-required-valid-signature-count``
+*******************************************
+
+When ``--galaxy-keyring`` is set, the number of required valid collection signatures can be overridden. 
+The value is passed unmodified to ``ansible-galaxy`` calls via the option ``--required-valid-signature-count``.
+See the ``ansible-galaxy`` documentation for more information.
+
+.. code::
+
+   $ ansible-builder create --galaxy-keyring=/path/to/pubring.kbx --galaxy-required-valid-signature-count 3
+   $ ansible-builder build --galaxy-keyring=/path/to/pubring.kbx --galaxy-required-valid-signature-count 3
+
 
 ``--context``
 *************

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -1,6 +1,8 @@
 import pytest
 import os
 
+from ansible_builder import constants
+
 # Need to call this directly for multiple tag testing
 from test.integration.conftest import delete_image
 
@@ -211,5 +213,8 @@ def test_collection_verification_on(cli, runtime, data_dir, ee_tag, tmp_path):
     # ansible-galaxy might error (older Ansible), but that should be ok
     result = cli(f'ansible-builder build --keyring {keyring} -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3', allow_error=True)
 
+    keyring_copy = tmp_path / constants.user_content_subfolder / constants.default_keyring_name
+    assert keyring_copy.exists()
+
     assert "RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy" not in result.stdout
-    assert "--keyring ./keyring.gpg" in result.stdout
+    assert f"--keyring {constants.default_keyring_name}" in result.stdout

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -211,10 +211,30 @@ def test_collection_verification_on(cli, runtime, data_dir, ee_tag, tmp_path):
     ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
 
     # ansible-galaxy might error (older Ansible), but that should be ok
-    result = cli(f'ansible-builder build --keyring {keyring} -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3', allow_error=True)
+    result = cli(f'ansible-builder build --galaxy-keyring {keyring} -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3', allow_error=True)
 
     keyring_copy = tmp_path / constants.user_content_subfolder / constants.default_keyring_name
     assert keyring_copy.exists()
 
     assert "RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy" not in result.stdout
-    assert f"--keyring {constants.default_keyring_name}" in result.stdout
+    assert f"--keyring \"{constants.default_keyring_name}\"" in result.stdout
+
+
+@pytest.mark.xfail(reason="Needs ansible 2.13")
+@pytest.mark.test_all_runtimes
+def test_galaxy_signing_extra_args(cli, runtime, data_dir, ee_tag, tmp_path):
+    """
+    Test that all extr asigning args for gpg are passed into the container file.
+    """
+    pytest.xfail("failing configuration (but should work)")
+
+    keyring = tmp_path / "mykeyring.gpg"
+    keyring.touch()
+    ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
+
+    result = cli(f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3 '
+                 f'--galaxy-keyring {keyring} --galaxy-ignore-signature-status-code 500 '
+                 f'--galaxy-required-valid-signature-count 3', allow_error=True)
+
+    assert "--galaxy-ignore-signature-status-code 500" in result.stdout
+    assert "--galaxy-required-valid-signature-count 3" in result.stdout

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -1,5 +1,7 @@
 import os
 
+from ansible_builder import constants
+
 
 def test_definition_syntax_error(cli, data_dir):
     ee_def = os.path.join(data_dir, 'definition_files', 'invalid.yml')
@@ -96,5 +98,9 @@ def test_collection_verification_on(cli, build_dir_and_ee_yml):
     containerfile = tmpdir / "Containerfile"
     assert containerfile.exists()
     text = containerfile.read_text()
+
+    keyring_copy = tmpdir / constants.user_content_subfolder / constants.default_keyring_name
+    assert keyring_copy.exists()
+
     assert "RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy" not in text
-    assert "--keyring ./keyring.gpg" in text
+    assert f"--keyring {constants.default_keyring_name}" in text

--- a/test/unit/test_steps.py
+++ b/test/unit/test_steps.py
@@ -18,18 +18,24 @@ def test_additional_build_steps(verb):
 
     assert len(list(steps)) == 2
 
+
 def test_galaxy_install_steps():
     steps = list(GalaxyInstallSteps("requirements.txt", None))
     expected = [
         f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
-        f"RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path {constants.base_collections_path}"
+
+        f"RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install "
+        f"$ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path {constants.base_collections_path}"
     ]
     assert steps == expected
+
 
 def test_galaxy_install_steps_with_keyring():
     steps = list(GalaxyInstallSteps("requirements.txt", "mykeyring.gpg"))
     expected = [
         f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
-        f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path {constants.base_collections_path} --keyring ./keyring.gpg"
+
+        f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
+        f"--collections-path {constants.base_collections_path} --keyring ./keyring.gpg"
     ]
     assert steps == expected

--- a/test/unit/test_steps.py
+++ b/test/unit/test_steps.py
@@ -20,22 +20,48 @@ def test_additional_build_steps(verb):
 
 
 def test_galaxy_install_steps():
-    steps = list(GalaxyInstallSteps("requirements.txt", None))
+    steps = list(GalaxyInstallSteps("requirements.txt", None, [], None))
     expected = [
-        f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
+        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
 
         f"RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install "
-        f"$ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path {constants.base_collections_path}"
+        f"$ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path \"{constants.base_collections_path}\""
     ]
     assert steps == expected
 
 
 def test_galaxy_install_steps_with_keyring():
-    steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name))
+    steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name, [], None))
     expected = [
-        f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
+        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
 
         f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
-        f"--collections-path {constants.base_collections_path} --keyring {constants.default_keyring_name}"
+        f"--collections-path \"{constants.base_collections_path}\" --keyring \"{constants.default_keyring_name}\""
+    ]
+    assert steps == expected
+
+
+def test_galaxy_install_steps_with_sig_count():
+    sig_count = 3
+    steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name, [], sig_count))
+    expected = [
+        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
+
+        f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
+        f"--collections-path \"{constants.base_collections_path}\" --required-valid-signature-count {sig_count} "
+        f"--keyring \"{constants.default_keyring_name}\""
+    ]
+    assert steps == expected
+
+
+def test_galaxy_install_steps_with_ignore_code():
+    codes = [1, 2]
+    steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name, codes, None))
+    expected = [
+        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
+
+        f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
+        f"--collections-path \"{constants.base_collections_path}\" --ignore-signature-status-code {codes[0]} "
+        f"--ignore-signature-status-code {codes[1]} --keyring \"{constants.default_keyring_name}\""
     ]
     assert steps == expected

--- a/test/unit/test_steps.py
+++ b/test/unit/test_steps.py
@@ -31,11 +31,11 @@ def test_galaxy_install_steps():
 
 
 def test_galaxy_install_steps_with_keyring():
-    steps = list(GalaxyInstallSteps("requirements.txt", "mykeyring.gpg"))
+    steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name))
     expected = [
         f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
 
         f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
-        f"--collections-path {constants.base_collections_path} --keyring ./keyring.gpg"
+        f"--collections-path {constants.base_collections_path} --keyring {constants.default_keyring_name}"
     ]
     assert steps == expected

--- a/test/unit/test_steps.py
+++ b/test/unit/test_steps.py
@@ -1,7 +1,8 @@
 import pytest
 import textwrap
 
-from ansible_builder.steps import AdditionalBuildSteps
+from ansible_builder import constants
+from ansible_builder.steps import AdditionalBuildSteps, GalaxyInstallSteps
 
 
 @pytest.mark.parametrize('verb', ['prepend', 'append'])
@@ -16,3 +17,19 @@ def test_additional_build_steps(verb):
     steps = AdditionalBuildSteps(additional_build_steps[verb])
 
     assert len(list(steps)) == 2
+
+def test_galaxy_install_steps():
+    steps = list(GalaxyInstallSteps("requirements.txt", None))
+    expected = [
+        f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
+        f"RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path {constants.base_collections_path}"
+    ]
+    assert steps == expected
+
+def test_galaxy_install_steps_with_keyring():
+    steps = list(GalaxyInstallSteps("requirements.txt", "mykeyring.gpg"))
+    expected = [
+        f"RUN ansible-galaxy role install -r requirements.txt --roles-path {constants.base_roles_path}",
+        f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path {constants.base_collections_path} --keyring ./keyring.gpg"
+    ]
+    assert steps == expected


### PR DESCRIPTION
It was requested that builder supports the opportunistic signature
verification feature of ansible-galaxy. this commit adds one ~~two~~ new
flags. ~~`disable-gpg-verify` lets galaxy always ignore signatures
and is simply added verbatim to the ansible-galaxy invocation in
the container file.~~ `keyring` is the path of a GPG keyring file
that shall contain public keys that are used to verify signatures
of collections. This is forwarded to the ansible-galaxy command
by copying the given path into the build directory and passing
the path to the copied file from within the container to the
ansible-galaxy invocation