### PR TITLE
Make the capitalization of Execution Environment coherent

### DIFF
--- a/docs/collection_metadata.rst
+++ b/docs/collection_metadata.rst
@@ -3,7 +3,7 @@
 Collection-level dependencies
 =============================
 
-When Ansible Builder installs collections into an execution environment, it also installs the dependencies listed by each collection on Galaxy.
+When Ansible Builder installs collections into an Execution Environment, it also installs the dependencies listed by each collection on Galaxy.
 
 For Ansible Builder to find and install collection dependencies, those dependencies must be defined in one of these files:
 
@@ -29,7 +29,7 @@ How to verify collection-level metadata
 
 .. note::
 
-  Running the introspect command described below is not a part of a typical workflow for building and using execution environments.
+  Running the introspect command described below is not a part of a typical workflow for building and using Execution Environments.
 
 Collection developers can verify that dependencies specified in the collection will be processed correctly by Ansible Builder.
 
@@ -94,6 +94,6 @@ If you need to include one of these ignored package names, use the ``--user-pip`
 System-level Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For system packages, use the ``bindep`` format to specify cross-platform requirements, so they can be installed by whichever package management system the execution environment uses. Collections should specify necessary requirements for ``[platform:rpm]``.
+For system packages, use the ``bindep`` format to specify cross-platform requirements, so they can be installed by whichever package management system the Execution Environment uses. Collections should specify necessary requirements for ``[platform:rpm]``.
 
 Ansible Builder combines system package entries from multiple collections into a single file. Only requirements with *no* profiles (runtime requirements) are installed to the image. Entries from multiple collections which are outright duplicates of each other may be consolidated in the combined file.

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -1,9 +1,9 @@
 .. _builder_ee_definition:
 
-Execution environment definition
+Execution Environment definition
 ================================
 
-You define the content of your execution environment in a YAML file. By default, this file is called ``execution_environment.yml``. This file tells Ansible Builder how to create the build instruction file (Containerfile for Podman, Dockerfile for Docker) and build context for your container image.
+You define the content of your Execution Environment in a YAML file. By default, this file is called ``execution_environment.yml``. This file tells Ansible Builder how to create the build instruction file (Containerfile for Podman, Dockerfile for Docker) and build context for your container image.
 
 .. note::
    This page documents the definition schema for Ansible Builder 3.x. If you are running an older version of Ansible Builder, you need an older schema version. Please consult older versions of the docs for more information. We recommend using version 3, which offers substantially more configurability and functionality than previous versions.
@@ -15,7 +15,7 @@ You define the content of your execution environment in a YAML file. By default,
 
 Overview
 --------
-The Ansible Builder 3.x execution environment definition file accepts seven top-level sections:
+The Ansible Builder 3.x Execution Environment definition file accepts seven top-level sections:
 
 * additional_build_files
 * additional_build_steps
@@ -86,7 +86,7 @@ Here is a sample version 3 EE file. To use Ansible Builder 3.x, you must specify
 Configuration options
 ---------------------
 
-You may use the configuration YAML keys listed here in your v3 execution environment definition file.
+You may use the configuration YAML keys listed here in your v3 Execution Environment definition file.
 
 additional_build_files
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ Each list item must be a dictionary containing the following (non-optional) keys
     ``src``
       Specifies the source file(s) to copy into the build context directory. This
       may either be an absolute path (e.g., ``/home/user/.ansible.cfg``),
-      or a path that is relative to the execution environment file. Relative paths may be
+      or a path that is relative to the Execution Environment file. Relative paths may be
       a glob expression matching one or more files (e.g. ``files/*.cfg``). Note
       that an absolute path may *not* include a regular expression. If ``src`` is
       a directory, the entire contents of that directory are copied to ``dest``.
@@ -177,14 +177,14 @@ Build args used by ``ansible-builder`` are the following:
 Ansible Builder hard-codes values given inside of ``build_arg_defaults`` into the
 build instruction file, so they will persist if you run your container build manually.
 
-If you specify the same variable in the execution environment definition and at the command line with the CLI :ref:`build-arg` flag, the CLI value will take higher precedence (the CLI value will override the value in the execution environment definition).
+If you specify the same variable in the Execution Environment definition and at the command line with the CLI :ref:`build-arg` flag, the CLI value will take higher precedence (the CLI value will override the value in the Execution Environment definition).
 
 dependencies
 ^^^^^^^^^^^^
 
 Specifies dependencies to install into the final image, including ``ansible-core``, ``ansible-runner``, Python packages, system packages, and Ansible Collections. Ansible Builder automatically installs dependencies for any Ansible Collections you install.
 
-In general you can use standard syntax to constrain package versions. Use the same syntax you would pass to ``dnf``, ``pip``, ``ansible-galaxy``, or any other package management utility. You can also define your packages or collections in separate files and reference those files in the ``dependencies`` section of your execution environment definition file.
+In general you can use standard syntax to constrain package versions. Use the same syntax you would pass to ``dnf``, ``pip``, ``ansible-galaxy``, or any other package management utility. You can also define your packages or collections in separate files and reference those files in the ``dependencies`` section of your Execution Environment definition file.
 
 The following keys are valid for this section:
 
@@ -284,7 +284,7 @@ Specifies the base image to be used. At a minimum you *MUST* specify a source, i
 Valid keys for this section are:
 
     ``base_image``
-      A dictionary defining the parent image for the execution environment. A ``name``
+      A dictionary defining the parent image for the Execution Environment. A ``name``
       key must be supplied with the container image to use. Use the ``signature_original_name``
       key if the image is mirrored within your repository, but signed with the original
       image's signature key.
@@ -396,4 +396,4 @@ Example ``options`` section:
 version
 ^^^^^^^
 
-An integer value that sets the schema version of the execution environment definition file. Defaults to ``1``. Must be ``3`` if you are using Ansible Builder 3.x.
+An integer value that sets the schema version of the Execution Environment definition file. Defaults to ``1``. Must be ``3`` if you are using Ansible Builder 3.x.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -6,8 +6,8 @@ Glossary
 
 .. glossary::
 
-    execution environment
-      execution environments are container images intended to be used as Ansible control nodes.
+    Execution Environment
+      Execution Environments are container images intended to be used as Ansible control nodes.
       Starting in version 2.0, `ansible-runner <https://ansible-runner.readthedocs.io/en/latest/>`_.
       can make use of these images.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@
 Introduction to Ansible Builder
 *******************************
 
