### PR TITLE
Validate the EE definition file earlier

### DIFF
--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -24,3 +24,10 @@ if shutil.which('podman'):
     default_container_runtime = 'podman'
 else:
     default_container_runtime = 'docker'
+
+# Files that need to be moved into the build context, and their naming inside the context
+CONTEXT_FILES = {
+    'galaxy': 'requirements.yml',
+    'python': 'requirements.txt',
+    'system': 'bindep.txt',
+}

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -1,32 +1,15 @@
 import logging
 import os
-import textwrap
-import yaml
 
 from . import constants
-from .exceptions import DefinitionError
 from .steps import (
     AdditionalBuildSteps, BuildContextSteps, GalaxyInstallSteps, GalaxyCopySteps, AnsibleConfigSteps
 )
+from .user_definition import UserDefinition
 from .utils import run_command, copy_file
 
 
 logger = logging.getLogger(__name__)
-
-# Files that need to be moved into the build context, and their naming inside the context
-CONTEXT_FILES = {
-    'galaxy': 'requirements.yml',
-    'python': 'requirements.txt',
-    'system': 'bindep.txt',
-}
-
-ALLOWED_KEYS = [
-    'version',
-    'build_arg_defaults',
-    'dependencies',
-    'ansible_config',
-    'additional_build_steps',
-]
 
 
 class AnsibleBuilder:
@@ -41,7 +24,10 @@ class AnsibleBuilder:
                  no_cache=False,
                  verbosity=constants.default_verbosity):
         self.action = action
+
+        # Read and validate the EE file early
         self.definition = UserDefinition(filename=filename)
+        self.definition.validate()
 
         self.tags = tag or []
         self.build_context = build_context
@@ -125,169 +111,6 @@ class AnsibleBuilder:
         return True
 
 
