### PR TITLE
Add PIP_OPTS on build_arg_defaults

### DIFF
--- a/ansible_builder/constants.py
+++ b/ansible_builder/constants.py
@@ -16,7 +16,8 @@ build_arg_defaults = dict(
     ANSIBLE_GALAXY_CLI_COLLECTION_OPTS='',
     ANSIBLE_GALAXY_CLI_ROLE_OPTS='',
     EE_BASE_IMAGE='quay.io/ansible/ansible-runner:latest',
-    EE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest'
+    EE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest',
+    PIP_OPTS=''
 )
 
 user_content_subfolder = '_build'

--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -192,6 +192,7 @@ class Containerfile:
             'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS'],
             'ANSIBLE_GALAXY_CLI_ROLE_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_ROLE_OPTS'],
             'ANSIBLE_INSTALL_REFS': self.definition.ansible_ref_install_list,
+            'PIP_OPTS': self.definition.build_arg_defaults['PIP_OPTS'],
         }
 
         if self.definition.version >= 3:


### PR DESCRIPTION
Team,

this pull request add support to `PIP_OPTS ` on `build_arg_defaults`, as suggested in this #211.

So with this implementation we can fix it and allow us to use `PIP_OPTS ` option.

One things related why we need this.
I notice, as the same in the AWX matrix channel shared, that after upgrade of PIP to >21 the resolve dependecies is very slow and pip try to download each package release for each package passed on `requirements.txt`.

One of the workaround at this moment is to use the param `--use-deprecated=legacy-resolver` that will use "old style" of repo dependecies.

Other way to resolve this is to put a release of every package passed (that can be under our control) and all package requirement of each collection, but we need manually resolve dependecies.

In any case this is an option present in `assemble` that can be usefull for everybody tht requires special opts on pip.