### PR TITLE
Implement ANSIBLE_GALAXY_CLI_ROLE_OPTS

### DIFF
--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -14,6 +14,7 @@ base_collections_path = '/usr/share/ansible/collections'
 
 build_arg_defaults = dict(
     ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='',
+    ANSIBLE_GALAXY_CLI_ROLE_OPTS='',
     EE_BASE_IMAGE='quay.io/ansible/ansible-runner:latest',
     EE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest'
 )

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -284,6 +284,9 @@ class Containerfile:
             "ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS={}".format(
                 self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS']
             ),
+            "ARG ANSIBLE_GALAXY_CLI_ROLE_OPTS={}".format(
+                self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_ROLE_OPTS']
+            ),
             "USER root",
             ""
         ])

--- a/ansible_builder/steps.py
+++ b/ansible_builder/steps.py
@@ -72,7 +72,7 @@ class GalaxyInstallSteps(Steps):
             env = "ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 "
 
         self.steps = [
-            f"RUN ansible-galaxy role install -r {requirements_naming} --roles-path \"{constants.base_roles_path}\"",
+            f"RUN ansible-galaxy role install $ANSIBLE_GALAXY_CLI_ROLE_OPTS -r {requirements_naming} --roles-path \"{constants.base_roles_path}\"",
             f"RUN {env}ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS {install_opts}",
         ]
 

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -39,6 +39,9 @@ Build args used by ``ansible-builder`` are the following:
 The ``ANSIBLE_GALAXY_CLI_COLLECTION_OPTS`` build arg allows the user to pass
 the '--pre' flag to enable the installation of pre-releases collections.
 
+The ``ANSIBLE_GALAXY_CLI_ROLE_OPTS`` build arg allows the user to pass
+the flags to the Role installation.
+
 The ``EE_BASE_IMAGE`` build arg specifies the parent image
 for the execution environment.
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -23,6 +23,14 @@ def test_custom_ansible_galaxy_cli_collection_opts(exec_env_definition_file, tmp
     assert aee.build_args == {'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': '--pre'}
 
 
+def test_custom_ansible_galaxy_cli_role_opts(exec_env_definition_file, tmp_path):
+    content = {'version': 1}
+    path = str(exec_env_definition_file(content=content))
+
+    aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_ROLE_OPTS=--ignore-errors', '-c', str(tmp_path)])
+    assert aee.build_args == {'ANSIBLE_GALAXY_CLI_ROLE_OPTS': '--ignore-errors'}
+
+
 def test_build_context(good_exec_env_definition_path, tmp_path):
     path = str(good_exec_env_definition_path)
     build_context = str(tmp_path)

--- a/test/unit/test_steps.py
+++ b/test/unit/test_steps.py
@@ -22,7 +22,7 @@ def test_additional_build_steps(verb):
 def test_galaxy_install_steps():
     steps = list(GalaxyInstallSteps("requirements.txt", None, [], None))
     expected = [
-        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
+        f"RUN ansible-galaxy role install $ANSIBLE_GALAXY_CLI_ROLE_OPTS -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
 
         f"RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy collection install "
         f"$ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt --collections-path \"{constants.base_collections_path}\""
@@ -33,7 +33,7 @@ def test_galaxy_install_steps():
 def test_galaxy_install_steps_with_keyring():
     steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name, [], None))
     expected = [
-        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
+        f"RUN ansible-galaxy role install $ANSIBLE_GALAXY_CLI_ROLE_OPTS -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
 
         f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
         f"--collections-path \"{constants.base_collections_path}\" --keyring \"{constants.default_keyring_name}\""
@@ -45,7 +45,7 @@ def test_galaxy_install_steps_with_sig_count():
     sig_count = 3
     steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name, [], sig_count))
     expected = [
-        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
+        f"RUN ansible-galaxy role install $ANSIBLE_GALAXY_CLI_ROLE_OPTS -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
 
         f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
         f"--collections-path \"{constants.base_collections_path}\" --required-valid-signature-count {sig_count} "
@@ -58,7 +58,7 @@ def test_galaxy_install_steps_with_ignore_code():
     codes = [1, 2]
     steps = list(GalaxyInstallSteps("requirements.txt", constants.default_keyring_name, codes, None))
     expected = [
-        f"RUN ansible-galaxy role install -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
+        f"RUN ansible-galaxy role install $ANSIBLE_GALAXY_CLI_ROLE_OPTS -r requirements.txt --roles-path \"{constants.base_roles_path}\"",
 
         f"RUN ansible-galaxy collection install $ANSIBLE_GALAXY_CLI_COLLECTION_OPTS -r requirements.txt "
         f"--collections-path \"{constants.base_collections_path}\" --ignore-signature-status-code {codes[0]} "


### PR DESCRIPTION
##### SUMMARY

Allow users to pass ansible-galaxy role arguments
which might be required for installing roles.

Fixes: #392

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_builder/constants.py
ansible_builder/main.py
ansible_builder/steps.py
docs/definition.rst
test/unit/test_cli.py
test/unit/test_steps.py