-class BaseDefinition:
-    """Subclasses should populate these properties in the __init__ method
-    self.raw - a dict that basically is the definition
-    self.reference_path - the folder which dependencies are specified relative to
-    """
-
-    @property
-    def version(self):
-        version = self.raw.get('version')
-
-        if not version:
-            raise ValueError("Expected top-level 'version' key to be present.")
-
-        return str(version)
-
-    @property
-    def ansible_config(self):
-        ansible_config = self.raw.get('ansible_config')
-
-        if not ansible_config:
-            pass
-        else:
-            return str(ansible_config)
-
-
-class UserDefinition(BaseDefinition):
-    def __init__(self, filename):
-        self.filename = filename
-        self.reference_path = os.path.dirname(filename)
-
-        try:
-            with open(filename, 'r') as f:
-                y = yaml.safe_load(f)
-                self.raw = y if y else {}
-        except FileNotFoundError:
-            raise DefinitionError(textwrap.dedent("""
-            Could not detect '{0}' file in this directory.
-            Use -f to specify a different location.
-            """).format(filename))
-        except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
-            raise DefinitionError(textwrap.dedent("""
-            An error occured while parsing the definition file:
-            {0}
-            """).format(str(e)))
-
-        if not isinstance(self.raw, dict):
-            raise DefinitionError("Definition must be a dictionary, not {0}".format(type(self.raw).__name__))
-
-        if self.raw.get('dependencies') is not None:
-            if not isinstance(self.raw.get('dependencies'), dict):
-                raise DefinitionError(textwrap.dedent(
-                    f"""
-                    Error: Unknown type {type(self.raw.get('dependencies'))} found for dependencies, must be a dict.\n
-                    Allowed options are:
-                    {list(CONTEXT_FILES.keys())}
-                    """)
-                )
-
-        # Populate build arg defaults, which are customizable in definition
-        self.build_arg_defaults = {}
-        user_build_arg_defaults = self.raw.get('build_arg_defaults', {})
-        if not isinstance(user_build_arg_defaults, dict):
-            user_build_arg_defaults = {}  # so that validate method can throw error
-        for key, default_value in constants.build_arg_defaults.items():
-            self.build_arg_defaults[key] = user_build_arg_defaults.get(key, default_value)
-
-    def get_additional_commands(self):
-        """Gets additional commands from the exec env file, if any are specified.
-        """
-        commands = self.raw.get('additional_build_steps')
-        return commands
-
-    def get_dep_abs_path(self, entry):
-        """Unique to the user EE definition, files can be referenced by either
-        an absolute path or a path relative to the EE definition folder
-        This method will return the absolute path.
-        """
-        req_file = self.raw.get('dependencies', {}).get(entry)
-
-        if not req_file:
-            return None
-
-        if os.path.isabs(req_file):
-            return req_file
-
-        return os.path.join(self.reference_path, req_file)
-
-    def validate(self):
-        # Check that all specified keys in the definition file are valid.
-        def_file_dict = self.raw
-        yaml_keys = set(def_file_dict.keys())
-        invalid_keys = yaml_keys - set(ALLOWED_KEYS)
-        if invalid_keys:
-            raise DefinitionError(textwrap.dedent(
-                f"""
-                Error: Unknown yaml key(s), {invalid_keys}, found in the definition file.\n
-                Allowed options are:
-                {ALLOWED_KEYS}
-                """)
-            )
-
-        if self.raw.get('dependencies') is not None:
-            dependencies_keys = set(self.raw.get('dependencies'))
-            invalid_dependencies_keys = dependencies_keys - set(CONTEXT_FILES.keys())
-            if invalid_dependencies_keys:
-                raise DefinitionError(textwrap.dedent(
-                    f"""
-                    Error: Unknown yaml key(s), {invalid_dependencies_keys}, found in dependencies.\n
-                    Allowed options are:
-                    {list(CONTEXT_FILES.keys())}
-                    """)
-                )
-
-        for item in CONTEXT_FILES:
-            requirement_path = self.get_dep_abs_path(item)
-            if requirement_path:
-                if not os.path.exists(requirement_path):
-                    raise DefinitionError("Dependency file {0} does not exist.".format(requirement_path))
-
-        build_arg_defaults = self.raw.get('build_arg_defaults')
-        if build_arg_defaults:
-            if not isinstance(build_arg_defaults, dict):
-                raise DefinitionError(
-                    f"Error: Unknown type {type(build_arg_defaults)} found for build_arg_defaults; "
-                    f"must be a dict."
-                )
-            unexpected_keys = set(build_arg_defaults.keys()) - set(constants.build_arg_defaults)
-            if unexpected_keys:
-                raise DefinitionError(
-                    f"Keys {unexpected_keys} are not allowed in 'build_arg_defaults'."
-                )
-            for key, value in constants.build_arg_defaults.items():
-                user_value = build_arg_defaults.get(key)
-                if user_value and not isinstance(user_value, str):
-                    raise DefinitionError(
-                        f"Expected build_arg_defaults.{key} to be a string; "
-                        f"Found a {type(user_value)} instead."
-                    )
-
-        additional_cmds = self.get_additional_commands()
-        if additional_cmds:
-            if not isinstance(additional_cmds, dict):
-                raise DefinitionError(textwrap.dedent("""
-                    Expected 'additional_build_steps' in the provided definition file to be a dictionary
-                    with keys 'prepend' and/or 'append'; found a {0} instead.
-                    """).format(type(additional_cmds).__name__))
-
-            expected_keys = frozenset(('append', 'prepend'))
-            unexpected_keys = set(additional_cmds.keys()) - expected_keys
-            if unexpected_keys:
-                raise DefinitionError(
-                    f"Keys {*unexpected_keys,} are not allowed in 'additional_build_steps'."
-                )
-
-        ansible_config_path = self.raw.get('ansible_config')
-        if ansible_config_path:
-            if not isinstance(ansible_config_path, str):
-                raise DefinitionError(textwrap.dedent("""
-                    Expected 'ansible_config' in the provided definition file to
-                    be a string; found a {0} instead.
-                    """).format(type(ansible_config_path).__name__))
-
-
 class Containerfile:
     newline_char = '\n'
 
@@ -320,12 +143,9 @@ class Containerfile:
         """Creates the build context file for this Containerfile
         moves files from the definition into the folder
         """
-        # courteously validate items before starting to write files
-        self.definition.validate()
-
         os.makedirs(self.build_outputs_dir, exist_ok=True)
 
