### PR TITLE
pylint: Fix remaining pylint refactor (Rxxxx) problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,15 @@ disable = [
   "C0115",  # missing-class-docstring
   "C0116",  # missing-function-docstring
 
+  "R0801",  # duplicate-code
   "R0902",  # too-many-instance-attributes
+  "R0903",  # too-few-public-methods
+  "R0904",  # too-many-public-methods
+  "R0911",  # too-many-return-statements
+  "R0912",  # too-many-branches
+  "R0913",  # too-many-arguments
+  "R0914",  # too-many-locals
+  "R0915",  # too-many-statements
 
   "W1514",  # unspecified-encoding
 ]
@@ -30,9 +38,17 @@ enable = [
 
   "R0205",  # useless-object-inheritance
   "R0402",  # consider-using-from-import
+  "R1701",  # consider-merging-isinstance
+  "R1704",  # redefined-argument-from-local
   "R1705",  # no-else-return
+  "R1710",  # inconsistent-return-statements
+  "R1720",  # no-else-raise
+  "R1724",  # no-else-continue
   "R1725",  # super-with-arguments
+  "R1729",  # use-a-generator
   "R1735",  # use-dict-literal
+  "R1730",  # consider-using-min-builtin
+  "R1732",  # consider-using-with
 
   "W0102",  # dangerous-default-value
   "W0212",  # protected-access

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -179,6 +179,7 @@ class UserDefinition:
             _tempfiles.append(tf)
             req_file = tf.name
         elif (is_list := isinstance(req_file, list)) or (isinstance(req_file, str) and '\n' in req_file):
+            # pylint: disable=R1732
             tf = tempfile.NamedTemporaryFile('w')
             if is_list:
                 tf.write('\n'.join(req_file))

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -67,6 +67,7 @@ def run_command(command, capture_output=False, allow_error=False):
     logger.info('Running command:')
     logger.info('  %s', ' '.join(command))
     try:
+        # pylint: disable=R1732
         process = subprocess.Popen(command,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT)


### PR DESCRIPTION
##### SUMMARY

Corrects many of the refactor suggestions from pylint.
Some others are ignored (`too-many-*` and `too-few-*`, for example) because of the work required to rewrite the code.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
pyproject.toml
src/ansible_builder/user_definition.py
src/ansible_builder/utils.py

