### PR TITLE
Cleanup UserDefinition class

### DIFF
--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -7,7 +7,7 @@ def test_definition_syntax_error(cli, data_dir):
     ee_def = os.path.join(data_dir, 'definition_files', 'invalid.yml')
     r = cli(f'ansible-builder create -f {ee_def}', allow_error=True)
     assert r.rc != 0
-    assert 'An error occured while parsing the definition file' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+    assert 'An error occurred while parsing the definition file' in (r.stdout + r.stderr), (r.stdout + r.stderr)
 
 
 def test_missing_python_requirements_file(cli, data_dir):

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -14,7 +14,7 @@ class TestUserDefinition:
         with pytest.raises(DefinitionError) as error:
             AnsibleBuilder(filename=path)
 
-        assert 'An error occured while parsing the definition file:' in str(error.value.args[0])
+        assert 'An error occurred while parsing the definition file:' in str(error.value.args[0])
 
     @pytest.mark.parametrize('yaml_text,expect', [
         ('1', 'Definition must be a dictionary, not int'),  # integer


### PR DESCRIPTION
Doing some cleanup of the `UserDefinition` class:

- Combine `UserDefinition` with the unnecessary `BaseDefinition` class.
- Convert all strings to f-strings.
- Use more descriptive temp var names instead of `f` and `y`.
- Add missing inline method/property documentation.
- Replace use of `.items()` to iterate through dict keys.
- `ansible_config` property now returns `None` directly instead of just using `pass`.
- Correct spelling error: `occured` -> `occurred`