### PR TITLE
Update yamllint config for new 1.29.0 version

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -14,6 +14,9 @@ rules:
     level: error
   line-length: disable
   document-start: disable
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
   truthy:
     allowed-values:
       - 'True'


### PR DESCRIPTION
The `yamllint` lib was updated recently and now causes linting errors in one of our test yaml files. This updates the config to have yamllint not complain as long as spacing is consistent within yaml files, rather than complaining about an arbitrary default number of indentation spaces. See https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.indentation for discussion of the new options.