### PR TITLE
Add --prune-images flag in build command

### DIFF
--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -123,6 +123,12 @@ def add_container_options(parser):
         help='Do not use cache when building the image',
     )
 
+    build_command_parser.add_argument(
+        '--prune-images',
+        action='store_true',
+        help='Remove all dangling images after building the image',
+    )
+
     for p in [create_command_parser, build_command_parser]:
 
         p.add_argument('-f', '--file',

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -22,6 +22,7 @@ class AnsibleBuilder:
                  container_runtime=constants.default_container_runtime,
                  output_filename=None,
                  no_cache=False,
+                 prune_images=False,
                  verbosity=constants.default_verbosity,
                  galaxy_keyring=None,
                  galaxy_required_valid_signature_count=None,
@@ -48,6 +49,7 @@ class AnsibleBuilder:
         self.container_runtime = container_runtime
         self.build_args = build_args or {}
         self.no_cache = no_cache
+        self.prune_images = prune_images
         self.containerfile = Containerfile(
             definition=self.definition,
             build_context=self.build_context,
@@ -95,6 +97,14 @@ class AnsibleBuilder:
         return self.containerfile.write()
 
     @property
+    def prune_image_command(self):
+        command = [
+            self.container_runtime, "image",
+            "prune", "--force"
+        ]
+        return command
+
+    @property
     def build_command(self):
         command = [
             self.container_runtime, "build",
@@ -123,6 +133,9 @@ class AnsibleBuilder:
         logger.debug(f'Ansible Builder is building your execution environment image. Tags: {", ".join(self.tags)}')
         self.write_containerfile()
         run_command(self.build_command)
+        if self.prune_images:
+            logger.debug('Removing all dangling images')
+            run_command(self.prune_image_command)
         return True
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -165,6 +165,21 @@ To customize the level of verbosity:
    $ ansible-builder build --verbosity 2
 
 
+``--prune-images``
+******************
+
+To remove unused images created after the build process:
+
+.. code::
+
+   $ ansible-builder build --prune-images
+
+.. note::
+
+   This flag essentially removes all the dangling images on the given machine whether they
+   already exists or created by ansible-builder build process.
+
+
 The ``create`` command
 ----------------------
 

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -238,3 +238,15 @@ def test_galaxy_signing_extra_args(cli, runtime, data_dir, ee_tag, tmp_path):
 
     assert "--galaxy-ignore-signature-status-code 500" in result.stdout
     assert "--galaxy-required-valid-signature-count 3" in result.stdout
+
+
+@pytest.mark.test_all_runtimes
+def test_prune_images(cli, runtime, ee_tag, tmp_path, data_dir):
+    """Test that the prune-images flag works"""
+    bc = tmp_path
+    ee_def = data_dir / 'blank' / 'execution-environment.yml'
+    result = cli(
+        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} '
+        f'--container-runtime {runtime} --prune-images --verbosity 3'
+    )
+    assert 'Removing all dangling images' in result.stdout

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -49,3 +49,15 @@ def test_build_multiple_tags(exec_env_definition_file, tmp_path):
     # test with 'container' sub-command
     aee = prepare(['build', '--tag', 'TAG1', '--tag', 'TAG2', '-f', path, '-c', str(tmp_path)])
     assert aee.tags == ['TAG1', 'TAG2']
+
+
+def test_build_prune_images(good_exec_env_definition_path, tmp_path):
+    path = str(good_exec_env_definition_path)
+    build_context = str(tmp_path)
+
+    aee_prune_images = prepare(['build', '-f', path, '-c', build_context, '--prune-images'])
+    aee_no_prune_images = prepare(['build', '-f', path, '-c', build_context])
+
+    assert aee_prune_images.prune_images
+    assert 'prune' in aee_prune_images.prune_image_command
+    assert not aee_no_prune_images.prune_images


### PR DESCRIPTION
##### SUMMARY

Added a flag in ansible-builder build command to remove
dangling container images after the build is completed

Fixes: #363

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_builder/cli.py
ansible_builder/main.py
test/unit/test_cli.py
