### PR TITLE
Remove set-output syntax in GH workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - id: has_secrets
         if: ${{ env.secret_user != '' && env.secret_pass != '' }}
         run: |
-          echo "has_secrets::${{ true }}" >> $GITHUB_OUTPUT
+          echo "has_secrets=${{ true }}" >> $GITHUB_OUTPUT
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.has_secrets }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - id: has_secrets
         if: ${{ env.secret_user != '' && env.secret_pass != '' }}
         run: |
-          echo "::set-output name=has_secrets::${{ true }}"
+          echo "has_secrets::${{ true }}" >> $GITHUB_OUTPUT
     outputs:
       has_secrets: ${{ steps.has_secrets.outputs.has_secrets }}
 


### PR DESCRIPTION
##### SUMMARY

* Use a new set of environment files to manage state
  and output provided by GH.

Fixes: #458

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
.github/workflows/ci.yml
