### PR TITLE
Update sanity fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,25 @@ disable = [
   "C0116",  # missing-function-docstring
 
   "R0902",  # too-many-instance-attributes
+
+  "W1514",  # unspecified-encoding
 ]
 
 enable = [
   "C0206",  # consider-using-dict-items
   "C0209",  # consider-using-f-string
+  "C0411",  # wrong-import-order
 
+  "E1101",  # no-member
+
+  "R0205",  # useless-object-inheritance
   "R0402",  # consider-using-from-import
   "R1705",  # no-else-return
   "R1725",  # super-with-arguments
   "R1735",  # use-dict-literal
 
   "W0102",  # dangerous-default-value
+  "W0707",  # raise-missing-from
   "W1203",  # logging-fstring-interpolation
 
 ]

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -1,11 +1,11 @@
 import argparse
+import importlib.metadata
 import logging
 import os
 import sys
 import yaml
 
 import requirements
-import importlib.metadata
 
 base_collections_path = '/usr/share/ansible/collections'
 default_file = 'execution-environment.yml'

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -2,10 +2,10 @@ import logging
 import os
 import textwrap
 import tempfile
-import yaml
-
 from pathlib import Path
 from typing import Callable
+
+import yaml
 
 from . import constants
 from .exceptions import DefinitionError


### PR DESCRIPTION
##### SUMMARY

* Enable (C0411) wrong-import-order
* Enable (E1101) no-member
* Enable (R0205) useless-object-inheritance
* Enable (W0707) raise-missing-from
* Disable (W1514) unspecified-encoding

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
pyproject.toml
src/ansible_builder/_target_scripts/introspect.py
src/ansible_builder/user_definition.py