-        for item, new_name in CONTEXT_FILES.items():
+        for item, new_name in constants.CONTEXT_FILES.items():
             requirement_path = self.definition.get_dep_abs_path(item)
             if requirement_path is None:
                 continue
@@ -371,7 +191,7 @@ class Containerfile:
 
     def prepare_galaxy_install_steps(self):
         if self.definition.get_dep_abs_path('galaxy'):
-            self.steps.extend(GalaxyInstallSteps(CONTEXT_FILES['galaxy']))
+            self.steps.extend(GalaxyInstallSteps(constants.CONTEXT_FILES['galaxy']))
         return self.steps
 
     def prepare_introspect_assemble_steps(self):
@@ -381,18 +201,18 @@ class Containerfile:
             introspect_cmd = "RUN ansible-builder introspect --sanitize"
 
             requirements_file_exists = os.path.exists(os.path.join(
-                self.build_outputs_dir, CONTEXT_FILES['python']
+                self.build_outputs_dir, constants.CONTEXT_FILES['python']
             ))
             if requirements_file_exists:
-                relative_requirements_path = os.path.join(constants.user_content_subfolder, CONTEXT_FILES['python'])
-                self.steps.append(f"ADD {relative_requirements_path} {CONTEXT_FILES['python']}")
+                relative_requirements_path = os.path.join(constants.user_content_subfolder, constants.CONTEXT_FILES['python'])
+                self.steps.append(f"ADD {relative_requirements_path} {constants.CONTEXT_FILES['python']}")
                 # WORKDIR is /build, so we use the (shorter) relative paths there
-                introspect_cmd += " --user-pip={0}".format(CONTEXT_FILES['python'])
-            bindep_exists = os.path.exists(os.path.join(self.build_outputs_dir, CONTEXT_FILES['system']))
+                introspect_cmd += " --user-pip={0}".format(constants.CONTEXT_FILES['python'])
+            bindep_exists = os.path.exists(os.path.join(self.build_outputs_dir, constants.CONTEXT_FILES['system']))
             if bindep_exists:
