### PR TITLE
Add type hints for Containerfile and AnsibleBuilder

### DIFF
--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -178,6 +178,7 @@ def add_container_options(parser):
                        help='A gpg status code to ignore during signature verification when installing with '
                        'ansible-galaxy. May be specified multiple times. See ansible-galaxy doc for more info.')
         p.add_argument('--galaxy-required-valid-signature-count',
+                       type=int,
                        help='The number of signatures that must successfully verify collections from '
                        'ansible-galaxy ~if there are any signatures provided~. See ansible-galaxy doc for more info.')
 

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os
 
 from . import constants
 from .containerfile import Containerfile
-from .policies import PolicyChoices, IgnoreAll, ExactReference
+from .policies import PolicyChoices, BaseImagePolicy, IgnoreAll, ExactReference
 from .user_definition import UserDefinition
 from .utils import run_command
 
@@ -13,30 +15,45 @@ logger = logging.getLogger(__name__)
 
 class AnsibleBuilder:
     def __init__(self,
-                 action=None,
-                 filename=constants.default_file,
-                 build_args=None,
-                 build_context=constants.default_build_context,
-                 tag=None,
-                 container_runtime=constants.default_container_runtime,
-                 output_filename=None,
-                 no_cache=False,
-                 prune_images=False,
-                 verbosity=constants.default_verbosity,
-                 galaxy_keyring=None,
-                 galaxy_required_valid_signature_count=None,
-                 galaxy_ignore_signature_status_codes=(),
-                 container_policy=None,
-                 container_keyring=None,
-                 squash=None,
-                 ):
+                 action: str,
+                 filename: str = constants.default_file,
+                 build_args: dict[str, str] | None = None,
+                 build_context: str = constants.default_build_context,
+                 tag: list | None = None,
+                 container_runtime: str = constants.default_container_runtime,
+                 output_filename: str | None = None,
+                 no_cache: bool = False,
+                 prune_images: bool = False,
+                 verbosity: int = constants.default_verbosity,
+                 galaxy_keyring: str | None = None,
+                 galaxy_required_valid_signature_count: int | None = None,
+                 galaxy_ignore_signature_status_codes: list | None = None,
+                 container_policy: str | None = None,
+                 container_keyring: str | None = None,
+                 squash: str | None = None,
+                 ) -> None:
         """
-        :param str galaxy_keyring: GPG keyring file used by ansible-galaxy to
-                                   opportunistically validate collection signatures.
-        :param str galaxy_required_valid_signature_count: Number of sigs (prepend + to disallow no sig) required
-                                                          for ansible-galaxy to accept collections.
-        :param str galaxy_ignore_signature_status_codes: GPG Status code to ignore when validating galaxy collections.
+        Initialize the AnsibleBuilder object.
+
+        :param str action: Builder action to perform (build/create/introspect).
+        :param str filename: Execution environment file to use.
+        :param dict build_args: Dictionary of build args to consider.
+        :param str build_context: Name of the build context directory.
+        :param list tag: List of tag names to apply to resulting image.
+        :param str container_runtime: Name of the container runtime in use.
+        :param str output_filename: Name of the resulting instruction file. If not supplied, it
+            will default to a value based on container_runtime.
+        :param bool no_cache: If True, will not use the build cache when building an image.
+        :param bool prune_images: If True, will attempt an image prune at the end of a successful build.
+        :param int verbosity: Output verbosity level.
+        :param str galaxy_keyring: GPG keyring file used by ansible-galaxy to opportunistically
+            validate collection signatures.
+        :param int galaxy_required_valid_signature_count: Number of sigs (prepend + to disallow no sig)
+            required for ansible-galaxy to accept collections.
+        :param list galaxy_ignore_signature_status_codes: GPG Status code to ignore when validating galaxy collections.
         :param str container_policy: The container validation policy. A valid string value from the PolicyChoices enum.
+        :param str container_keyring: GPG keyring for container image validation.
+        :param str squash: With podman, controls layer squashing.
         """
 
         if not galaxy_keyring and (galaxy_required_valid_signature_count or galaxy_ignore_signature_status_codes):
@@ -68,6 +85,7 @@ class AnsibleBuilder:
         self.build_args = build_args or {}
         self.no_cache = no_cache
         self.prune_images = prune_images
+
         self.containerfile = Containerfile(
             definition=self.definition,
             build_context=self.build_context,
@@ -76,6 +94,7 @@ class AnsibleBuilder:
             galaxy_keyring=galaxy_keyring,
             galaxy_required_valid_signature_count=galaxy_required_valid_signature_count,
             galaxy_ignore_signature_status_codes=galaxy_ignore_signature_status_codes)
