### PR TITLE
Update 1.2 CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,15 @@ jobs:
   sanity:
     name: ${{ matrix.test.name }}
     runs-on: ubuntu-20.04
-    container:
-      image: quay.io/ansible/ansible-builder-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        TOXENV: ${{ matrix.test.tox_env }}
+    env:
+      TOXENV: ${{ matrix.test.tox_env }}
 
     strategy:
       fail-fast: false
       matrix:
         test:
           - name: Lint
-            tox_env: linters
+            tox_env: linters-py38
 
           - name: Docs
             tox_env: docs
@@ -28,6 +25,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install tox
 
       - name: Create tox environment
         run: tox --notest
@@ -143,15 +145,13 @@ jobs:
 
       - name: Run integration tests
         run: |
-          docker build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
-          podman build --rm=true -t quay.io/ansible/ansible-builder -f Containerfile .
           tox
 
       - name: Upload coverage report
-        run: |
-          curl --silent --show-error --output codecov https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/linux/codecov
-          chmod +x codecov
-          ./codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: test/coverage/reports/coverage.xml
+          flags: ${{ matrix.py_version.tox_env }}
 
 
   unit:
@@ -180,6 +180,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install Python ${{ matrix.py_version.name }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.py_version.name }}
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install tox
+
       - name: Create tox environment
         run: tox --notest
 
@@ -187,4 +197,7 @@ jobs:
         run: tox
 
       - name: Upload coverage report
-        run: codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: test/coverage/reports/coverage.xml
+          flags: ${{ matrix.py_version.tox_env }}

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -92,7 +92,7 @@ def test_build_command(exec_env_definition_file, runtime):
     content = {'version': 1}
     path = exec_env_definition_file(content=content)
 
-    aee = AnsibleBuilder(filename=path, tag='my-custom-image')
+    aee = AnsibleBuilder(filename=path, tag=['my-custom-image'])
     command = aee.build_command
     assert 'build' and 'my-custom-image' in command
 
@@ -100,7 +100,8 @@ def test_build_command(exec_env_definition_file, runtime):
 
     command = aee.build_command
     assert 'foo/bar/path' in command
-    assert 'foo/bar/path/Dockerfile' in " ".join(command)
+    fpath = 'foo/bar/path/' + constants.runtime_files[runtime]
+    assert fpath in " ".join(command)
 
 
 def test_nested_galaxy_file(data_dir, tmp_path):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     -r {toxinidir}/test/requirements.txt
 commands = pytest {posargs}
 
-[testenv:linters]
+[testenv:linters{,-py38,-py39,-py310}]
 description = Run code linters
 commands =
     flake8 --version


### PR DESCRIPTION
- Removes use of the test container
- Updates codecov portion to use GH Action
- Use quay.io containers for integration tests instead of building our own
- Fixes to `test_build_command` test