### PR TITLE
Change ansible_core/ansible_runner schema types

### DIFF
--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -71,7 +71,7 @@ class Containerfile:
         self._insert_custom_steps('prepend_base')
 
         if not self.definition.builder_image:
-            if self.definition.python_package_name:
+            if self.definition.python_package_system:
                 self.steps.append('RUN $PKGMGR install $PYPKG -y && $PKGMGR clean all')
 
             # We should always make sure pip is available for later stages.
@@ -188,7 +188,7 @@ class Containerfile:
             'EE_BASE_IMAGE': self.definition.build_arg_defaults['EE_BASE_IMAGE'],
             'EE_BUILDER_IMAGE': self.definition.build_arg_defaults['EE_BUILDER_IMAGE'],
             'PYCMD': self.definition.python_path or '/usr/bin/python3',
-            'PYPKG': self.definition.python_package_name,
+            'PYPKG': self.definition.python_package_system,
             'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS'],
             'ANSIBLE_GALAXY_CLI_ROLE_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_ROLE_OPTS'],
             'ANSIBLE_INSTALL_REFS': self.definition.ansible_ref_install_list,

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -217,8 +217,8 @@ schema_v3 = {
                     "type": "object",
                     "additionalProperties": False,
                     "properties": {
-                        "package_name": {
-                            "description": "The python package to install",
+                        "package_system": {
+                            "description": "The python package to install via system package manager",
                             "type": "string",
                         },
                         "python_path": {

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -228,12 +228,34 @@ schema_v3 = {
                     },
                 },
                 "ansible_core": {
-                    "description": "Ansible version for pip installation",
-                    "type": "string",
+                    "description": "Ansible package installation",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "package_pip": {
+                            "description": "Ansible package to install via pip",
+                            "type": "string",
+                        },
+                    },
+                    "oneOf": [
+                        # more to be added later
+                        {"required": ["package_pip"]},
+                    ],
                 },
                 "ansible_runner": {
-                    "description": "Ansible Runner version for pip installation",
-                    "type": "string",
+                    "description": "Ansible Runner package installation",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "package_pip": {
+                            "description": "Ansible Runner package to install via pip",
+                            "type": "string",
+                        },
+                    },
+                    "oneOf": [
+                        # more to be added later
+                        {"required": ["package_pip"]},
+                    ],
                 },
             },
         },

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -128,8 +128,8 @@ class UserDefinition:
         return self.raw.get('additional_build_steps')
 
     @property
-    def python_package_name(self):
-        return self.raw.get('dependencies', {}).get('python_interpreter', {}).get('package_name', None)
+    def python_package_system(self):
+        return self.raw.get('dependencies', {}).get('python_interpreter', {}).get('package_system', None)
 
     @property
     def python_path(self):

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -137,11 +137,11 @@ class UserDefinition:
 
     @property
     def ansible_core_ref(self):
-        return self.raw.get('dependencies', {}).get('ansible_core', None)
+        return self.raw.get('dependencies', {}).get('ansible_core', {}).get('package_pip', None)
 
     @property
     def ansible_runner_ref(self):
-        return self.raw.get('dependencies', {}).get('ansible_runner', None)
+        return self.raw.get('dependencies', {}).get('ansible_runner', {}).get('package_pip', None)
 
     @property
     def ansible_ref_install_list(self):

--- a/demo/v3_demo/execution-environment.yml
+++ b/demo/v3_demo/execution-environment.yml
@@ -14,7 +14,7 @@ images:
 
 dependencies:
   python_interpreter:
-    package_name: python39
+    package_system: python39
     python_path: /usr/bin/python3.9
 
   ansible_core:

--- a/demo/v3_demo/execution-environment.yml
+++ b/demo/v3_demo/execution-environment.yml
@@ -17,9 +17,11 @@ dependencies:
     package_name: python39
     python_path: /usr/bin/python3.9
 
-  ansible_core: https://github.com/ansible/ansible/archive/refs/tags/v2.13.2.tar.gz   # install from a GH ref tarball
+  ansible_core:
+    package_pip: https://github.com/ansible/ansible/archive/refs/tags/v2.13.2.tar.gz   # install from a GH ref tarball
 
