### PR TITLE
Update schema doc for 3.0 version reference

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -5,7 +5,7 @@ The execution environment (EE) definition file supports multiple versions.
 
   * Version 1: Supported by all ``ansible-builder`` versions.
   * Version 2: Supported by ``ansible-builder`` versions ``1.2`` and later.
-  * Version 3: Supported by ``ansible-builder`` versions after ``1.2``.
+  * Version 3: Supported by ``ansible-builder`` versions ``3.0`` and later.
 
 If the EE file does not specify a version, version 1 will be assumed.
 


### PR DESCRIPTION
We were unsure of which version we were going to use for the new builder when this doc was updated. Now we know so let's be more specific.