### PR TITLE
pylint: enable W0212

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ enable = [
   "R1735",  # use-dict-literal
 
   "W0102",  # dangerous-default-value
+  "W0212",  # protected-access
   "W0707",  # raise-missing-from
   "W1203",  # logging-fstring-interpolation
 

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -2,6 +2,8 @@ from ansible_builder import constants
 from ansible_builder.containerfile import Containerfile
 from ansible_builder.user_definition import UserDefinition
 
+# pylint: disable=W0212
+
 
 def make_containerfile(tmpdir, ee_path, **cf_kwargs):
     definition = UserDefinition(ee_path)


### PR DESCRIPTION
##### SUMMARY

Enable pylint warning W0212 to warn of access to protected class members.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
pyproject.toml
test/unit/test_containerfile.py

