### PR TITLE
[PoC] Allow to skip ensurepip; make package manager use more flexible

### DIFF
--- a/src/ansible_builder/_target_scripts/assemble
+++ b/src/ansible_builder/_target_scripts/assemble
@@ -31,7 +31,9 @@ PKGMGR_PRESERVE_CACHE="${PKGMGR_PRESERVE_CACHE:-}"
 PYCMD="${PYCMD:=/usr/bin/python3}"
 PIPCMD="${PIPCMD:=$PYCMD -m pip}"
 
-$PYCMD -m ensurepip
+if [ $PY_DISABLE_ENSUREPIP != "true" ]; then
+    $PYCMD -m ensurepip
+fi
 
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.

--- a/src/ansible_builder/_target_scripts/assemble
+++ b/src/ansible_builder/_target_scripts/assemble
@@ -25,6 +25,10 @@ RELEASE=$(source /etc/os-release; echo $ID)
 # NOTE(pabelanger): Allow users to force either microdnf or dnf as a package
 # manager.
 PKGMGR="${PKGMGR:-}"
+PKGMGR_CLEAN_ALL_COMMAND="${PKGMGR_CLEAN_ALL_COMMAND:-clean all}"
+PKGMGR_CACHE_LOCATION="${PKGMGR_CACHE_LOCATION:-/var/cache/{dnf,yum\}}"
+PKGMGR_CLEANUP_LOCATIONS="${PKGMGR_CLEANUP_LOCATIONS:-/var/lib/dnf/history.* /var/log/{dnf.*,hawkey.log\}}"
+PKGMGR_INSTALL_COMMAND="${PKGMGR_INSTALL_COMMAND:-install -y}"
 PKGMGR_OPTS="${PKGMGR_OPTS:-}"
 PKGMGR_PRESERVE_CACHE="${PKGMGR_PRESERVE_CACHE:-}"
 
@@ -74,7 +78,7 @@ function install_bindep {
         fi
         compile_packages=$(bindep -b compile || true)
         if [ ! -z "$compile_packages" ] ; then
-            $PKGMGR install -y $PKGMGR_OPTS ${compile_packages}
+            $PKGMGR $PKGMGR_INSTALL_COMMAND $PKGMGR_OPTS ${compile_packages}
         fi
     fi
 }
@@ -164,10 +168,9 @@ for sibling in ${ZUUL_SIBLINGS:-}; do
 done
 
 if [ -z $PKGMGR_PRESERVE_CACHE ]; then
-  $PKGMGR clean all
-  rm -rf /var/cache/{dnf,yum}
+  $PKGMGR $PKGMGR_CLEAN_ALL_COMMAND
+  rm -rf $PKGMGR_CACHE_LOCATION
 fi
 
-rm -rf /var/lib/dnf/history.*
-rm -rf /var/log/{dnf.*,hawkey.log}
+rm -rf $PKGMGR_CLEANUP_LOCATIONS
 rm -rf /tmp/venv

--- a/src/ansible_builder/_target_scripts/install-from-bindep
+++ b/src/ansible_builder/_target_scripts/install-from-bindep
@@ -18,6 +18,10 @@ set -ex
 # NOTE(pabelanger): Allow users to force either microdnf or dnf as a package
 # manager.
 PKGMGR="${PKGMGR:-}"
+PKGMGR_CLEAN_ALL_COMMAND="${PKGMGR_CLEAN_ALL_COMMAND:-clean all}"
+PKGMGR_CACHE_LOCATION="${PKGMGR_CACHE_LOCATION:-/var/cache/{dnf,yum\}}"
+PKGMGR_CLEANUP_LOCATIONS="${PKGMGR_CLEANUP_LOCATIONS:-/var/lib/dnf/history.* /var/log/{dnf.*,hawkey.log\}}"
+PKGMGR_INSTALL_COMMAND="${PKGMGR_INSTALL_COMMAND:-install -y}"
 PKGMGR_OPTS="${PKGMGR_OPTS:-}"
 PKGMGR_PRESERVE_CACHE="${PKGMGR_PRESERVE_CACHE:-}"
 
@@ -50,14 +54,14 @@ fi
 if [ -f /output/bindep/run.txt ] ; then
     PACKAGES=$(cat /output/bindep/run.txt)
     if [ ! -z "$PACKAGES" ]; then