+
         self.verbosity = verbosity
         self.container_policy, self.container_keyring = self._handle_image_validation_opts(
             container_policy,
@@ -83,7 +102,10 @@ class AnsibleBuilder:
         )
         self.squash = squash
 
-    def _handle_image_validation_opts(self, policy, keyring):
+    def _handle_image_validation_opts(self,
+                                      policy: str | None,
+                                      keyring: str | None,
+                                      ) -> tuple[PolicyChoices | None, str | None]:
         """
         Process the container_policy and container_keyring arguments.
 
@@ -140,20 +162,21 @@ class AnsibleBuilder:
         return (resolved_policy, resolved_keyring)
 
     @property
-    def version(self):
+    def version(self) -> int:
         return self.definition.version
 
     @property
-    def ansible_config(self):
+    def ansible_config(self) -> str:
         return self.definition.ansible_config
 
-    def create(self):
+    def create(self) -> bool:
         logger.debug('Ansible Builder is generating your execution environment build context.')
         self.containerfile.prepare()
-        return self.containerfile.write()
+        self.containerfile.write()
+        return True
 
     @property
-    def prune_image_command(self):
+    def prune_image_command(self) -> list[str]:
         command = [
             self.container_runtime, "image",
             "prune", "--force"
@@ -161,7 +184,7 @@ class AnsibleBuilder:
         return command
 
     @property
-    def build_command(self):
+    def build_command(self) -> list[str]:
         command = [
             self.container_runtime, "build",
             "-f", self.containerfile.path
@@ -191,6 +214,8 @@ class AnsibleBuilder:
         if self.container_policy:
             logger.debug('Container policy is %s', PolicyChoices(self.container_policy).value)
 
+            policy: BaseImagePolicy
+
             if self.container_policy == PolicyChoices.IGNORE:
                 policy = IgnoreAll()
             elif self.container_policy == PolicyChoices.SIG_REQ:
@@ -219,7 +244,7 @@ class AnsibleBuilder:
 
         return command
 
-    def build(self):
+    def build(self) -> bool:
         self.create()
         logger.debug('Ansible Builder is building your execution environment image. Tags: %s', ", ".join(self.tags))
         run_command(self.build_command)

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -6,13 +6,13 @@ from ansible_builder.main import AnsibleBuilder
 
 def test_definition_version(exec_env_definition_file):
     path = exec_env_definition_file(content={'version': 1})
-    aee = AnsibleBuilder(filename=path)
+    aee = AnsibleBuilder(action='create', filename=path)
     assert aee.version == 1
 
 
 def test_definition_version_missing(exec_env_definition_file):
     path = exec_env_definition_file(content={})
-    aee = AnsibleBuilder(filename=path)
+    aee = AnsibleBuilder(action='create', filename=path)
     assert aee.version == 1
 
 
@@ -35,7 +35,7 @@ def test_galaxy_requirements(exec_env_definition_file, galaxy_requirements_file,
 
     exec_env_path = exec_env_definition_file(content=exec_env_content)
 
-    aee = AnsibleBuilder(filename=exec_env_path, build_context=str(tmp_path / 'bc'))
+    aee = AnsibleBuilder(action='create', filename=exec_env_path, build_context=str(tmp_path / 'bc'))
     aee.build()
 
     with open(aee.containerfile.path) as f:
@@ -47,7 +47,7 @@ def test_galaxy_requirements(exec_env_definition_file, galaxy_requirements_file,
 def test_base_image_via_build_args(exec_env_definition_file, tmp_path):
     content = {'version': 1}
     path = exec_env_definition_file(content=content)
-    aee = AnsibleBuilder(filename=path, build_context=tmp_path.joinpath('bc').as_posix())
+    aee = AnsibleBuilder(action='create', filename=path, build_context=tmp_path.joinpath('bc').as_posix())
     aee.build()
 
     with open(aee.containerfile.path) as f:
@@ -56,6 +56,7 @@ def test_base_image_via_build_args(exec_env_definition_file, tmp_path):
     assert 'ansible-runner' in content
 
     aee = AnsibleBuilder(
+        action='create',
         filename=path, build_args={'EE_BASE_IMAGE': 'my-custom-image'},
         build_context=tmp_path.joinpath('bc2')
     )
@@ -75,7 +76,7 @@ def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmp_
         }
     }
     path = exec_env_definition_file(content=content)
-    aee = AnsibleBuilder(filename=path, build_context=tmp_path.joinpath('bc'))
+    aee = AnsibleBuilder(action='create', filename=path, build_context=tmp_path.joinpath('bc'))
     aee.build()
 
     with open(aee.containerfile.path) as f:
@@ -89,12 +90,12 @@ def test_build_command(exec_env_definition_file, runtime):
     content = {'version': 1}
     path = exec_env_definition_file(content=content)
 
-    aee = AnsibleBuilder(filename=path, tag=['my-custom-image'])
+    aee = AnsibleBuilder(action='create', filename=path, tag=['my-custom-image'])
     command = aee.build_command
     assert 'build' in command
     assert 'my-custom-image' in command
 
-    aee = AnsibleBuilder(filename=path, build_context='foo/bar/path', container_runtime=runtime)
+    aee = AnsibleBuilder(action='create', filename=path, build_context='foo/bar/path', container_runtime=runtime)
 
     command = aee.build_command
     assert 'foo/bar/path' in command
@@ -104,7 +105,7 @@ def test_build_command(exec_env_definition_file, runtime):
 
 def test_nested_galaxy_file(data_dir, tmp_path):
     nested_galaxy_file = str(data_dir / 'nested_galaxy_file' / 'nested-galaxy.yml')
-    AnsibleBuilder(filename=nested_galaxy_file, build_context=tmp_path).build()
+    AnsibleBuilder(action='create', filename=nested_galaxy_file, build_context=tmp_path).build()
 
     req_in_bc = tmp_path.joinpath(constants.user_content_subfolder, 'requirements.yml')
     assert req_in_bc.exists()
@@ -124,7 +125,7 @@ def test_ansible_config_for_galaxy(exec_env_definition_file, tmp_path, data_dir)
         },
     }
     path = exec_env_definition_file(content=content)
-    aee = AnsibleBuilder(filename=path, build_context=tmp_path.joinpath('bc'))
+    aee = AnsibleBuilder(action='create', filename=path, build_context=tmp_path.joinpath('bc'))
     aee.build()
 
     with open(aee.containerfile.path) as f:
@@ -137,6 +138,7 @@ def test_ansible_config_for_galaxy(exec_env_definition_file, tmp_path, data_dir)
 def test_use_dockerfile(exec_env_definition_file, tmp_path, runtime):
     path = exec_env_definition_file(content={'version': 1})
     aee = AnsibleBuilder(
+        action='create',
         filename=path, build_context=tmp_path.joinpath('bc'),
         container_runtime=runtime, output_filename='Dockerfile'
     )

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -12,7 +12,7 @@ class TestUserDefinition:
         path = os.path.join(data_dir, 'definition_files/bad.yml')
 
         with pytest.raises(DefinitionError) as error:
-            AnsibleBuilder(filename=path)
+            AnsibleBuilder(action='create', filename=path)
 
         assert 'An error occurred while parsing the definition file:' in str(error.value.args[0])
 
@@ -110,7 +110,7 @@ class TestUserDefinition:
         path = "exec_env.txt"
 
         with pytest.raises(DefinitionError) as error:
-            AnsibleBuilder(filename=path)
+            AnsibleBuilder(action='create', filename=path)
 
         err_msg = "Could not detect 'exec_env.txt' file in this directory.\nUse -f to specify a different location."
         assert err_msg in str(error.value.args[0])
@@ -121,13 +121,13 @@ class TestUserDefinition:
         """
         path = exec_env_definition_file("{'version': 1, 'bad_key': 1}")
         with pytest.raises(DefinitionError) as error:
-            AnsibleBuilder(filename=path)
+            AnsibleBuilder(action='create', filename=path)
         assert "Additional properties are not allowed ('bad_key' was unexpected)" in str(error.value.args[0])
 
     def test_ee_missing_image_name(self, exec_env_definition_file):
         path = exec_env_definition_file("{'version': 2, 'images': { 'base_image': {'signature_original_name': ''}}}")
         with pytest.raises(DefinitionError) as error:
-            AnsibleBuilder(filename=path)
+            AnsibleBuilder(action='create', filename=path)
         assert "'name' is a required field for 'base_image'" in str(error.value.args[0])
 
     def test_v1_to_v2_key_upgrades(self, exec_env_definition_file):


### PR DESCRIPTION
Adding type hints to Containerfile and the AnsibleBuilder led to the following related changes:

- The `action` parameter to `AnsibleBuilder` should not allow `None` (seems this was only useful in tests).
- The `galaxy_required_valid_signature_count` parameter to `Containerfile` and `AnsibleBuilder` should only ever be an `int` value, so this is now forced in CLI argument parsing.
- `galaxy_ignore_signature_status_codes` was being initialized to an empty `tuple`, but this should only ever be a `list` type.
- `Containerfile.write()` method had a useless `bool` return value. This is moved to `AnsibleBuilder.create()` (the caller which is the method that is required to return `True`).