### PR TITLE
Add Python 3.11 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,15 @@ jobs:
   sanity:
     name: ${{ matrix.test.name }}
     runs-on: ubuntu-22.04
-    container:
-      image: quay.io/ansible/ansible-builder-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        TOXENV: ${{ matrix.test.tox_env }}
+    env:
+      TOXENV: ${{ matrix.test.tox_env }}
 
     strategy:
       fail-fast: false
       matrix:
         test:
           - name: Lint
-            tox_env: linters-py39
+            tox_env: linters-py310
 
           - name: Docs
             tox_env: docs
@@ -28,6 +25,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install tox
 
       - name: Create tox environment
         run: tox --notest
@@ -119,6 +121,8 @@ jobs:
           - name: '3.10'
             tox_env: integration-py310
 
+          - name: '3.11'
+            tox_env: integration-py311
 
     steps:
       - name: Checkout
@@ -143,20 +147,16 @@ jobs:
           tox
 
       - name: Upload coverage report
-        run: |
-          curl --silent --show-error --output codecov https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/linux/codecov
-          chmod +x codecov
-          ./codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
-
+        uses: codecov/codecov-action@v3
+        with:
+          files: test/coverage/reports/coverage.xml
+          flags: ${{ matrix.py_version.tox_env }}
 
   unit:
     name: Unit - ${{ matrix.py_version.name}}
     runs-on: ubuntu-22.04
-    container:
-      image: quay.io/ansible/ansible-builder-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        TOXENV: ${{ matrix.py_version.tox_env }}
+    env:
+      TOXENV: ${{ matrix.py_version.tox_env }}
 
     strategy:
       fail-fast: false
@@ -168,9 +168,22 @@ jobs:
           - name: '3.10'
             tox_env: unit-py310
 
+          - name: '3.11'
+            tox_env: unit-py311
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install Python ${{ matrix.py_version.name }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.py_version.name }}
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install tox
 
       - name: Create tox environment
         run: tox --notest
@@ -179,4 +192,7 @@ jobs:
         run: tox
 
       - name: Upload coverage report
-        run: codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: test/coverage/reports/coverage.xml
+          flags: ${{ matrix.py_version.tox_env }}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     -r {toxinidir}/test/requirements.txt
 commands = pytest {posargs}
 
-[testenv:linters{,-py39,-py310}]
+[testenv:linters{,-py39,-py310,-py311}]
 description = Run code linters
 commands =
     flake8 --version
@@ -18,11 +18,11 @@ commands =
     yamllint -s .
     mypy ansible_builder
 
-[testenv:unit{,-py39,-py310}]
+[testenv:unit{,-py39,-py310,-py311}]
 description = Run unit tests
 commands = pytest {posargs:test/unit}
 
-[testenv:pulp-integration{,-py310}]
+[testenv:pulp-integration{-py39,-py310,-py311}]
 # Some of these tests must run serially because of a shared resource
 # (the system policy.json file).
 description = Run pulp integration tests
@@ -30,7 +30,7 @@ commands =
     pytest -n 1 -m "serial" {posargs:test/pulp_integration}
     pytest -m "not serial" {posargs:test/pulp_integration}
 
-[testenv:integration{,-py39,-py310}]
+[testenv:integration{,-py39,-py310,-py311}]
 description = Run integration tests
 # rootless podman reads $HOME
 passenv =


### PR DESCRIPTION
- Adds testing for Python 3.11
- Removes usage of the test container (actually speeds up unit tests)
- Replaces codecov portion with a GH action

Closes #473 