### PR TITLE
Fail CI on codecov upload failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
         with:
           files: test/coverage/reports/coverage.xml
           flags: ${{ matrix.py_version.tox_env }}
+          fail_ci_if_error: true
+          verbose: true
 
   unit:
     name: Unit - ${{ matrix.py_version.name}}
@@ -198,3 +200,5 @@ jobs:
         with:
           files: test/coverage/reports/coverage.xml
           flags: ${{ matrix.py_version.tox_env }}
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
Similar to runner PR https://github.com/ansible/ansible-runner/pull/1251, fail CI on codecov upload failures so we can have accurate coverage numbers.