-  ansible_runner: ansible-runner==2.2.1   # install from PyPI
+  ansible_runner:
+    package_pip: ansible-runner==2.2.1   # install from PyPI
 
   # FIXME: inline splat-as-string sucks, make separate keys for collections and roles
   galaxy: |

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -194,7 +194,7 @@ The following keys are valid for this section:
 
     ``python_interpreter``
       A dictionary that defines the Python system package name to be installed by
-      dnf (``package_name``) and/or a path to the Python interpreter to be used
+      dnf (``package_system``) and/or a path to the Python interpreter to be used
       (``python_path``).
 
     ``system``
@@ -214,7 +214,7 @@ The following example uses filenames that contain the various dependencies:
         ansible_runner:
             package_pip: ansible-runner==2.3.1
         python_interpreter:
-            package_name: "python310"
+            package_system: "python310"
             python_path: "/usr/bin/python3.10"
 
 And this example uses inline values:
@@ -235,7 +235,7 @@ And this example uses inline values:
         ansible_runner:
             package_pip: ansible-runner==2.3.1
         python_interpreter:
-            package_name: "python310"
+            package_system: "python310"
             python_path: "/usr/bin/python3.10"
 
 .. note::

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -32,6 +32,10 @@ Below is an example version 3 EE file:
       ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: '--pre'
 
     dependencies:
+      ansible_core:
+        package_pip: ansible-core==2.14.4
+      ansible_runner:
+        package_pip: ansible-runner
       galaxy: requirements.yml
       python:
         - six
@@ -152,25 +156,33 @@ The following keys are valid for this section:
 
     ``ansible_core``
       The version of the Ansible python package to be installed. This value is
-      passed directly to `pip` for installation and can be in any format that
+      a dictionary with a single key, ``package_pip``. The ``package_pip`` value
+      is passed directly to `pip` for installation and can be in any format that
       pip supports. Below are some example values:
 
       .. code:: yaml
 
-        ansible_core: ansible-core
-        ansible_core: ansible-core==2.14.3
-        ansible_core: https://github.com/example_user/ansible/archive/refs/heads/ansible.tar.gz
+        ansible_core:
+            package_pip: ansible-core
+        ansible_core:
+            package_pip: ansible-core==2.14.3
+        ansible_core:
+            package_pip: https://github.com/example_user/ansible/archive/refs/heads/ansible.tar.gz
 
     ``ansible_runner``
-      The version of the Ansible Runner python package to be installed. This value is
-      passed directly to `pip` for installation and can be in any format that
+      The version of the Ansible Runner python package to be installed. This value
+      is a dictionary with a single key, ``package_pip``. The ``package_pip`` value
+      is passed directly to `pip` for installation and can be in any format that
       pip supports. Below are some example values:
 
       .. code:: yaml
 
-        ansible_runner: ansible-runner
-        ansible_runner: ansible-runner==2.3.2
-        ansible_runner: https://github.com/example_user/ansible-runner/archive/refs/heads/ansible-runner.tar.gz
+        ansible_runner:
+            package_pip: ansible-runner
+        ansible_runner:
+            package_pip: ansible-runner==2.3.2
+        ansible_runner:
+            package_pip: https://github.com/example_user/ansible-runner/archive/refs/heads/ansible-runner.tar.gz
 
     ``galaxy``
       Galaxy installation requirements. This may either be a filename, or a string
@@ -197,8 +209,10 @@ The following example uses filenames that contain the various dependencies:
         python: requirements.txt
         system: bindep.txt
         galaxy: requirements.yml
-        ansible_core: ansible-core==2.14.2
-        ansible_runner: ansible-runner==2.3.1
+        ansible_core:
+            package_pip: ansible-core==2.14.2
+        ansible_runner:
+            package_pip: ansible-runner==2.3.1
         python_interpreter:
             package_name: "python310"
             python_path: "/usr/bin/python3.10"
@@ -216,8 +230,10 @@ And this example uses inline values:
           collections:
             - community.windows
             - ansible.utils
