### PR TITLE
Fix for pulp setup

### DIFF
--- a/.github/test-scripts/setup_pulp.sh
+++ b/.github/test-scripts/setup_pulp.sh
@@ -37,10 +37,29 @@ EOF
 
 
 ##############################################################################
+# Set up for an insecure registry. Back it up only once for local testing.
+##############################################################################
+
+REGISTRY_FILE="$HOME/.config/containers/registries.conf"
+REGISTRY_FILE_BACKUP="${REGISTRY_FILE}.ORIG"
+if [ -e "$REGISTRY_FILE" ] && [ ! -e "$REGISTRY_FILE_BACKUP" ]
+then
+    echo "Backing up user's Podman registry to $REGISTRY_FILE_BACKUP"
+    mv $REGISTRY_FILE $REGISTRY_FILE_BACKUP
+fi
+
+cat <<EOF > "$REGISTRY_FILE"
+[[registry]]
+location="localhost:8080"
+insecure=true
+EOF
+
+##############################################################################
 # Pull and run the pulp container
 ##############################################################################
 
-podman pull docker.io/pulp/pulp:3.19
+PULP_IMAGE="pulp:3.19"
+podman pull docker.io/pulp/$PULP_IMAGE
 
 mkdir pulp
 cd pulp
@@ -59,7 +78,7 @@ podman run --detach \
            --volume "$(pwd)/pgsql":/var/lib/pgsql \
            --volume "$(pwd)/containers":/var/lib/containers \
            --device /dev/fuse \
-           pulp/pulp
+           $PULP_IMAGE
 
 ##############################################################################
 # Iteratively query the REST API until we get a JSON response (http code will

--- a/.github/test-scripts/setup_pulp.sh
+++ b/.github/test-scripts/setup_pulp.sh
@@ -58,7 +58,7 @@ EOF
 # Pull and run the pulp container
 ##############################################################################
 
-PULP_IMAGE="pulp:3.19"
+PULP_IMAGE="pulp:3.23.3"
 podman pull docker.io/pulp/$PULP_IMAGE
 
 mkdir pulp


### PR DESCRIPTION
This fixes the `pulp-integration` job. Passing results at: https://github.com/Shrews/ansible-builder/actions/runs/4863096603/jobs/8670349109

* Corrects the pulp setup script to run the specified pulp image (it was accidentally running with `latest`).
* Bumps pulp image to 3.23.3.
* Creates the `registries.conf` file in `setup_pulp.sh` now instead of within `test_policies.py`, while still trying to be considerate of local testing. This was accidentally working because we were running the `test_policies.py` tests before the `test_v3.py` tests. But since a previous change switched the order, the `test_v3.py` tests began failing because we couldn't connect to the pulp registry.
* Remove the image prune and image delete that was happening in `test_policies.py` test setup. This was only a local testing convenience and doesn't need to happen in CI. As a result, removed the `destructive` marker.