### PR TITLE
Add min python version to install docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,12 +1,14 @@
 Installation
 ============
 
-In order to build images, you need to have either ``podman`` or ``docker``
-installed as well as the ``ansible-builder`` Python package.
-The ``--container-runtime`` option needs to correspond to the Podman/Docker
-executable you intend to use.
+Requirements
+************
 
-The following sections cover how to install ``ansible-builder``.
+- In order to build images, you need to have either ``podman`` or ``docker``
+  installed as well as the ``ansible-builder`` Python package.
+  The ``--container-runtime`` option needs to correspond to the Podman/Docker
+  executable you intend to use.
+- ``ansible-builder`` version ``1.1.0`` requires Python ``3.8`` or higher.
 
 
 Install from PyPi


### PR DESCRIPTION
Call out the minimum supported python version in the installation documentation.

Fixes #379 