-        ansible_core: ansible-core==2.14.2
-        ansible_runner: ansible-runner==2.3.1
+        ansible_core:
+            package_pip: ansible-core==2.14.2
+        ansible_runner:
+            package_pip: ansible-runner==2.3.1
         python_interpreter:
             package_name: "python310"
             python_path: "/usr/bin/python3.10"

--- a/test/data/v3/check_ansible/ee-missing-ansible.yml
+++ b/test/data/v3/check_ansible/ee-missing-ansible.yml
@@ -6,7 +6,8 @@ images:
     name: localhost:8080/testrepo/ubi-minimal:latest
 
 dependencies:
-  ansible_runner: ansible_runner
+  ansible_runner:
+    package_pip: ansible-runner
   python_interpreter:
     package_name: python3
 

--- a/test/data/v3/check_ansible/ee-missing-ansible.yml
+++ b/test/data/v3/check_ansible/ee-missing-ansible.yml
@@ -9,7 +9,7 @@ dependencies:
   ansible_runner:
     package_pip: ansible-runner
   python_interpreter:
-    package_name: python3
+    package_system: python3
 
 options:
   package_manager_path: /usr/bin/microdnf

--- a/test/data/v3/check_ansible/ee-missing-runner.yml
+++ b/test/data/v3/check_ansible/ee-missing-runner.yml
@@ -9,7 +9,7 @@ dependencies:
   ansible_core:
     package_pip: ansible-core
   python_interpreter:
-    package_name: python3
+    package_system: python3
 
 options:
   package_manager_path: /usr/bin/microdnf

--- a/test/data/v3/check_ansible/ee-missing-runner.yml
+++ b/test/data/v3/check_ansible/ee-missing-runner.yml
@@ -6,7 +6,8 @@ images:
     name: localhost:8080/testrepo/ubi-minimal:latest
 
 dependencies:
-  ansible_core: ansible_core
+  ansible_core:
+    package_pip: ansible-core
   python_interpreter:
     package_name: python3
 

--- a/test/data/v3/check_ansible/ee-skip.yml
+++ b/test/data/v3/check_ansible/ee-skip.yml
@@ -7,7 +7,7 @@ images:
 
 dependencies:
   python_interpreter:
-    package_name: python3
+    package_system: python3
 
 options:
   skip_ansible_check: True

--- a/test/data/v3/complete/ee.yml
+++ b/test/data/v3/complete/ee.yml
@@ -10,8 +10,10 @@ build_arg_defaults:
   ANSIBLE_GALAXY_CLI_ROLE_OPTS: '--bar'
 
 dependencies:
-  ansible_core: ansible-core==2.13
-  ansible_runner: ansible-runner==2.3.1
+  ansible_core:
+    package_pip: ansible-core==2.13
+  ansible_runner:
+    package_pip: ansible-runner==2.3.1
   python_interpreter:
     package_name: "mypython3"
     python_path: "/usr/local/bin/mypython"

--- a/test/data/v3/complete/ee.yml
+++ b/test/data/v3/complete/ee.yml
@@ -15,7 +15,7 @@ dependencies:
   ansible_runner:
     package_pip: ansible-runner==2.3.1
   python_interpreter:
-    package_name: "mypython3"
+    package_system: "mypython3"
     python_path: "/usr/local/bin/mypython"
   galaxy: |
     collections:

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -161,7 +161,14 @@ class TestUserDefinition:
 
     def test_v3_ansible_install_refs(self, exec_env_definition_file):
         path = exec_env_definition_file(
-            "{'version': 3, 'dependencies': {'ansible_core': 'ansible-core==2.13', 'ansible_runner': 'ansible-runner==2.3.1'}}"
+            """
+            {'version': 3,
+             'dependencies': {
+                'ansible_core': {'package_pip': 'ansible-core==2.13'},
+                'ansible_runner': { 'package_pip': 'ansible-runner==2.3.1'}
+             }
+            }
+            """
         )
         definition = UserDefinition(path)
         definition.validate()


### PR DESCRIPTION
Changes `dependencies.ansible_core` and `dependencies.ansible_runner` from string type to a dict. This dict can/will contain keys specific to different installation types. Currently, only pip installation (`package_pip` subkey) is supported.