### PR TITLE
Do not build local builder image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,6 @@ jobs:
 
       - name: Run integration tests
         run: |
-          docker build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
-          podman build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
           tox
 
       - name: Upload coverage report


### PR DESCRIPTION
Since we no longer publish quay.io images, it's no longer realistic to build a local builder image to use in tests. Just allow the tests to pull the builder image from quay.

Also removes the test dependency on centos:stream9, which is currently broken.