### PR TITLE
[RFE] Support for tags from the configuration file

### DIFF
--- a/demo/execution-environment.yml
+++ b/demo/execution-environment.yml
@@ -10,7 +10,8 @@ images:
 
 options:
   user: '1000'  # (optional) sets the username or UID
-  # tags: 'ee_development:latest' # (optional) sets tags
+  # tags:  # (optional) sets tags
+  #   - 'ee_development:latest'
 
 dependencies:
   python_interpreter:

--- a/demo/execution-environment.yml
+++ b/demo/execution-environment.yml
@@ -10,6 +10,7 @@ images:
 
 options:
   user: '1000'  # (optional) sets the username or UID
+  # tags: 'ee_development:latest' # (optional) sets tags
 
 dependencies:
   python_interpreter:

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -355,6 +355,9 @@ builder runtime functionality. Valid keys for this section are:
       This sets the username or UID to use as the default user for the final container image.
       The default value ``1000``.
 
+    ``tags``
+      Specifies the name which is assigned to resulting image if build process completes successfully.
+      The default value is ``ansible-execution-env:latest``.
 
 Example ``options`` section:
 
@@ -370,6 +373,8 @@ Example ``options`` section:
         skip_ansible_check: true
         workdir: /myworkdir
         user: bob
+        tags:
+          - ee_development:latest
 
 version
 ^^^^^^^

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -193,10 +193,6 @@ def parse_args(args=sys.argv[1:]):
 
     args = parser.parse_args(args)
 
-    # Tag default must be handled differently. See comment for --tag option.
-    if 'tag' not in vars(args) or not args.tag:
-        args.tag = [constants.default_tag]
-
     return args
 
 

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -329,7 +329,7 @@ schema_v3 = {
         },
 
         "options": {
-            "description": "Options that affects the runtime behavior",
+            "description": "Options that affect the runtime behavior",
             "type": "object",
             "additionalProperties": False,
             "properties": {
@@ -374,7 +374,7 @@ schema_v3 = {
                 },
                 "tags": {
                     "description": "Specifies the name which is assigned to resulting image if build process completes successfully",
-                    "type": ["string", "array", "null"],
+                    "type": "array",
                 },
             },
         },

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -329,7 +329,7 @@ schema_v3 = {
         },
 
         "options": {
-            "description": "Options that effect runtime behavior",
+            "description": "Options that affects the runtime behavior",
             "type": "object",
             "additionalProperties": False,
             "properties": {
@@ -371,6 +371,10 @@ schema_v3 = {
                             "type": "string",
                         },
                     },
+                },
+                "tags": {
+                    "description": "Specifies the name which is assigned to resulting image if build process completes successfully",
+                    "type": ["string", "array", "null"],
                 },
             },
         },
@@ -444,3 +448,4 @@ def _handle_options_defaults(ee_def: dict):
         'cmd': '["bash"]',
     })
     options.setdefault('user', '1000')
+    options.setdefault('tags', [])

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -373,8 +373,12 @@ schema_v3 = {
                     },
                 },
                 "tags": {
-                    "description": "Specifies the name which is assigned to resulting image if build process completes successfully",
+                    "description": "A list of names to assign to the resulting image if build process completes successfully",
                     "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+
                 },
             },
         },

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -46,7 +46,12 @@ class AnsibleBuilder:
         self.definition = UserDefinition(filename=filename)
         self.definition.validate()
 
-        self.tags = tag or []
+        self.tags = []
+        if self.definition.version >= 3 and self.definition.options['tags']:
+            self.tags = self.definition.options['tags']
+
+        if not self.tags and tag:
+            self.tags = tag
         self.build_context = build_context
         self.build_outputs_dir = os.path.join(
             build_context, constants.user_content_subfolder)

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -49,9 +49,12 @@ class AnsibleBuilder:
         self.tags = []
         if self.definition.version >= 3 and self.definition.options['tags']:
             self.tags = self.definition.options['tags']
-
-        if not self.tags and tag:
+        elif tag:
             self.tags = tag
+        else:
+            # Set default value
+            self.tags = [constants.default_tag]
+
         self.build_context = build_context
         self.build_outputs_dir = os.path.join(
             build_context, constants.user_content_subfolder)

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -46,14 +46,12 @@ class AnsibleBuilder:
         self.definition = UserDefinition(filename=filename)
         self.definition.validate()
 
-        self.tags = []
+        self.tags = [constants.default_tag]
         if self.definition.version >= 3 and self.definition.options['tags']:
             self.tags = self.definition.options['tags']
-        elif tag:
+
+        if tag:
             self.tags = tag
-        else:
-            # Set default value
-            self.tags = [constants.default_tag]
 
         self.build_context = build_context
         self.build_outputs_dir = os.path.join(

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -241,6 +241,19 @@ class TestUserDefinition:
         value = definition.raw.get('options', {}).get('user')
         assert value == 'bob'
 
+    def test_v3_set_tags(self, exec_env_definition_file):
+        """
+        Test that options.tags sets to tags
+        """
+        path = exec_env_definition_file(
+            "{'version': 3, 'options': {'tags': ['ee_test:latest']}}"
+        )
+        definition = UserDefinition(path)
+        definition.validate()
+
+        value = definition.raw.get('options', {}).get('tags')
+        assert value == ['ee_test:latest']
+
 
 class TestImageDescription:
 


### PR DESCRIPTION
##### SUMMARY

* Added support for providing tags from the configuration file

Fixes: #523

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
demo/execution-environment.yml
docs/definition.rst
src/ansible_builder/ee_schema.py
src/ansible_builder/main.py
test/unit/test_user_definition.py

