### PR TITLE
Include data files from _target_scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include ansible_builder/_target_scripts/*


### PR DESCRIPTION
pbr ignores the data files when .git directory is missing from the source. Use `MANIFEST.in` to include data files from _target_scripts directory while building source distribution.

Fixes: #482