### PR TITLE
Purge /output for final image

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -297,7 +297,7 @@ builder runtime functionality. Valid keys for this section are:
         entrypoint script may emit warnings to ``stderr`` in cases where it is unable to suitably adjust the
         user runtime environment. This behavior can be ignored or elevated to a fatal error; consult the
         source for the ``entrypoint`` target script for more details. The default value is
-        ``["/output/scripts/entrypoint", "dumb-init"]``.
+        ``["/opt/builder/bin/entrypoint", "dumb-init"]``.
 
       ``package_pip``
         Package to install via pip for entrypoint support. This package will be installed in the final build image.

--- a/src/ansible_builder/constants.py
+++ b/src/ansible_builder/constants.py
@@ -43,3 +43,5 @@ CONTEXT_FILES = {
     'python': 'requirements.txt',
     'system': 'bindep.txt',
 }
+
+FINAL_IMAGE_BIN_PATH = "/opt/builder/bin"

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -1,5 +1,8 @@
+import os
+
 from jsonschema import validate, SchemaError, ValidationError
 
+import ansible_builder.constants as constants
 from ansible_builder.exceptions import DefinitionError
 
 
@@ -27,6 +30,7 @@ TYPE_DictOrStringOrListOfStrings = {
         }
     ]
 }
+
 ############
 # Version 1
 ############
@@ -428,13 +432,15 @@ def _handle_options_defaults(ee_def: dict):
     """
     options = ee_def.setdefault('options', {})
 
+    entrypoint_path = os.path.join(constants.FINAL_IMAGE_BIN_PATH, "entrypoint")
+
     options.setdefault('skip_ansible_check', False)
     options.setdefault('relax_passwd_permissions', True)
     options.setdefault('workdir', '/runner')
     options.setdefault('package_manager_path', '/usr/bin/dnf')
     options.setdefault('container_init', {
         'package_pip': 'dumb-init==1.2.5',
-        'entrypoint': '["/output/scripts/entrypoint", "dumb-init"]',
+        'entrypoint': f'["{entrypoint_path}", "dumb-init"]',
         'cmd': '["bash"]',
     })
     options.setdefault('user', '1000')

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -316,12 +316,15 @@ def test_v3_complete(cli, data_dir, tmp_path):
     # verify that the ansible/runner check is performed
     assert 'RUN /output/scripts/check_ansible' in text
 
+    # /output should be removed in final image
+    assert 'RUN rm -rf /output' in text
+
     # verify that the default init is being installed and that ENTRYPOINT is set
     assert "RUN $PYCMD -m pip install --no-cache-dir 'dumb-init==" in text
     assert 'WORKDIR /runner' in text
     assert 'RUN chmod ug+rw /etc/passwd' in text
     assert 'RUN mkdir -p /runner' in text
-    assert 'ENTRYPOINT ["/output/scripts/entrypoint", "dumb-init"]' in text
+    assert f'ENTRYPOINT ["{constants.FINAL_IMAGE_BIN_PATH}/entrypoint", "dumb-init"]' in text
     assert 'USER 1001' in text
 
     # check additional_build_files


### PR DESCRIPTION
* Places entrypoint script in `/opt/builder/bin`.
* Removes the `/output` directory as the last step in the final image stage.