### PR TITLE
Add pylint to CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,20 @@ requires = ["setuptools>=45, <=67.7.2", "setuptools-scm[toml]>=6.2, <=7.1.0"]  #
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.pylint.main]
+output-format = "colorized"
+max-line-length=120
+disable = [
+  "all",
+
+  # Some codes we will leave disabled
+  "C0103",  # invalid-name
+  "C0114",  # missing-module-docstring
+  "C0116",  # missing-function-docstring
+  "R0902",  # too-many-instance-attributes
+]
+
+enable = [
+  "W0102",  # dangerous-default-value
+]

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -208,7 +208,7 @@ def simple_combine(reqs):
     return fancy_lines
 
 
-def parse_args(args=None):
+def parse_args():
 
     parser = argparse.ArgumentParser(
         prog='introspect',
@@ -217,14 +217,15 @@ def parse_args(args=None):
         )
     )
 
-    subparsers = parser.add_subparsers(help='The command to invoke.', dest='action')
-    subparsers.required = True
+    subparsers = parser.add_subparsers(
+        help='The command to invoke.',
+        dest='action',
+        required=True,
+    )
 
     create_introspect_parser(subparsers)
 
-    args = parser.parse_args(args)
-
-    return args
+    return parser.parse_args()
 
 
 def run_introspect(args, logger):

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -208,7 +208,7 @@ def simple_combine(reqs):
     return fancy_lines
 
 
-def parse_args(args=sys.argv[1:]):
+def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
         prog='introspect',

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -208,7 +208,7 @@ def simple_combine(reqs):
     return fancy_lines
 
 
-def parse_args():
+def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
         prog='introspect',
@@ -225,7 +225,7 @@ def parse_args():
 
     create_introspect_parser(subparsers)
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def run_introspect(args, logger):

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -194,7 +194,7 @@ def add_container_options(parser):
                             'Integer values are also accepted (for example, "-v3" or "--verbosity 3"). Default is %(default)s.')
 
 
-def parse_args():
+def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
         prog='ansible-builder',
@@ -216,7 +216,7 @@ def parse_args():
 
     add_container_options(subparsers)
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 class BuildArgAction(argparse.Action):

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -194,7 +194,7 @@ def add_container_options(parser):
                             'Integer values are also accepted (for example, "-v3" or "--verbosity 3"). Default is %(default)s.')
 
 
-def parse_args(args=None):
+def parse_args():
 
     parser = argparse.ArgumentParser(
         prog='ansible-builder',
@@ -208,14 +208,15 @@ def parse_args(args=None):
         help='Print ansible-builder version and exit.'
     )
 
-    subparsers = parser.add_subparsers(help='The command to invoke.', dest='action')
-    subparsers.required = True
+    subparsers = parser.add_subparsers(
+        help='The command to invoke.',
+        dest='action',
+        required=True,
+    )
 
     add_container_options(subparsers)
 
-    args = parser.parse_args(args)
-
-    return args
+    return parser.parse_args()
 
 
 class BuildArgAction(argparse.Action):

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -194,7 +194,7 @@ def add_container_options(parser):
                             'Integer values are also accepted (for example, "-v3" or "--verbosity 3"). Default is %(default)s.')
 
 
-def parse_args(args=sys.argv[1:]):
+def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
         prog='ansible-builder',

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,3 +9,4 @@ types-jsonschema
 types-pyyaml
 tox
 yamllint
+pylint==2.17.4

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -1,6 +1,8 @@
 import os
+import pytest
 
 from ansible_builder._target_scripts.introspect import process, process_collection, simple_combine, sanitize_requirements
+from ansible_builder._target_scripts.introspect import parse_args
 
 
 def test_multiple_collection_metadata(data_dir):
@@ -32,3 +34,35 @@ def test_single_collection_metadata(data_dir):
 
     assert py_reqs == ['pyvcloud>=14']
     assert sys_reqs == []
+
+
+def test_parse_args_empty(capsys):
+    with pytest.raises(SystemExit):
+        parse_args()
+    dummy, err = capsys.readouterr()
+    assert 'usage: introspect' in err
+
+
+def test_parse_args_default_action():
+    action = 'introspect'
+    user_pip = '/tmp/user-pip.txt'
+    user_bindep = '/tmp/user-bindep.txt'
+    write_pip = '/tmp/write-pip.txt'
+    write_bindep = '/tmp/write-bindep.txt'
+
+    parser = parse_args(
+        [
+            action, '--sanitize',
+            f'--user-pip={user_pip}',
+            f'--user-bindep={user_bindep}',
+            f'--write-pip={write_pip}',
+            f'--write-bindep={write_bindep}',
+        ]
+    )
+
+    assert parser.action == action
+    assert parser.sanitize
+    assert parser.user_pip == user_pip
+    assert parser.user_bindep == user_bindep
+    assert parser.write_pip == write_pip
+    assert parser.write_bindep == write_bindep

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     yamllint --version
     yamllint -s .
     mypy src/ansible_builder
+    pylint src/ansible_builder
 
 [testenv:unit{,-py39,-py310,-py311}]
 description = Run unit tests


### PR DESCRIPTION
Adding `pylint` to the CI linting tests.

The plan is to slowly enable individual checks until we get the number of errors down a bit. Disabled all checks for now except for `W0102 - dangerous-default-value`.