### PR TITLE
fix serial mark enforcement

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -102,7 +102,9 @@ def pytest_collection_modifyitems(session, config, items):
             destructive_item.add_marker(pytest.mark.skip(reason='test is potentially destructive to the host (add --run-destructive to allow)'))
 
     # mark serial items as skipped if it looks like we're running with some obvious kinds of parallelism
-    if getattr(config.option, 'numprocesses', None):
+    numproc = getattr(config.known_args_namespace, 'numprocesses', None)
+
+    if isinstance(numproc, int) and numproc > 1:
         for serial_item in (i for i in items if any(i.iter_markers(name='serial'))):
             serial_item.add_marker(pytest.mark.skip(reason='test requires serial execution (add --numprocesses 0 to allow)'))
 


### PR DESCRIPTION
* found a more robust location for `numprocesses` config