-                relative_bindep_path = os.path.join(constants.user_content_subfolder, CONTEXT_FILES['system'])
-                self.steps.append(f"ADD {relative_bindep_path} {CONTEXT_FILES['system']}")
-                introspect_cmd += " --user-bindep={0}".format(CONTEXT_FILES['system'])
+                relative_bindep_path = os.path.join(constants.user_content_subfolder, constants.CONTEXT_FILES['system'])
+                self.steps.append(f"ADD {relative_bindep_path} {constants.CONTEXT_FILES['system']}")
+                introspect_cmd += " --user-bindep={0}".format(constants.CONTEXT_FILES['system'])
 
             introspect_cmd += " --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt"
 

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -1,0 +1,178 @@
+import os
+import textwrap
+import yaml
+
+from . import constants
+from .exceptions import DefinitionError
+
+
+ALLOWED_KEYS = [
+    'version',
+    'build_arg_defaults',
+    'dependencies',
+    'ansible_config',
+    'additional_build_steps',
+]
+
+
+class BaseDefinition:
+    """Subclasses should populate these properties in the __init__ method
+    self.raw - a dict that basically is the definition
+    self.reference_path - the folder which dependencies are specified relative to
+    """
+
+    @property
+    def version(self):
+        version = self.raw.get('version')
+
+        if not version:
+            raise ValueError("Expected top-level 'version' key to be present.")
+
+        return str(version)
+
+    @property
+    def ansible_config(self):
+        ansible_config = self.raw.get('ansible_config')
+
+        if not ansible_config:
+            pass
+        else:
+            return str(ansible_config)
+
+
+class UserDefinition(BaseDefinition):
+    def __init__(self, filename):
+        self.filename = filename
+        self.reference_path = os.path.dirname(filename)
+
+        try:
+            with open(filename, 'r') as f:
+                y = yaml.safe_load(f)
+                self.raw = y if y else {}
+        except FileNotFoundError:
+            raise DefinitionError(textwrap.dedent("""
+            Could not detect '{0}' file in this directory.
+            Use -f to specify a different location.
+            """).format(filename))
+        except (yaml.parser.ParserError, yaml.scanner.ScannerError) as e:
+            raise DefinitionError(textwrap.dedent("""
+            An error occured while parsing the definition file:
+            {0}
+            """).format(str(e)))
+
+        if not isinstance(self.raw, dict):
+            raise DefinitionError("Definition must be a dictionary, not {0}".format(type(self.raw).__name__))
+
+        if self.raw.get('dependencies') is not None:
+            if not isinstance(self.raw.get('dependencies'), dict):
+                raise DefinitionError(textwrap.dedent(
+                    f"""
+                    Error: Unknown type {type(self.raw.get('dependencies'))} found for dependencies, must be a dict.\n
+                    Allowed options are:
+                    {list(constants.CONTEXT_FILES.keys())}
+                    """)
+                )
+
+        # Populate build arg defaults, which are customizable in definition
+        self.build_arg_defaults = {}
+        user_build_arg_defaults = self.raw.get('build_arg_defaults', {})
+        if not isinstance(user_build_arg_defaults, dict):
+            user_build_arg_defaults = {}  # so that validate method can throw error
+        for key, default_value in constants.build_arg_defaults.items():
+            self.build_arg_defaults[key] = user_build_arg_defaults.get(key, default_value)
+
+    def get_additional_commands(self):
+        """Gets additional commands from the exec env file, if any are specified.
+        """
+        commands = self.raw.get('additional_build_steps')
+        return commands
+
+    def get_dep_abs_path(self, entry):
+        """Unique to the user EE definition, files can be referenced by either
+        an absolute path or a path relative to the EE definition folder
+        This method will return the absolute path.
+        """
+        req_file = self.raw.get('dependencies', {}).get(entry)
+
+        if not req_file:
+            return None
+
+        if os.path.isabs(req_file):
+            return req_file
+
+        return os.path.join(self.reference_path, req_file)
+
+    def validate(self):
+        # Check that all specified keys in the definition file are valid.
+        def_file_dict = self.raw
+        yaml_keys = set(def_file_dict.keys())
+        invalid_keys = yaml_keys - set(ALLOWED_KEYS)
+        if invalid_keys:
+            raise DefinitionError(textwrap.dedent(
+                f"""
+                Error: Unknown yaml key(s), {invalid_keys}, found in the definition file.\n
+                Allowed options are:
+                {ALLOWED_KEYS}
+                """)
+            )
+
+        if self.raw.get('dependencies') is not None:
+            dependencies_keys = set(self.raw.get('dependencies'))
+            invalid_dependencies_keys = dependencies_keys - set(constants.CONTEXT_FILES.keys())
+            if invalid_dependencies_keys:
+                raise DefinitionError(textwrap.dedent(
+                    f"""
+                    Error: Unknown yaml key(s), {invalid_dependencies_keys}, found in dependencies.\n
+                    Allowed options are:
+                    {list(constants.CONTEXT_FILES.keys())}
+                    """)
+                )
+
+        for item in constants.CONTEXT_FILES:
+            requirement_path = self.get_dep_abs_path(item)
+            if requirement_path:
+                if not os.path.exists(requirement_path):
+                    raise DefinitionError("Dependency file {0} does not exist.".format(requirement_path))
+
+        build_arg_defaults = self.raw.get('build_arg_defaults')
+        if build_arg_defaults:
+            if not isinstance(build_arg_defaults, dict):
+                raise DefinitionError(
+                    f"Error: Unknown type {type(build_arg_defaults)} found for build_arg_defaults; "
+                    f"must be a dict."
+                )
+            unexpected_keys = set(build_arg_defaults.keys()) - set(constants.build_arg_defaults)
+            if unexpected_keys:
+                raise DefinitionError(
+                    f"Keys {unexpected_keys} are not allowed in 'build_arg_defaults'."
+                )
+            for key, value in constants.build_arg_defaults.items():
+                user_value = build_arg_defaults.get(key)
+                if user_value and not isinstance(user_value, str):
+                    raise DefinitionError(
+                        f"Expected build_arg_defaults.{key} to be a string; "
+                        f"Found a {type(user_value)} instead."
+                    )
+
+        additional_cmds = self.get_additional_commands()
+        if additional_cmds:
+            if not isinstance(additional_cmds, dict):
+                raise DefinitionError(textwrap.dedent("""
+                    Expected 'additional_build_steps' in the provided definition file to be a dictionary
+                    with keys 'prepend' and/or 'append'; found a {0} instead.
+                    """).format(type(additional_cmds).__name__))
+
+            expected_keys = frozenset(('append', 'prepend'))
+            unexpected_keys = set(additional_cmds.keys()) - expected_keys
+            if unexpected_keys:
+                raise DefinitionError(
+                    f"Keys {*unexpected_keys,} are not allowed in 'additional_build_steps'."
+                )
+
+        ansible_config_path = self.raw.get('ansible_config')
+        if ansible_config_path:
+            if not isinstance(ansible_config_path, str):
+                raise DefinitionError(textwrap.dedent("""
+                    Expected 'ansible_config' in the provided definition file to
+                    be a string; found a {0} instead.
+                    """).format(type(ansible_config_path).__name__))

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -4,10 +4,7 @@ import pathlib
 import pytest
 
 from ansible_builder import constants
