### PR TITLE
Add pytest option to skip runtime

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,16 @@ a single test, with a single thread, and with increased verbosity, as above.
 Be aware that if you are going invoke `pytest` directly to run multiple tests,
 we do mark several tests as `serial` so those should never be run in parallel.
 
+### Skipping a Container Runtime
+
+Tests marked with `test_all_runtimes` will be run with any container runtime
+engine it can identify (for example, podman or docker). If you want to skip
+one or more runtimes, use the `--skip-runtime` pytest option:
+
+```bash
+  (ansible-builder) $ tox -e integration-py311 -- --skip-runtime docker
+```
+
 ## Gating and Merging
 
 We require at least one approval on a pull request before it can be merged.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,10 @@ CONTAINER_RUNTIMES = (
     'podman',
 )
 
+FOUND_RUNTIMES = set()
+
+GOOD_CONTENT = {'version': 1}
+
 
 @pytest.fixture(autouse=True)
 def do_not_run_commands(request, mocker):
@@ -64,9 +68,6 @@ def exec_env_definition_file(tmp_path):
     return _write_file
 
 
-good_content = {'version': 1}
-
-
 @pytest.fixture
 def good_exec_env_definition_path(tmp_path):
     path = tmp_path / 'aee'
@@ -74,7 +75,7 @@ def good_exec_env_definition_path(tmp_path):
     path = path / 'execution-env.yml'
 
     with path.open('w') as outfile:
-        yaml.dump(good_content, outfile)
+        yaml.dump(GOOD_CONTENT, outfile)
 
     return path
 
@@ -95,6 +96,15 @@ def galaxy_requirements_file(tmp_path):
     return _write_file
 
 
+# This will be called once for every xdist worker session. For more info, see:
+# https://pytest-xdist.readthedocs.io/en/stable/how-it-works.html#how-it-works
+def pytest_sessionstart(session):
+    """Find the available runtimes only once per test session."""
+    for runtime in CONTAINER_RUNTIMES:
+        if shutil.which(runtime):
+            FOUND_RUNTIMES.add(runtime)
+
+
 def pytest_collection_modifyitems(session, config, items):
     # mark destructive items as skipped if `--run-destructive` was not specified
     if not config.getoption('--run-destructive'):
@@ -112,35 +122,24 @@ def pytest_generate_tests(metafunc):
     for all supported container runtimes. The requires the test to accept
     and use the ``runtime`` argument.
 
+    This also serves to identify the runtime being tested through the pytest
+    output by appending "[<runtime>]" to the test name.
+
     Based on examples from https://docs.pytest.org/en/latest/example/parametrize.html.
     """
-
     for mark in getattr(metafunc.function, 'pytestmark', []):
         if getattr(mark, 'name', '') == 'test_all_runtimes':
-            args = tuple(
-                pytest.param(
-                    runtime,
-                    marks=pytest.mark.skipif(
-                        shutil.which(runtime) is None,
-                        reason=f'{runtime} is not installed',
-                    ),
-                )
-                for runtime in CONTAINER_RUNTIMES
-            )
-            metafunc.parametrize('runtime', args)
+            metafunc.parametrize('runtime', tuple(FOUND_RUNTIMES))
             break
 
 
 @pytest.fixture
 def build_dir_and_ee_yml(tmp_path):
     """Fixture to return temporary file maker."""
-
     def tmp_dir_and_file(ee_contents):
         tmp_file = tmp_path / 'ee.txt'
         tmp_file.write_text(ee_contents)
-
         return tmp_path, tmp_file
-
     return tmp_dir_and_file
 
 


### PR DESCRIPTION
If you have multiple container runtime engines installed, and you want to run tests, but don't care about one of those runtimes for whatever reason, you can now skip it:

```
tox -e integration-py310 -- --skip-runtime docker
```
