### PR TITLE
Docs: Use the Ansible Sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ def _get_version():
 # ones.
 extensions = [
     'sphinx.ext.autosectionlabel',
+    "sphinx_ansible_theme",
     'pbr.sphinxext',
 ]
 
@@ -69,7 +70,7 @@ version = _get_version()
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -88,13 +89,18 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_ansible_theme'
+html_title = "Ansible Builder Documentation"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'display_version': False,
+    'titles_only': False,
+    'documentation_home_url': 'https://ansible-builder.readthedocs.io/en/latest/',
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,22 +4,23 @@ certifi==2021.10.8
 charset-normalizer==2.0.7
 docutils==0.17.1
 idna==3.3
-imagesize==1.2.0
+imagesize==1.3.0
 Jinja2==3.0.2
 MarkupSafe==2.0.1
 packaging==21.0
 pbr==5.6.0
-Pygments==2.10.0
+Pygments==2.12.0
 pyparsing==3.0.3
 pytz==2021.3
 requests==2.26.0
 six==1.16.0
 snowballstemmer==2.1.0
-Sphinx==4.2.0
+Sphinx==5.3.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+sphinx-ansible-theme == 0.10.1
 urllib3==1.26.7


### PR DESCRIPTION
This PR updates the Sphinx configuration to use the Ansible theme.

The Ansible community team recently updated the docsite and included Builder on the new [ecosystem](https://docs.ansible.com/ecosystem.html) page. We're working to create a more cohesive user experience for the Ansible community and noticed that this project could start using the Ansible Sphinx theme with a pretty straightforward change.