### PR TITLE
 Supports line continuations for requirements.txt

### DIFF
--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -28,7 +28,7 @@ def pip_file_data(path):
     pip_content = read_req_file(path)
 
     pip_lines = []
-    for line in pip_content.split('\n'):
+    for line in join_lines(pip_content.split('\n')):
         if line_is_empty(line):
             continue
         if line.startswith('-r') or line.startswith('--requirement'):
@@ -39,6 +39,23 @@ def pip_file_data(path):
             pip_lines.append(line)
 
     return pip_lines
+
+
+def join_lines(pip_lines):
+
+    joined_pip_lines = []
+    contexts = []
+    for line in pip_lines:
+        if line.endswith('\\'):
+            contexts.append(line.strip('\\'))
+        else:
+            if contexts:
+                contexts.append(line)
+                joined_pip_lines.append(''.join(contexts))
+                contexts.clear()
+            else:
+                joined_pip_lines.append(line)
+    return joined_pip_lines
 
 
 def bindep_file_data(path):

--- a/test/data/ansible_collections/test/splitted_lines/requirements.txt
+++ b/test/data/ansible_collections/test/splitted_lines/requirements.txt
@@ -1,0 +1,5 @@
+paramiko
+ansible-pylibssh\
+  >=\
+  1.1.0
+ncclient

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -37,6 +37,19 @@ def test_single_collection_metadata(data_dir):
     assert not sys_reqs
 
 
+def test_single_collection_splitted_lines(data_dir):
+
+    col_path = os.path.join(data_dir, 'ansible_collections', 'test', 'splitted_lines')
+    py_reqs, sys_reqs = process_collection(col_path)
+
+    assert py_reqs == [
+        'paramiko',
+        'ansible-pylibssh  >=  1.1.0',
+        'ncclient'
+    ]
+    assert not sys_reqs
+
+
 def test_parse_args_empty(capsys):
     with pytest.raises(SystemExit):
         parse_args()


### PR DESCRIPTION
#### SUMMARY

This PR allows [line continuations](https://pip.pypa.io/en/stable/reference/requirements-file-format/#line-continuations) by `\` for `requirements.txt`.

#### ISSUE TYPE

- Bugfix Pull Request

#### COMPONENT NAME

- src/ansible_builder/_target_scripts/introspect.py

### ADDITIONAL INFORMATION

related to:
  - https://github.com/ansible/ansible-builder/issues/593
  - https://github.com/PaloAltoNetworks/pan-os-ansible/issues/447

(Not a PR that solves all problems)