-With ``ansible-builder`` you can configure and build portable, consistent, customized Ansible `control nodes`_ that are packaged as containers by Podman or Docker. These containers are known as execution environments. You can use execution environments on AWX or Ansible Controller, for local playbook development and testing, in your CI pipeline, and anywhere else you run automation. You can design and distribute specialized execution environments for your playbooks, choosing the versions of Python and ansible-core you want, and installing only the Python packages, system packages, and Ansible collections you need for each playbook.
+With ``ansible-builder`` you can configure and build portable, consistent, customized Ansible `control nodes`_ that are packaged as containers by Podman or Docker. These containers are known as Execution Environments. You can use Execution Environments on AWX or Ansible Controller, for local playbook development and testing, in your CI pipeline, and anywhere else you run automation. You can design and distribute specialized Execution Environments for your playbooks, choosing the versions of Python and ansible-core you want, and installing only the Python packages, system packages, and Ansible collections you need for each playbook.
 
 .. contents::
    :local:
@@ -24,10 +24,10 @@ Here are a few terms you should know. These concepts and terms are relevant to a
   * Container: a package of code and dependencies that runs a service or an application across a variety of computing environments
   * Image: a complete but inactive version of a container - you can distribute images and create one or more containers based on each image
 
-What are execution environments?
+What are Execution Environments?
 ================================
 
-Execution environments are container images that serve as Ansible `control nodes`_. An execution environment contains:
+Execution Environments are container images that serve as Ansible `control nodes`_. An Execution Environment contains:
 
 - Python
 - Ansible-core
