### PR TITLE
Docs: mention a few base images as examples, using a free one as the default

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -48,6 +48,7 @@ Below is an example version 3 EE file:
         # Other available base images:
         #   - quay.io/rockylinux/rockylinux:9
         #   - quay.io/centos/centos:stream9
+        #   - registry.fedoraproject.org/fedora:38
         #   - registry.redhat.io/ansible-automation-platform-23/ee-minimal-rhel8:latest
         #     (needs an account)
 

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -48,7 +48,7 @@ Below is an example version 3 EE file:
         # Other available base images:
         #   - quay.io/rockylinux/rockylinux:9
         #   - quay.io/centos/centos:stream9
-        #   - registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest
+        #   - registry.redhat.io/ansible-automation-platform-23/ee-minimal-rhel8:latest
         #     (needs an account)
 
     additional_build_files:

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -44,7 +44,12 @@ Below is an example version 3 EE file:
 
     images:
       base_image:
-        name: registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest
+        name: docker.io/redhat/ubi9:latest
+        # Other available base images:
+        #   - quay.io/rockylinux/rockylinux:9
+        #   - quay.io/centos/centos:stream9
+        #   - registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest
+        #     (needs an account)
 
     additional_build_files:
         - src: files/ansible.cfg


### PR DESCRIPTION
Right now the example base image can only be pulled with an account. This replaces it with a free alternative (UBI 9 base image), and lists several examples (Rocky Linux 9, CentOS Stream 9, and the original AAP base image).