### PR TITLE
Add codecov config file

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true


### PR DESCRIPTION
Add a `codecov.yml` file which configures the builder repo to:

- Fail the codecov patch check if a PR does not have code coverage of 80% of any new code being added.
- Fail the codecov project check if the project coverage drops compared to the previous base commit (pull request base or parent commit).
- Both checks are currently in "informational" mode, which does not fail CI if coverage goals are not met. This will likely be removed after we gain some experience with current settings.