@@ -44,8 +44,8 @@ Execution environments are container images that serve as Ansible `control nodes
 Quickstart for Ansible Builder
 ==============================
 
-To get started with Ansible Builder, you must install the ``ansible-builder`` utility and a containerization tool. Once you have the tools you need, create an :ref:`execution environment definition <builder_ee_definition>` file. By default this file is called ``execution_environment.yml``. In this file you can specify the exact content you want to include in your
-execution environment. You can specify these items:
+To get started with Ansible Builder, you must install the ``ansible-builder`` utility and a containerization tool. Once you have the tools you need, create an :ref:`Execution Environment definition <builder_ee_definition>` file. By default this file is called ``execution_environment.yml``. In this file you can specify the exact content you want to include in your
+Execution Environment. You can specify these items:
 
 - the base container image
 - the version of Python
@@ -59,12 +59,12 @@ execution environment. You can specify these items:
 Choosing a base image
 ---------------------
 
-You can use any base image you choose. The smaller the base image, generally, the smaller the final image. However, to make Ansible Builder more efficient, you should know what packages, if any, are already installed on the base image you use. For example, some base images already have Python installed. Others do not. If you use a base image that already has Python installed, you can omit Python in your execution environment definition file. Not all base images have package managers installed.
+You can use any base image you choose. The smaller the base image, generally, the smaller the final image. However, to make Ansible Builder more efficient, you should know what packages, if any, are already installed on the base image you use. For example, some base images already have Python installed. Others do not. If you use a base image that already has Python installed, you can omit Python in your Execution Environment definition file. Not all base images have package managers installed.
 
 How Ansible Builder executes
 ============================
 
-Ansible Builder can execute two separate steps. The first step is to create a build instruction file (Containerfile for Podman, Dockerfile for Docker) and a build context based on the execution environment definition file. The second step is to run a containerization tool (Podman or Docker) to build an image based on the build instruction file and build context. The ``ansible-builder build`` command runs both steps. The ``ansible-builder create`` command runs only the first step. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
+Ansible Builder can execute two separate steps. The first step is to create a build instruction file (Containerfile for Podman, Dockerfile for Docker) and a build context based on the Execution Environment definition file. The second step is to run a containerization tool (Podman or Docker) to build an image based on the build instruction file and build context. The ``ansible-builder build`` command runs both steps. The ``ansible-builder create`` command runs only the first step. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
 
 How Ansible Builder builds images
 ---------------------------------
@@ -84,12 +84,12 @@ In the Builder stage, Ansible Builder downloads the other packages (Python packa
 
 In the Final stage, Ansible Builder integrates the first three stages, installing all the stashed files on the output of the Base stage and generating a new image that includes all the content.
 
-Ansible Builder injects hooks at each stage of the container build process so you can add custom steps before and after every build stage. You may need to install certain packages or utilities before the Galaxy and Builder stages. For example, if you need to install a collection from GitHub, you must install git after the Base stage to make it available during the Galaxy stage. To add custom build steps, add an ``additional_build_steps`` section to your execution environment definition. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
+Ansible Builder injects hooks at each stage of the container build process so you can add custom steps before and after every build stage. You may need to install certain packages or utilities before the Galaxy and Builder stages. For example, if you need to install a collection from GitHub, you must install git after the Base stage to make it available during the Galaxy stage. To add custom build steps, add an ``additional_build_steps`` section to your Execution Environment definition. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
 
 Defining collection dependencies
 ================================
 
-When Ansible Builder installs collections into an execution environment, it also installs each collection's dependencies. Collection maintainers can learn to correctly declare dependencies for their collections from the :ref:`collection-level dependencies <builder_collection_metadata>` page.
+When Ansible Builder installs collections into an Execution Environment, it also installs each collection's dependencies. Collection maintainers can learn to correctly declare dependencies for their collections from the :ref:`collection-level dependencies <builder_collection_metadata>` page.
 
 
 .. toctree::

--- a/docs/scenario_guides/scenario_copy.rst
+++ b/docs/scenario_guides/scenario_copy.rst
@@ -6,7 +6,7 @@ Copying arbitratory files to EE
 Ansible Builder version 3 schema provides the option to copy files to an EE image.
 See  the :ref:`version 3 schema <version_3_format>` for more details.
 
-In the example below, we will take a look at copying arbitratory files to an execution environment.
+In the example below, we will take a look at copying arbitratory files to an Execution Environment.
 
 
 .. literalinclude:: copy_ee.yml

--- a/docs/scenario_guides/scenario_custom.rst
+++ b/docs/scenario_guides/scenario_custom.rst
@@ -10,7 +10,7 @@ into the EE build without leaking them into the final EE image.
 
 In the example below, we will take a look at
 
-* Copying `ansible.cfg` file to an execution environment
+* Copying `ansible.cfg` file to an Execution Environment
 * Using Galaxy Server environment variables
 
 .. literalinclude:: galaxy_ee.yml

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -13,14 +13,14 @@ The ``build`` command
 
 The ``ansible-builder build`` command:
 
-* takes an :ref:`execution environment definition file<builder_ee_definition>` as an input,
+* takes an :ref:`Execution Environment definition file<builder_ee_definition>` as an input,
 * outputs a build instruction file (Containerfile for Podman, Dockerfile for Docker),
-* creates a build context necessary for building an execution environment image,
+* creates a build context necessary for building an Execution Environment image,
 * builds the image.
 
 By default, it looks for a file named ``execution-environment.yml`` in the current directory.
 
-To build an execution environment using the default definition file, run:
+To build an Execution Environment using the default definition file, run:
 
 .. code::
 
@@ -52,7 +52,7 @@ More recent versions of ``ansible-builder`` support multiple tags:
 ``--file``
 **********
 
-Specifies the execution environment file. To use a file named something other than ``execution-environment.yml``:
+Specifies the Execution Environment file. To use a file named something other than ``execution-environment.yml``:
 
 .. code::
 
@@ -110,7 +110,7 @@ Specifies the directory name for the build context Ansible Builder creates. Defa
 
 Passes build-time arguments to Podman or Docker. Specify these flags or variables the same way you would with ``podman build`` or ``docker build``.
 
-By default, the Containerfile / Dockerfile created by Ansible Builder contains a build argument ``EE_BASE_IMAGE``, which can be useful for rebuilding execution environments without modifying any files.
+By default, the Containerfile / Dockerfile created by Ansible Builder contains a build argument ``EE_BASE_IMAGE``, which can be useful for rebuilding Execution Environments without modifying any files.
 
 .. code::
 
@@ -221,13 +221,13 @@ Controls the final image layer squashing. Valid values are:
 The ``create`` command
 ----------------------
 
-The ``ansible-builder create`` command accepts an execution environment definition as an input and outputs the build context necessary for building an execution environment image. However, the ``create`` command *will not* build the execution environment image; this is useful for creating just the build context and a ``Containerfile`` that can then be shared.
+The ``ansible-builder create`` command accepts an Execution Environment definition as an input and outputs the build context necessary for building an Execution Environment image. However, the ``create`` command *will not* build the Execution Environment image; this is useful for creating just the build context and a ``Containerfile`` that can then be shared.
 
 
 Examples
 --------
 
-The example in ``test/data/pytz`` requires the ``awx.awx`` collection in the execution environment definition. The lookup plugin
+The example in ``test/data/pytz`` requires the ``awx.awx`` collection in the Execution Environment definition. The lookup plugin
 ``awx.awx.schedule_rrule`` requires the PyPI ``pytz`` and another
 library to work. If ``test/data/pytz/execution-environment.yml`` file is
 given to the ``ansible-builder build`` command, then it will install the
@@ -247,7 +247,7 @@ the private data directory.
     process_isolation: true
 
 The ``awx.awx`` collection is a subset of content included in the default
-AWX execution environment. More details can be found at the
+AWX Execution Environment. More details can be found at the
 `awx-ee <https://github.com/ansible/awx-ee>`_ repository.
 
 


### PR DESCRIPTION
My assumption is that the correct one would be "Execution Environment", since it is abbreviated "EE", but if the correct one is different, please let me know and I will change the PR to match the preferred capitalization.