### PR TITLE
Normalize package names with lowercase

### DIFF
--- a/ansible_builder/_target_scripts/introspect.py
+++ b/ansible_builder/_target_scripts/introspect.py
@@ -5,7 +5,7 @@ import sys
 import yaml
 
 import requirements
-from pkg_resources import safe_name
+import importlib.metadata
 
 base_collections_path = '/usr/share/ansible/collections'
 default_file = 'execution-environment.yml'
@@ -330,7 +330,7 @@ def sanitize_requirements(collection_py_reqs):
         try:
             for req in requirements.parse('\n'.join(lines)):
                 if req.specifier:
-                    req.name = safe_name(req.name)
+                    req.name = importlib.metadata.Prepared(req.name).normalized
                 req.collections = [collection]  # add backref for later
                 if req.name is None:
                     consolidated.append(req)

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 import os
-import pkg_resources
+import importlib.metadata
 
 from . import constants
 
@@ -43,7 +43,7 @@ def run():
 
 
 def get_version():
-    return pkg_resources.get_distribution('ansible_builder').version
+    return importlib.metadata.version('ansible_builder')
 
 
 def add_container_options(parser):

--- a/ansible_builder/requirements.py
+++ b/ansible_builder/requirements.py
@@ -1,6 +1,6 @@
 import logging
 import requirements
-from pkg_resources import safe_name
+import importlib.metadata
 
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ def sanitize_requirements(collection_py_reqs):
         try:
             for req in requirements.parse('\n'.join(lines)):
                 if req.specifier:
-                    req.name = safe_name(req.name)
+                    req.name = importlib.metadata.Prepared(req.name).normalized
                 req.collections = [collection]  # add backref for later
                 if req.name is None:
                     consolidated.append(req)

--- a/test/data/ansible_collections/other/reqfile/requirements.txt
+++ b/test/data/ansible_collections/other/reqfile/requirements.txt
@@ -1,1 +1,2 @@
 python_dateutil    # intentional underscore
+Jinja2    # intentional uppercase

--- a/test/data/ansible_collections/test/reqfile/requirements.txt
+++ b/test/data/ansible_collections/test/reqfile/requirements.txt
@@ -1,3 +1,4 @@
 pytz
 python-dateutil>=2.8.2    # intentional dash
+jinja2>=3.0    # intentional lowercase
 -r extra_req.txt

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -36,6 +36,7 @@ def test_introspect_write_python(cli, data_dir, tmp_path):
         'pyvcloud>=14  # from collection test.metadata',
         'pytz  # from collection test.reqfile',
         'python-dateutil>=2.8.2  # from collection test.reqfile',
+        'jinja2>=3.0  # from collection test.reqfile',
         'tacacs_plus  # from collection test.reqfile',
         'pyvcloud>=18.0.10  # from collection test.reqfile',
         '',
@@ -49,8 +50,9 @@ def test_introspect_write_python_and_sanitize(cli, data_dir, tmp_path):
     assert dest_file.read_text() == '\n'.join([
         'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
         'pytz  # from collection test.reqfile',
-        'python-dateutil>=2.8.2  # from collection test.reqfile',
-        'tacacs-plus  # from collection test.reqfile',
+        'python_dateutil>=2.8.2  # from collection test.reqfile',
+        'jinja2>=3.0  # from collection test.reqfile',
+        'tacacs_plus  # from collection test.reqfile',
         '',
     ])
 

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -15,8 +15,11 @@ def test_multiple_collection_metadata(data_dir):
         'pytz  # from collection test.reqfile',
         # python-dateutil should appear only once even though referenced in
         # multiple places, once with a dash and another with an underscore in the name.
-        'python-dateutil>=2.8.2  # from collection test.reqfile',
-        'tacacs-plus  # from collection test.reqfile'
+        'python_dateutil>=2.8.2  # from collection test.reqfile',
+        # jinja2 should appear only once even though referenced in multiple
+        # places, once with uppercase and another with lowercase in the name.
+        'jinja2>=3.0  # from collection test.reqfile',
+        'tacacs_plus  # from collection test.reqfile'
     ], 'system': [
         'subversion [platform:rpm]  # from collection test.bindep',
         'subversion [platform:dpkg]  # from collection test.bindep'


### PR DESCRIPTION
When a python package is listed multiple time but with uppercase/lowercase changes then introspect sanitization won't handle it. In db9e74a, only the underscore/dash scenario has been solved. As a result, the assemble script will fail with a double requirement error.

```console
ERROR: Double requirement given: Jinja2==3.0.3 (from -r /tmp/src/requirements.txt (line 40)) (already in jinja2>=2.8 (from -r /tmp/src/requirements.txt (line 12)), name='Jinja2')
```

While this isn't an issue for recent pip version, older versions with python 3.8 and 3.9 runtimes on RHEL 8 based distributions are affected by this.

This replaces the setuptools runtime usage by importlib.metadata which provides builtin method to normalize package names.

Unlike pkg_resources.safe_name, the dash character is changed to underscore.

Closes: #408

https://packaging.python.org/en/latest/specifications/name-normalization