-        $PKGMGR install -y $PKGMGR_OPTS $PACKAGES
+        $PKGMGR $PKGMGR_INSTALL_COMMAND $PKGMGR_OPTS $PACKAGES
     fi
 fi
 
 if [ -f /output/bindep/epel.txt ] ; then
     EPEL_PACKAGES=$(cat /output/bindep/epel.txt)
     if [ ! -z "$EPEL_PACKAGES" ]; then
-        $PKGMGR install -y $PKGMGR_OPTS --enablerepo epel $EPEL_PACKAGES
+        $PKGMGR $PKGMGR_INSTALL_COMMAND $PKGMGR_OPTS --enablerepo epel $EPEL_PACKAGES
     fi
 fi
 
@@ -101,9 +105,8 @@ fi
 
 # clean up after ourselves, unless requested to keep the cache
 if [[ "$PKGMGR_PRESERVE_CACHE" != always ]]; then
-  $PKGMGR clean all
-  rm -rf /var/cache/{dnf,yum}
+  $PKGMGR $PKGMGR_CLEAN_ALL_COMMAND
+  rm -rf $PKGMGR_CACHE_LOCATION
 fi
 
-rm -rf /var/lib/dnf/history.*
-rm -rf /var/log/{dnf.*,hawkey.log}
+rm -rf $PKGMGR_CLEANUP_LOCATIONS

--- a/src/ansible_builder/_target_scripts/install-from-bindep
+++ b/src/ansible_builder/_target_scripts/install-from-bindep
@@ -25,7 +25,9 @@ PYCMD="${PYCMD:=/usr/bin/python3}"
 PIPCMD="${PIPCMD:=$PYCMD -m pip}"
 PIP_OPTS="${PIP_OPTS-}"
 
-$PYCMD -m ensurepip
+if [ $PY_DISABLE_ENSUREPIP != "true" ]; then
+    $PYCMD -m ensurepip
+fi
 
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.

--- a/src/ansible_builder/constants.py
+++ b/src/ansible_builder/constants.py
@@ -20,6 +20,10 @@ build_arg_defaults = dict(
     # this value is removed elsewhere for v3+ schemas
     EE_BUILDER_IMAGE='quay.io/ansible/ansible-builder:latest',
     PKGMGR_PRESERVE_CACHE='',
+    PKGMGR_CLEAN_ALL_COMMAND='clean all',
+    PKGMGR_CACHE_LOCATION='/var/cache/{dnf,yum}',
+    PKGMGR_CLEANUP_LOCATIONS='/var/lib/dnf/history.* /var/log/{dnf.*,hawkey.log}',
+    PKGMGR_INSTALL_COMMAND='install -y',
 )
 
 user_content_subfolder = '_build'

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -214,6 +214,10 @@ class Containerfile:
 
         if self.definition.version >= 3:
             global_args['PKGMGR'] = self.definition.options['package_manager_path']
+            global_args['PKGMGR_CLEAN_ALL_COMMAND'] = self.definition.build_arg_defaults['PKGMGR_CLEAN_ALL_COMMAND']
+            global_args['PKGMGR_CACHE_LOCATION'] = self.definition.build_arg_defaults['PKGMGR_CACHE_LOCATION']
+            global_args['PKGMGR_CLEANUP_LOCATIONS'] = self.definition.build_arg_defaults['PKGMGR_CLEANUP_LOCATIONS']
+            global_args['PKGMGR_INSTALL_COMMAND'] = self.definition.build_arg_defaults['PKGMGR_INSTALL_COMMAND']
 
         for arg, value in global_args.items():
             if value is None:

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -75,7 +75,7 @@ class Containerfile:
                 self.steps.append('RUN $PKGMGR install $PYPKG -y ; if [ -z $PKGMGR_PRESERVE_CACHE ]; then $PKGMGR clean all; fi')
 
             # We should always make sure pip is available for later stages.
-            if not self.definition.options['disable_ensurepip']:
+            if not self.definition.options.get('disable_ensurepip'):
                 self.steps.append('RUN $PYCMD -m ensurepip')
 
             if self.definition.ansible_ref_install_list:
@@ -209,7 +209,7 @@ class Containerfile:
             'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS'],
             'ANSIBLE_GALAXY_CLI_ROLE_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_ROLE_OPTS'],
             'ANSIBLE_INSTALL_REFS': self.definition.ansible_ref_install_list,
