### PR TITLE
Only add some steps if EE_BUILDER_IMAGE is defined

### DIFF
--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -265,10 +265,13 @@ class Containerfile:
             "ARG EE_BASE_IMAGE={}".format(
                 self.definition.build_arg_defaults['EE_BASE_IMAGE']
             ),
-            "ARG EE_BUILDER_IMAGE={}".format(
-                self.definition.build_arg_defaults['EE_BUILDER_IMAGE']
-            ),
         ]
+        if self.definition.build_arg_defaults['EE_BUILDER_IMAGE']:
+            self.steps.extend([
+                "ARG EE_BUILDER_IMAGE={}".format(
+                    self.definition.build_arg_defaults['EE_BUILDER_IMAGE']
+                )
+            ])
 
     def create_folder_copy_files(self):
         """Creates the build context file for this Containerfile
@@ -367,12 +370,13 @@ class Containerfile:
         return self.steps
 
     def prepare_system_runtime_deps_steps(self):
-        self.steps.extend([
-            "COPY --from=builder /output/ /output/",
-            "RUN /output/install-from-bindep && rm -rf /output/wheels",
-        ])
+        if self.definition.build_arg_defaults['EE_BUILDER_IMAGE']:
+            self.steps.extend([
+                "COPY --from=builder /output/ /output/",
+                "RUN /output/install-from-bindep && rm -rf /output/wheels",
+            ])
 
-        return self.steps
+            return self.steps
 
     def prepare_galaxy_stage_steps(self):
         self.steps.extend([
@@ -391,13 +395,14 @@ class Containerfile:
         return self.steps
 
     def prepare_build_stage_steps(self):
-        self.steps.extend([
-            "",
-            "FROM $EE_BUILDER_IMAGE as builder"
-            "",
-        ])
+        if self.definition.build_arg_defaults['EE_BUILDER_IMAGE']:
+            self.steps.extend([
+                "",
+                "FROM $EE_BUILDER_IMAGE as builder"
+                "",
+            ])
 
-        return self.steps
+            return self.steps
 
     def prepare_final_stage_steps(self):
         self.steps.extend([


### PR DESCRIPTION
I wanted to take a base image and then just add a couple of prepend steps to add some downloadable executables. So I did not define an `EE_BUILDER_IAMGE` (since nothing new was going to be built). When I did this I got errors because some of the steps in the `context/Containerfile` assumed I would have a build image. This change prevents these lines from making it into the file if `EE_BUILDER_IMAGE` is not defined.

To reproduce, create a builder file like:
```
---
version: 2

additional_build_steps:
  append:
    - RUN curl -L -o /usr/local/bin/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v1.27.0/operator-sdk_linux_amd64
    - RUN chmod +x /usr/local/bin/operator-sdk
    - RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s /usr/local/bin
    - RUN curl --output - https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.9/opm-linux.tar.gz | tar -xzv --directory /usr/local/bin

images:
  base_image:
    name: quay.io/ansible/awx-ee:latest
```

Run: `ansible-builder build -f operator_hub_release.yml --tag quay.io/rhn_gps_jowestco/operator-hub-ee`

At first you should get the following error because EE_BUILDER_IMAGE is `None`:
```
podman build -f context/Containerfile -t quay.io/rhn_gps_jowestco/operator-hub-ee context
[1/3] STEP 1/4: FROM quay.io/ansible/awx-ee:latest AS galaxy
[1/3] STEP 2/4: ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=
--> Using cache 9139fb655e1886da23b7a5c74d44d84fd55b5e1067d7753e3d54b3a7636a95b7
--> 9139fb655e1
[1/3] STEP 3/4: ARG ANSIBLE_GALAXY_CLI_ROLE_OPTS=
--> Using cache 9827f677dd161bb2ad88ed30602d4d8f3caa67cc023ce1e69408d57d7d28d838
--> 9827f677dd1
[1/3] STEP 4/4: USER root
--> Using cache 174abd59005ddd1bb6bcf60bdc03b517c8af64abb37bb8258b5d66a9158c2de6
--> 174abd59005
[2/3] STEP 1/1: FROM None AS builder
Error: error creating build container: repository name must be lowercase

An error occured (rc=125), see output line(s) above for details.
```

You can then add these if conditions one at a time until you can build the image successfully.

When I started going down the route of trying to add a `EE_BUILD_IMAGE` I was then getting errors because the dependency files were missing or empty.