### PR TITLE
Wrap variable in double quotes

### DIFF
--- a/src/ansible_builder/_target_scripts/assemble
+++ b/src/ansible_builder/_target_scripts/assemble
@@ -43,7 +43,7 @@ fi
 
 if [ "$PKGMGR" = "/usr/bin/microdnf" ]
 then
-    if [ -z $PKGMGR_OPTS ]; then
+    if [ -z "${PKGMGR_OPTS}" ]; then
         # NOTE(pabelanger): skip install docs and weak dependencies to
         # make smaller images. Sadly, setting these in dnf.conf don't
         # appear to work.

--- a/src/ansible_builder/_target_scripts/install-from-bindep
+++ b/src/ansible_builder/_target_scripts/install-from-bindep
@@ -37,7 +37,7 @@ fi
 
 if [ "$PKGMGR" = "/usr/bin/microdnf" ]
 then
-    if [ -z $PKGMGR_OPTS ]; then
+    if [ -z "${PKGMGR_OPTS}" ]; then
         # NOTE(pabelanger): skip install docs and weak dependencies to
         # make smaller images. Sadly, setting these in dnf.conf don't
         # appear to work.


### PR DESCRIPTION
* avoid 'too many arguments' error when PKGMGR_OPTS contains spaces or special character