-            'PY_DISABLE_ENSUREPIP': 'true' if self.definition.options['disable_ensurepip'] else '',
+            'PY_DISABLE_ENSUREPIP': 'true' if self.definition.options.get('disable_ensurepip') else '',
         }
 
         if self.definition.version >= 3:

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -75,7 +75,8 @@ class Containerfile:
                 self.steps.append('RUN $PKGMGR install $PYPKG -y ; if [ -z $PKGMGR_PRESERVE_CACHE ]; then $PKGMGR clean all; fi')
 
             # We should always make sure pip is available for later stages.
-            self.steps.append('RUN $PYCMD -m ensurepip')
+            if not self.definition.options['disable_ensurepip']:
+                self.steps.append('RUN $PYCMD -m ensurepip')
 
             if self.definition.ansible_ref_install_list:
                 self.steps.append('RUN $PYCMD -m pip install --no-cache-dir $ANSIBLE_INSTALL_REFS')
@@ -208,6 +209,7 @@ class Containerfile:
             'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_COLLECTION_OPTS'],
             'ANSIBLE_GALAXY_CLI_ROLE_OPTS': self.definition.build_arg_defaults['ANSIBLE_GALAXY_CLI_ROLE_OPTS'],
             'ANSIBLE_INSTALL_REFS': self.definition.ansible_ref_install_list,
+            'PY_DISABLE_ENSUREPIP': 'true' if self.definition.options['disable_ensurepip'] else '',
         }
 
         if self.definition.version >= 3:

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -353,6 +353,10 @@ schema_v3 = {
                     "description": "Sets the username or UID",
                     "type": "string",
                 },
+                "disable_ensurepip": {
+                    "description": "Disable running ensurepip",
+                    "type": "boolean",
+                },
                 "container_init": {
                     "description": "Customize container startup behavior",
                     "type": "object",
@@ -435,6 +439,7 @@ def _handle_options_defaults(ee_def: dict):
     entrypoint_path = os.path.join(constants.FINAL_IMAGE_BIN_PATH, "entrypoint")
 
     options.setdefault('skip_ansible_check', False)
+    options.setdefault('disable_ensurepip', False)
     options.setdefault('relax_passwd_permissions', True)
     options.setdefault('workdir', '/runner')
     options.setdefault('package_manager_path', '/usr/bin/dnf')

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -216,6 +216,18 @@ schema_v3 = {
                 "PKGMGR_PRESERVE_CACHE": {
                     "type": "string",
                 },
+                "PKGMGR_CLEAN_ALL_COMMAND": {
+                    "type": "string",
+                },
+                "PKGMGR_CACHE_LOCATION": {
+                    "type": "string",
+                },
+                "PKGMGR_CLEANUP_LOCATIONS": {
+                    "type": "string",
+                },
+                "PKGMGR_INSTALL_COMMAND": {
+                    "type": "string",
+                },
             },
         },
 


### PR DESCRIPTION
This allows to create a Debian based execution environment:
```yaml
---
version: 3

build_arg_defaults:
  PKGMGR_CLEAN_ALL_COMMAND: clean
  PKGMGR_CACHE_LOCATION: /var/lib/apt/lists/*
  # I was too lazy to figure out what to put here, so for now don't delete anything
  PKGMGR_CLEANUP_LOCATIONS: ' '
  PKGMGR_INSTALL_COMMAND: install -y --no-install-recommends

options:
  package_manager_path: /usr/bin/apt
  disable_ensurepip: true

dependencies:
  ansible_core:
    package_pip: ansible-core==2.15.0
  ansible_runner:
    package_pip: ansible-runner
  galaxy: requirements.yml

images:
  base_image:
    name: docker.io/library/debian:bullseye

additional_build_steps:
  prepend_base:
    - RUN apt-get update && apt-get install -y --no-install-recommends python3-pip python3-venv python3-wheel python3-cryptography
```
I've tried this with requirements.yml:
```yaml
collections:
  - community.crypto
  - community.docker
  - community.general
  - community.sops
```
and got a nice Debian Bullseye based EE having these three collections. (community.sops installs `gnupg` via bindep; community.docker installs some Python dependencies; community.crypto installs both Python and binary dependencies.)