### PR TITLE
Validate build_steps for USER directive

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -146,7 +146,7 @@ string, or a list of strings.
 
     Please make sure that you do not specify `USER` directives in these build steps. This may lead to
     failures while building the image.
-    If you want to override `USER` setting, consider using `options.user` setting mentioned below.
+    If you want to override the `USER` setting, consider using the `options.user` setting mentioned below.
 
 build_arg_defaults
 ^^^^^^^^^^^^^^^^^^

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -142,6 +142,12 @@ string, or a list of strings.
     ``append_final``
       Commands to insert after building of the final image.
 
+.. note::
+
+    Please make sure that you do not specify `USER` directives in these build steps. This may lead to
+    failures while building the image.
+    If you want to override `USER` setting, consider using `options.user` setting mentioned below.
+
 build_arg_defaults
 ^^^^^^^^^^^^^^^^^^
 

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import textwrap
 import tempfile
@@ -10,6 +11,7 @@ from . import constants
 from .exceptions import DefinitionError
 from .ee_schema import validate_schema
 
+logger = logging.getLogger(__name__)
 
 # HACK: manage lifetimes more carefully
 _tempfiles: list[Callable] = []
@@ -243,3 +245,13 @@ class UserDefinition:
                     self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
 
             self._validate_additional_build_files()
+
+            if self.version == 3:
+                build_steps = self.raw.get('additional_build_steps', {})
+                for step_name, steps in build_steps.items():
+                    for directive in steps:
+                        if directive.startswith('USER '):
+                            logging.warning(
+                                f"Found USER directive in '{step_name}' in 'additional_build_steps'. "
+                                f"Remove this directive from '{step_name}', "
+                                f"since this may cause failure in the build process.")

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -246,12 +246,11 @@ class UserDefinition:
 
             self._validate_additional_build_files()
 
-            if self.version == 3:
+            if self.version >= 3:
                 build_steps = self.raw.get('additional_build_steps', {})
                 for step_name, steps in build_steps.items():
                     for directive in steps:
                         if directive.startswith('USER '):
                             logging.warning(
                                 f"Found USER directive in '{step_name}' in 'additional_build_steps'. "
-                                f"Remove this directive from '{step_name}', "
-                                f"since this may cause failure in the build process.")
+                                f"Including this directive may cause failures in the build process.")

--- a/test/data/build_fail/user-ee.yml
+++ b/test/data/build_fail/user-ee.yml
@@ -1,0 +1,9 @@
+version: 3
+
+additional_build_steps:
+  prepend_base:
+  - USER bob
+
+images:
+  base_image:
+    name: quay.io/centos/centos:stream9

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -8,6 +8,20 @@ from test.conftest import delete_image
 
 
 @pytest.mark.test_all_runtimes
+def test_build_fail_user_directive(cli, runtime, ee_tag, tmp_path, data_dir):
+    """Test that user is warned when USER directive is used in additional_build_steps
+    """
+    bc = tmp_path
+    ee_def = data_dir / 'build_fail' / 'user-ee.yml'
+    r = cli(
+        f"ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3",
+        allow_error=True
+    )
+    assert r.rc != 0, (r.stdout + r.stderr)
+    assert 'Found USER directive in' in (r.stdout + r.stderr)
+
+
+@pytest.mark.test_all_runtimes
 def test_build_fail_exitcode(cli, runtime, ee_tag, tmp_path, data_dir):
     """Test that when a build fails, the ansible-builder exits with non-zero exit code.
 


### PR DESCRIPTION
* Providing USER details may lead to failure in the image building process. Validating presence of USER setting before hand may avoid this situation.

Fixes: #527