### PR TITLE
explicitly set WORKDIR on builder stage

### DIFF
--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -123,6 +123,7 @@ class Containerfile:
             "",
             "# Builder build stage",
             f"FROM {image} as builder",
+            "WORKDIR /build",
         ])
 
         self._insert_global_args()

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -392,5 +392,5 @@ def test_v3_no_workdir(cli, build_dir_and_ee_yml):
     assert containerfile.exists()
     text = containerfile.read_text()
 
-    assert "WORKDIR" not in text
+    assert "WORKDIR" not in text.replace('WORKDIR /build', '')  # intermediate stages set WORKDIR- ignore those
     assert "mkdir -p /runner" not in text


### PR DESCRIPTION
fixes #501

* fixes weird COPY failures with inherited WORKDIR from some base images in `podman build` when `--squash` is in use

The underlying issue looks to be a nasty `podman` bug around inherited `WORKDIR` from other ephemeral stages that only manifests when `--squash` is in use, but I'm unable to reproduce on a vanilla image. Just changing the `COPY` to be absolute seems like a better/"also good" fix, but it actually causes `podman build` to segfault (vs successfully copying files into the ether). So we'll live to diagnose that particular issue another day...