### PR TITLE
Make sure default images are used with EE v2 schema

### DIFF
--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -189,8 +189,11 @@ class UserDefinition:
             self.builder_image = ImageDescription(images, 'builder_image')
 
             # Must set these values so that Containerfile uses the proper images
-            self.build_arg_defaults['EE_BASE_IMAGE'] = self.base_image.name
-            self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
+            if self.base_image.name:
+                self.build_arg_defaults['EE_BASE_IMAGE'] = self.base_image.name
+
+            if self.builder_image.name:
+                self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
 
     def _validate_v1(self):
         """


### PR DESCRIPTION
When version 2 of the execution environment format was being used, the base and builder images were not using the defaults if one of those values was missing from the `images` section.

Note: If the `images` section was not supplied at all, the defaults were used.

Fixes #454 