### PR TITLE
Faster integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Run pulp integration tests
         run: |
-          tox
+          tox -- --run-destructive
 
 
   integration:
@@ -144,9 +144,9 @@ jobs:
         run: |
           tox --notest
 
-      - name: Run integration tests
+      - name: Run integration tests (including destructive)
         run: |
-          tox
+          tox -- --run-destructive
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ docs/_build/
 docs/build/
 pytestdebug.log
 test/coverage/
+test/data/**/context
 .coverage
 coverage.xml
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ markers =
     run_command: tests that use the run_command utility which runs a subprocess
     test_all_runtimes: Generate a test for each supported container runtime
     serial: Tests that need to run serially
+    destructive: Tests that may potentially be destructive to the host (skipped by default without `--run-destructive`)
 testpaths = test
 addopts =
     -r a
@@ -17,4 +18,3 @@ addopts =
     --cov-report html
     --cov-report term
     --cov-report xml
-

--- a/test/data/minimal_fast/execution-environment.yml
+++ b/test/data/minimal_fast/execution-environment.yml
@@ -1,5 +1,10 @@
 version: 3
 
+additional_build_steps:
+  prepend_base:
+  # a quick value we can check for cached output
+  - RUN echo "$(echo hi) $(echo mom)"
+
 images:
   base_image:
     name: centos:stream9
@@ -7,7 +12,7 @@ images:
 dependencies:
   python_interpreter:
     python_path: '/usr/libexec/platform-python'
-  system: bindep.txt
 
 options:
+  package_manager_path: '/bin/true'
   skip_ansible_check: yes

--- a/test/data/minimal_fast/execution-environment.yml
+++ b/test/data/minimal_fast/execution-environment.yml
@@ -7,7 +7,7 @@ additional_build_steps:
 
 images:
   base_image:
-    name: centos:stream9
+    name: quay.io/centos/centos:stream9
 
 dependencies:
   python_interpreter:

--- a/test/data/pip/execution-environment.yml
+++ b/test/data/pip/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: centos:stream9
+    name: quay.io/centos/centos:stream9
 
 additional_build_steps:
   prepend_base:

--- a/test/data/pip/execution-environment.yml
+++ b/test/data/pip/execution-environment.yml
@@ -1,4 +1,19 @@
 ---
-version: 1
+version: 3
+
+images:
+  base_image:
+    name: centos:stream9
+
+additional_build_steps:
+  prepend_base:
+  - RUN /usr/libexec/platform-python -m ensurepip
+
 dependencies:
+  python_interpreter:
+    python_path: '/usr/libexec/platform-python'
   python: project/requirements.txt
+
+options:
+  package_manager_path: '/bin/true'
+  skip_ansible_check: yes

--- a/test/data/pytz/execution-environment.yml
+++ b/test/data/pytz/execution-environment.yml
@@ -3,7 +3,7 @@ version: 3
 
 images:
   base_image:
-    name: centos:stream9
+    name: quay.io/centos/centos:stream9
 
 additional_build_steps:
   prepend_base:

--- a/test/data/pytz/execution-environment.yml
+++ b/test/data/pytz/execution-environment.yml
@@ -1,4 +1,22 @@
 ---
-version: 1
+version: 3
+
+images:
+  base_image:
+    name: centos:stream9
+
+additional_build_steps:
+  prepend_base:
+  - RUN /usr/libexec/platform-python -m ensurepip
+
 dependencies:
+  ansible_core:
+    package_pip: ansible-core<2.15
+  ansible_runner:
+    package_pip: ansible-runner<2.3
   galaxy: requirements.yml
+  python_interpreter:
+    python_path: '/usr/libexec/platform-python'
+
+options:
+  package_manager_path: '/bin/true'  # provide a no-op package manager override for the cases where we just don't care

--- a/test/data/subversion/execution-environment.yml
+++ b/test/data/subversion/execution-environment.yml
@@ -2,7 +2,7 @@ version: 3
 
 images:
   base_image:
-    name: centos:stream9
+    name: quay.io/centos/centos:stream9
 
 dependencies:
   python_interpreter:

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -173,6 +173,9 @@ def test_has_pytz(cli, runtime, data_dir, ee_tag, tmp_path):
     assert 'World timezone definitions, modern and historical' in result.stdout
 
 
+# can trash the build cache, must be run independently and with the user's explicit consent
+@pytest.mark.serial
+@pytest.mark.destructive
 @pytest.mark.test_all_runtimes
 def test_build_layer_reuse(cli, runtime, data_dir, ee_tag, tmp_path):
     ee_def = data_dir / 'minimal_fast' / 'execution-environment.yml'
@@ -182,7 +185,7 @@ def test_build_layer_reuse(cli, runtime, data_dir, ee_tag, tmp_path):
         cli(f'{runtime} builder prune --force')
 
     build_cmd = f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3 --squash off'
-    cli(build_cmd)
+    cli(build_cmd + ' --no-cache')
     result = cli(build_cmd)
 
     # Get the range of lines that contain the step we want to ensure used the cached layer

--- a/test/pulp_integration/test_policies.py
+++ b/test/pulp_integration/test_policies.py
@@ -19,6 +19,7 @@ BACKUP_REGISTRIES_PATH = f'~/.config/containers/registries.conf.{RUN_UUID}'
 
 
 @pytest.mark.serial
+@pytest.mark.destructive
 class TestPolicies:
     """
     All tests within this class must run serially since they all make use of

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,8 @@ commands = pytest {posargs:test/unit}
 # (the system policy.json file).
 description = Run pulp integration tests
 commands =
-    pytest -n 1 -m "serial" {posargs:test/pulp_integration}
-    pytest -m "not serial" {posargs:test/pulp_integration}
+    pytest -n 0 -m "serial" test/pulp_integration {posargs}
+    pytest -m "not serial" test/pulp_integration {posargs}
 
 [testenv:integration{,-py39,-py310,-py311}]
 description = Run integration tests
@@ -36,7 +36,9 @@ description = Run integration tests
 passenv =
     HOME
     KEEP_IMAGES
-commands = pytest {posargs:test/integration}
+commands =
+    pytest -m "not serial" test/integration {posargs}
+    pytest -n 0 -m "serial" test/integration {posargs}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
Speed up slowest integration tests
    
* use some builder v3 shortcuts to bypass slow/repetitive work that's not applicable to what we're testing
* also got rid of a bunch of xfails for things that should now test reliably under both podman and docker
