### PR TITLE
Warn user about using default base image in v3

### DIFF
--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -246,12 +246,12 @@ class UserDefinition:
                     self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
 
             if (
-                self.version >= 3 and
-                self.build_arg_defaults["EE_BASE_IMAGE"] == constants.build_arg_defaults["EE_BASE_IMAGE"]
+                self.version >= 3
+                and self.build_arg_defaults["EE_BASE_IMAGE"] == constants.build_arg_defaults["EE_BASE_IMAGE"]
             ):
-                raise DefinitionError(
-                    f"Using the outdated base image {self.build_arg_defaults['EE_BASE_IMAGE']} might "
-                    f"result in the build failures."
+                logging.warning(
+                    "Using the outdated base image '%s' might "
+                    "result in the build failures.", self.build_arg_defaults['EE_BASE_IMAGE']
                 )
 
             self._validate_additional_build_files()

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -245,9 +245,14 @@ class UserDefinition:
                     self.builder_image = ImageDescription(images, 'builder_image')
                     self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
 
-            if self.version >= 3 and \
-                self.build_arg_defaults['EE_BASE_IMAGE'] == constants.build_arg_defaults['EE_BASE_IMAGE']:
-                    raise DefinitionError(f"Using the old base image {self.build_arg_defaults['EE_BASE_IMAGE']} might result in build failures.")
+            if (
+                self.version >= 3 and
+                self.build_arg_defaults["EE_BASE_IMAGE"] == constants.build_arg_defaults["EE_BASE_IMAGE"]
+            ):
+                raise DefinitionError(
+                    f"Using the outdated base image {self.build_arg_defaults['EE_BASE_IMAGE']} might "
+                    f"result in the build failures."
+                )
 
             self._validate_additional_build_files()
 

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -247,7 +247,7 @@ class UserDefinition:
 
             if (
                 self.version >= 3
-                and self.build_arg_defaults["EE_BASE_IMAGE"] == constants.build_arg_defaults["EE_BASE_IMAGE"]
+                and self.build_arg_defaults["EE_BASE_IMAGE"] == 'quay.io/ansible/ansible-runner:latest'
             ):
                 logging.warning(
                     "Using the outdated base image '%s' might "

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -245,6 +245,10 @@ class UserDefinition:
                     self.builder_image = ImageDescription(images, 'builder_image')
                     self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
 
+            if self.version >= 3 and \
+                self.build_arg_defaults['EE_BASE_IMAGE'] == constants.build_arg_defaults['EE_BASE_IMAGE']:
+                    raise DefinitionError(f"Using the old base image {self.build_arg_defaults['EE_BASE_IMAGE']} might result in build failures.")
+
             self._validate_additional_build_files()
 
             if self.version >= 3:

--- a/test/data/v3/pre_and_post/ee.yml
+++ b/test/data/v3/pre_and_post/ee.yml
@@ -1,6 +1,10 @@
 ---
 version: 3
 
+images:
+  base_image:
+    name: quay.io/ansible/awx-ee:latest
+
 dependencies:
   galaxy: requirements.yml
 

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -283,7 +283,7 @@ def test_v2_default_builder_image(cli, build_dir_and_ee_yml):
 def test_v3_pre_post_commands(cli, data_dir, tmp_path):
     """Test that the pre/post commands are inserted"""
     ee_def = data_dir / 'v3' / 'pre_and_post' / 'ee.yml'
-    r = cli(f'ansible-builder create -c {str(tmp_path)} -f {ee_def}')
+    r = cli(f'ansible-builder create -c {str(tmp_path)} -f {ee_def} --output-filename Containerfile')
     assert r.rc == 0
 
     containerfile = tmp_path / "Containerfile"
@@ -305,7 +305,7 @@ def test_v3_pre_post_commands(cli, data_dir, tmp_path):
 def test_v3_complete(cli, data_dir, tmp_path):
     """For testing various elements in a complete v2 EE file"""
     ee_def = data_dir / 'v3' / 'complete' / 'ee.yml'
-    r = cli(f'ansible-builder create -c {str(tmp_path)} -f {ee_def}')
+    r = cli(f'ansible-builder create -c {str(tmp_path)} -f {ee_def} --output-filename Containerfile')
     assert r.rc == 0
 
     containerfile = tmp_path / "Containerfile"

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -64,6 +64,9 @@ def test_inline_str_galaxy_requirements(cli, build_dir_and_ee_yml):
     """
     ee_str = """
     version: 3
+    images:
+      base_image:
+        name: 'base_image:latest'
     dependencies:
       galaxy: |
         collections:  # a comment
@@ -90,6 +93,9 @@ def test_inline_mapping_galaxy_requirements(cli, build_dir_and_ee_yml):
     """
     ee_str = """
     version: 3
+    images:
+      base_image:
+        name: 'base_image:latest'
     dependencies:
       galaxy:
         collections:
@@ -359,6 +365,9 @@ def test_v3_skip_ansible_check(cli, build_dir_and_ee_yml):
     """
     ee = [
         'version: 3',
+        'images:',
+        '  base_image:',
+        '    name: quay.io/ansible/awx-ee:latest',
         'options:',
         '  skip_ansible_check: True',
     ]
@@ -377,6 +386,9 @@ def test_v3_skip_container_init(cli, build_dir_and_ee_yml):
     tmpdir, eeyml = build_dir_and_ee_yml(
         """
         version: 3
+        images:
+          base_image:
+            name: quay.io/ansible/awx-ee:latest
         options:
           container_init: {}
         """
@@ -396,6 +408,9 @@ def test_v3_custom_container_init(cli, build_dir_and_ee_yml):
     tmpdir, eeyml = build_dir_and_ee_yml(
         """
         version: 3
+        images:
+          base_image:
+            name: quay.io/ansible/awx-ee:latest
         options:
           container_init:
             package_pip: custominit==1.2.3
@@ -422,6 +437,9 @@ def test_v3_no_relax_passwd_perms(cli, build_dir_and_ee_yml):
     """
     ee = """
     version: 3
+    images:
+      base_image:
+        name: quay.io/ansible/awx-ee:latest
     options:
         relax_passwd_permissions: false
     """
@@ -442,6 +460,9 @@ def test_v3_custom_workdir(cli, build_dir_and_ee_yml):
     """
     ee = """
     version: 3
+    images:
+      base_image:
+        name: quay.io/ansible/awx-ee:latest
     options:
         workdir: /yourmom
     """
@@ -463,6 +484,9 @@ def test_v3_no_workdir(cli, build_dir_and_ee_yml):
     """
     ee = """
     version: 3
+    images:
+      base_image:
+        name: quay.io/ansible/awx-ee:latest
     options:
         workdir:
     """
@@ -485,6 +509,9 @@ def test_v3_set_user_id(cli, build_dir_and_ee_yml):
     tmpdir, eeyml = build_dir_and_ee_yml(
         """
         version: 3
+        images:
+          base_image:
+            name: quay.io/ansible/awx-ee:latest
         options:
           user: bob
         """

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -44,7 +44,7 @@ def test_custom_ansible_galaxy_cli_role_opts(exec_env_definition_file, tmp_path)
 
 
 def test_build_args_empty_value(exec_env_definition_file, tmp_path):
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
 
     aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_ROLE_OPTS=', '-c', str(tmp_path)])
@@ -52,7 +52,7 @@ def test_build_args_empty_value(exec_env_definition_file, tmp_path):
 
 
 def test_build_args_no_trailing_equal(exec_env_definition_file, tmp_path):
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
 
     aee = prepare(['build', '-f', path, '--build-arg', 'ANSIBLE_GALAXY_CLI_ROLE_OPTS', '-c', str(tmp_path)])
@@ -60,7 +60,7 @@ def test_build_args_no_trailing_equal(exec_env_definition_file, tmp_path):
 
 
 def test_build_args_multiple_equal_sign_value(exec_env_definition_file, tmp_path):
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
 
     aee = prepare(['build', '-f', path,
@@ -257,7 +257,7 @@ def test_squash_default(exec_env_definition_file, tmp_path):
     '''
     Test the squash CLI option with default.
     '''
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build',
                    '-f', path,
@@ -271,7 +271,7 @@ def test_squash_all(exec_env_definition_file, tmp_path):
     '''
     Test the squash CLI option with 'all'.
     '''
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build',
                    '-f', path,
@@ -286,7 +286,7 @@ def test_squash_off(exec_env_definition_file, tmp_path):
     '''
     Test the squash CLI option with 'off'.
     '''
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build',
                    '-f', path,
@@ -301,7 +301,7 @@ def test_squash_new(exec_env_definition_file, tmp_path):
     '''
     Test the squash CLI option with 'new'.
     '''
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build',
                    '-f', path,
@@ -317,7 +317,7 @@ def test_squash_ignored(exec_env_definition_file, tmp_path):
     '''
     Test the squash CLI option is ignored with docker.
     '''
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build',
                    '-f', path,
@@ -348,7 +348,7 @@ def test_as_executable_module(capsys):
                           ('--verbosity', 1),
                           ('--verbosity=2', 2)])
 def test_verbosity(exec_env_definition_file, tmp_path, verbosity_opt, expected_val):
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
 
     aee = prepare(['create',
@@ -361,7 +361,7 @@ def test_verbosity(exec_env_definition_file, tmp_path, verbosity_opt, expected_v
 
 @pytest.mark.parametrize('verbosity_opt', ['-v4', '-vvvv', '-v -v -v -v', '--verbosity=4'])
 def test_invalid_verbosity(exec_env_definition_file, tmp_path, verbosity_opt):
-    content = {'version': 3}
+    content = {'version': 3, 'images': {'base_image': {'name': 'base_image:latest'}}}
     path = str(exec_env_definition_file(content=content))
     with pytest.raises(ValueError, match=f'maximum verbosity is {constants.max_verbosity}'):
         prepare(['create', '-f', path, '-c', str(tmp_path), verbosity_opt])

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -63,11 +63,13 @@ class TestUserDefinition:
             "Additional properties are not allowed ('prepend' was unexpected)"
         ),  # 'prepend' is renamed in v2
         (
-            "{'version': 3, 'additional_build_files': [ {'src': 'a', 'dest': '../b'} ]}",
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}}, "
+            "'additional_build_files': [ {'src': 'a', 'dest': '../b'} ]}",
             "'dest' must not be an absolute path or contain '..': ../b"
         ),  # destination cannot contain ..
         (
-            "{'version': 3, 'additional_build_files': [ {'src': 'a', 'dest': '/b'} ]}",
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}}, "
+            "'additional_build_files': [ {'src': 'a', 'dest': '/b'} ]}",
             "'dest' must not be an absolute path or contain '..': /b"
         ),  # destination cannot be absolute
         (
@@ -168,6 +170,7 @@ class TestUserDefinition:
         path = exec_env_definition_file(
             """
             {'version': 3,
+             'images': { 'base_image': {'name': 'base_image:latest'}},
              'dependencies': {
                 'ansible_core': {'package_pip': 'ansible-core==2.13'},
                 'ansible_runner': { 'package_pip': 'ansible-runner==2.3.1'}
@@ -186,7 +189,8 @@ class TestUserDefinition:
         Test that inline values for dependencies.python work.
         """
         path = exec_env_definition_file(
-            "{'version': 3, 'dependencies': {'python': ['req1', 'req2']}}"
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}},"
+            "'dependencies': {'python': ['req1', 'req2']}}"
         )
         definition = UserDefinition(path)
         definition.validate()
@@ -199,7 +203,8 @@ class TestUserDefinition:
         Test that inline values for dependencies.system work.
         """
         path = exec_env_definition_file(
-            "{'version': 3, 'dependencies': {'system': ['req1', 'req2']}}"
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}},"
+            "'dependencies': {'system': ['req1', 'req2']}}"
         )
         definition = UserDefinition(path)
         definition.validate()
@@ -212,7 +217,7 @@ class TestUserDefinition:
         Test that options.skip_ansible_check defaults to False
         """
         path = exec_env_definition_file(
-            "{'version': 3}"
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}}}"
         )
         definition = UserDefinition(path)
         definition.validate()
@@ -225,7 +230,7 @@ class TestUserDefinition:
         Test that options.user defaults to 1000
         """
         path = exec_env_definition_file(
-            "{'version': 3}"
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}}}"
         )
         definition = UserDefinition(path)
         definition.validate()
@@ -238,7 +243,8 @@ class TestUserDefinition:
         Test that options.user sets to username
         """
         path = exec_env_definition_file(
-            "{'version': 3, 'options': {'user': 'bob'}}"
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}},"
+            "'options': {'user': 'bob'}}"
         )
         definition = UserDefinition(path)
         definition.validate()
@@ -251,7 +257,8 @@ class TestUserDefinition:
         Test that options.tags sets to tags
         """
         path = exec_env_definition_file(
-            "{'version': 3, 'options': {'tags': ['ee_test:latest']}}"
+            "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}}, "
+            "'options': {'tags': ['ee_test:latest']}}"
         )
         definition = UserDefinition(path)
         definition.validate()


### PR DESCRIPTION
##### SUMMARY

* Default base image is old, using it in v3 definition might
  result in build failures. It is good idea to fail before proceeding.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
src/ansible_builder/user_definition.py
test/unit/test_user_definition.py

