### PR TITLE
only run pulp tests when registry secrets are available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,24 @@ jobs:
       - name: Run tests
         run: tox
 
+  secrets_preflight:
+    runs-on: ubuntu-20.04
+    name: Secrets pre-flight check
+    steps:
+      - id: has_secrets
+        run: |
+          echo "::set-output name=has_secrets::${{ secrets.RH_REGISTRY_USER && secrets.RH_REGISTRY_PASSWORD }}"
+    outputs:
+      has_secrets: ${{ steps.has_secrets.outputs.has_secrets }}
+
 
   pulp_integration:
     runs-on: ubuntu-20.04
     name: Pulp Integration - ${{ matrix.py_version.name }}
+    # NB: running this job requires access to an RH registry token; PRs can't currently access the main repo secret,
+    # so forks will need to define the secrets locally to run these tests pre-merge
+    needs: secrets_preflight
+    if: needs.secrets_preflight.outputs.has_secrets == 'true'
 
     env:
       TOXENV: ${{ matrix.py_version.tox_env }}


### PR DESCRIPTION
Since GHA doesn't allow access to secrets to forks *at all* in PRs (regardless if the fork itself defines the secret), job(s) that require secrets access need to be conditional and best-effort (to avoid failing those jobs on all PRs and any forks that don't have the secrets). 
