### PR TITLE
Check minimum Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,5 @@ from setuptools import setup
 setup(
     setup_requires=['pbr'],
     pbr=True,
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
##### SUMMARY

* Ansible builder supports Python 3.8 and above. Added a check
  for minimum Python version checking.

Fixes: #407

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.py