-from ansible_builder.exceptions import DefinitionError
-from ansible_builder.main import (
-    AnsibleBuilder, UserDefinition
-)
+from ansible_builder.main import AnsibleBuilder
 
 
 def test_definition_version(exec_env_definition_file):
@@ -155,66 +152,3 @@ def test_use_dockerfile(exec_env_definition_file, tmp_path, runtime):
         content = f.read()
 
     assert 'FROM' in content
-
-
-class TestDefinitionErrors:
-
-    def test_definition_syntax_error(self, data_dir):
-        path = os.path.join(data_dir, 'definition_files/bad.yml')
-
-        with pytest.raises(DefinitionError) as error:
-            AnsibleBuilder(filename=path)
-
-        assert 'An error occured while parsing the definition file:' in str(error.value.args[0])
-
-    @pytest.mark.parametrize('yaml_text,expect', [
-        ('1', 'Definition must be a dictionary, not int'),  # integer
-        (
-            "{'version': 1, 'dependencies': {'python': 'foo/not-exists.yml'}}",
-            'not-exists.yml does not exist'
-        ),  # missing file
-        (
-            "{'version': 1, 'additional_build_steps': 'RUN me'}",
-            "Expected 'additional_build_steps' in the provided definition file to be a dictionary\n"
-            "with keys 'prepend' and/or 'append'; found a str instead."
-        ),  # not right format for additional_build_steps
-        (
-            "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",
-            "Keys ('middle',) are not allowed in 'additional_build_steps'."
-        ),  # there are no "middle" build steps
-        (
-            "{'version': 1, 'build_arg_defaults': {'EE_BASE_IMAGE': ['foo']}}",
-            "Expected build_arg_defaults.EE_BASE_IMAGE to be a string; Found a <class 'list'> instead."
-        ),  # image itself is wrong type
-        (
-            "{'version': 1, 'build_arg_defaults': {'BUILD_ARRRRRG': 'swashbuckler'}}",
-            "Keys {'BUILD_ARRRRRG'} are not allowed in 'build_arg_defaults'."
-        ),  # image itself is wrong type
-        (
-            "{'version': 1, 'ansible_config': ['ansible.cfg']}",
-            "Expected 'ansible_config' in the provided definition file to\n"
-            "be a string; found a list instead."
-        ),
-        (
-            "{'version': 1, 'foo': 'bar'}",
-            "Error: Unknown yaml key(s), {'foo'}, found in the definition file."
-        ),
-    ], ids=[
-        'integer', 'missing_file', 'additional_steps_format', 'additional_unknown',
-        'build_args_value_type', 'unexpected_build_arg', 'config_type', 'unknown_key'
-    ])
-    def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
-        path = exec_env_definition_file(yaml_text)
-        with pytest.raises(DefinitionError) as exc:
-            definition = UserDefinition(path)
-            definition.validate()
-        if expect:
-            assert expect in exc.value.args[0]
-
-    def test_file_not_found_error(self):
-        path = "exec_env.txt"
-
-        with pytest.raises(DefinitionError) as error:
-            AnsibleBuilder(filename=path)
-
-        assert "Could not detect 'exec_env.txt' file in this directory.\nUse -f to specify a different location." in str(error.value.args[0])

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -1,0 +1,78 @@
+import os
+import pytest
+
+from ansible_builder.exceptions import DefinitionError
+from ansible_builder.main import AnsibleBuilder
+from ansible_builder.user_definition import UserDefinition
+
+
+class TestUserDefinition:
+
+    def test_definition_syntax_error(self, data_dir):
+        path = os.path.join(data_dir, 'definition_files/bad.yml')
+
+        with pytest.raises(DefinitionError) as error:
+            AnsibleBuilder(filename=path)
+
+        assert 'An error occured while parsing the definition file:' in str(error.value.args[0])
+
+    @pytest.mark.parametrize('yaml_text,expect', [
+        ('1', 'Definition must be a dictionary, not int'),  # integer
+        (
+            "{'version': 1, 'dependencies': {'python': 'foo/not-exists.yml'}}",
+            'not-exists.yml does not exist'
+        ),  # missing file
+        (
+            "{'version': 1, 'additional_build_steps': 'RUN me'}",
+            "Expected 'additional_build_steps' in the provided definition file to be a dictionary\n"
+            "with keys 'prepend' and/or 'append'; found a str instead."
+        ),  # not right format for additional_build_steps
+        (
+            "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",
+            "Keys ('middle',) are not allowed in 'additional_build_steps'."
+        ),  # there are no "middle" build steps
+        (
+            "{'version': 1, 'build_arg_defaults': {'EE_BASE_IMAGE': ['foo']}}",
+            "Expected build_arg_defaults.EE_BASE_IMAGE to be a string; Found a <class 'list'> instead."
+        ),  # image itself is wrong type
+        (
+            "{'version': 1, 'build_arg_defaults': {'BUILD_ARRRRRG': 'swashbuckler'}}",
+            "Keys {'BUILD_ARRRRRG'} are not allowed in 'build_arg_defaults'."
+        ),  # image itself is wrong type
+        (
+            "{'version': 1, 'ansible_config': ['ansible.cfg']}",
+            "Expected 'ansible_config' in the provided definition file to\n"
+            "be a string; found a list instead."
+        ),
+        (
+            "{'version': 1, 'foo': 'bar'}",
+            "Error: Unknown yaml key(s), {'foo'}, found in the definition file."
+        ),
+    ], ids=[
+        'integer', 'missing_file', 'additional_steps_format', 'additional_unknown',
+        'build_args_value_type', 'unexpected_build_arg', 'config_type', 'unknown_key'
+    ])
+    def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
+        path = exec_env_definition_file(yaml_text)
+        with pytest.raises(DefinitionError) as exc:
+            definition = UserDefinition(path)
+            definition.validate()
+        if expect:
+            assert expect in exc.value.args[0]
+
+    def test_file_not_found_error(self):
+        path = "exec_env.txt"
+
+        with pytest.raises(DefinitionError) as error:
+            AnsibleBuilder(filename=path)
+
+        assert "Could not detect 'exec_env.txt' file in this directory.\nUse -f to specify a different location." in str(error.value.args[0])
+
+    def test_ee_validated_early(self, exec_env_definition_file):
+        """
+        Expect the EE file to be validated early during AnsibleBuilder instantiation.
+        """
+        path = exec_env_definition_file("{'bad_key': 1}")
+        with pytest.raises(DefinitionError) as error:
+            AnsibleBuilder(filename=path)
+        assert "Error: Unknown yaml key(s), {'bad_key'}, found in the definition file." in str(error.value.args[0])


### PR DESCRIPTION
The user defined EE file was being validated rather late within the first called method of the `Containerfile` class. It can be validated much earlier, right after instantiating the `UserDefinition` object. It's better to do it as early as possible and not rely on calling the correct sequence of methods in another class.

This change moves the `UserDefinition` class to its own source file, and moves the unit tests for this class into a separate unit testing file. Also, a test is added to verify that early EE validation is performed during `AnsibleBuilder` instantiation (`test/unit/test_user_definition.py::test_ee_validated_early()`).