### PR TITLE
Pass full path while copying

### DIFF
--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -241,7 +241,7 @@ class Containerfile:
         for script in ('assemble', 'get-extras-packages', 'install-from-bindep', 'introspect.py', 'check_galaxy', 'check_ansible'):
             with importlib.resources.as_file(scriptres / script) as script_path:
                 # FIXME: just use builtin copy?
-                copy_file(str(script_path), scripts_dir)
+                copy_file(str(script_path), os.path.join(scripts_dir, script))
 
         # later steps depend on base image containing these scripts
         context_dir = Path(self.build_outputs_dir).stem

--- a/ansible_builder/utils.py
+++ b/ansible_builder/utils.py
@@ -169,7 +169,11 @@ def copy_file(source: str, dest: str) -> bool:
     if os.path.abspath(source) == os.path.abspath(dest):
         logger.info("File %s was placed in build context by user, leaving unmodified.", dest)
         return False
-    elif not os.path.exists(dest):
+    if Path(source).is_dir():
+        raise Exception(f"Source {source} can not be a directory. Please use copy_directory instead.")
+    if Path(dest).is_dir():
+        raise Exception(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
+    if not os.path.exists(dest):
         logger.debug("File %s will be created.", dest)
         should_copy = True
     elif not filecmp.cmp(source, dest, shallow=False):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -55,6 +55,21 @@ def test_copy_touched_file(dest_file, source_file):
     assert not copy_file(source_file, dest_file)
 
 
+def test_copy_file_with_destination_directory(dest_file, source_file):
+    # Change source file to trigger copy_file
+    source_file.write_text('foo\nbar\nzoo')
+
+    with pytest.raises(Exception) as err:
+        copy_file(source_file, '/tmp')
+    assert "can not be a directory" in str(err.value.args[0])
+
+    with pytest.raises(Exception) as err:
+        copy_file('/tmp', dest_file)
+    assert "can not be a directory" in str(err.value.args[0])
+
+    assert copy_file(source_file, dest_file)
+
+
 @pytest.mark.run_command
 def test_failed_command(mocker):
     mocker.patch('ansible_builder.utils.subprocess.Popen.wait', return_value=1)


### PR DESCRIPTION
copy_file API compares and copies files, passing file's full path while copying.

Fixes: #476