### PR TITLE
[backport][release_1.0] Normalize python package names (#359)

### DIFF
--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -1,5 +1,6 @@
 import logging
 import requirements
+from pkg_resources import safe_name
 
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,8 @@ def sanitize_requirements(collection_py_reqs):
     for collection, lines in collection_py_reqs.items():
         try:
             for req in requirements.parse('\n'.join(lines)):
+                if req.specifier:
+                    req.name = safe_name(req.name)
                 req.collections = [collection]  # add backref for later
                 if req.name is None:
                     consolidated.append(req)

--- a/test/data/ansible_collections/other/reqfile/requirements.txt
+++ b/test/data/ansible_collections/other/reqfile/requirements.txt
@@ -1,0 +1,1 @@
+python_dateutil    # intentional underscore

--- a/test/data/ansible_collections/test/reqfile/requirements.txt
+++ b/test/data/ansible_collections/test/reqfile/requirements.txt
@@ -1,2 +1,3 @@
 pytz
+python-dateutil>=2.8.2    # intentional dash
 -r extra_req.txt

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -37,6 +37,7 @@ def test_introspect_write_python(cli, data_dir, tmp_path):
     assert dest_file.read_text() == '\n'.join([
         'pyvcloud>=14  # from collection test.metadata',
         'pytz  # from collection test.reqfile',
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
         'tacacs_plus  # from collection test.reqfile',
         'pyvcloud>=18.0.10  # from collection test.reqfile',
         ''
@@ -50,6 +51,7 @@ def test_introspect_write_python_and_sanitize(cli, data_dir, tmp_path):
     assert dest_file.read_text() == '\n'.join([
         'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
         'pytz  # from collection test.reqfile',
-        'tacacs_plus  # from collection test.reqfile',
-        ''
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
+        'tacacs-plus  # from collection test.reqfile',
+        '',
     ])

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -13,7 +13,10 @@ def test_multiple_collection_metadata(data_dir):
     assert files == {'python': [
         'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
         'pytz  # from collection test.reqfile',
-        'tacacs_plus  # from collection test.reqfile'
+        # python-dateutil should appear only once even though referenced in
+        # multiple places, once with a dash and another with an underscore in the name.
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
+        'tacacs-plus  # from collection test.reqfile'
     ], 'system': [
         'subversion [platform:rpm]  # from collection test.bindep',
         'subversion [platform:dpkg]  # from collection test.bindep'


### PR DESCRIPTION
Normalize python package names during sanitization

Backport of PR #359 

(cherry picked from commit db9e74a0b66aa4b535bf6946c5288f1c2619c133)