### PR TITLE
Account for PEP668 in pip invocations

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -357,6 +357,7 @@ builder runtime functionality. Valid keys for this section are:
       the base image. Pip is necessary for Python requirement installation, among
       other things. You may choose to disable this step and handle installing
       pip manually if the current method of pip installation does not work for you.
+      The default is ``False``.
 
     ``relax_passwd_permissions``
       This boolean value controls whether the ``root`` group (GID 0) is explicitly granted

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -352,6 +352,12 @@ builder runtime functionality. Valid keys for this section are:
       of Ansible and Ansible Runner is performed on the final image. Set this
       value to ``True`` to not perform this check. The default is ``False``.
 
+    ``skip_pip_install``
+      This boolean value controls whether or not we attempt to install pip into
+      the base image. Pip is necessary for Python requirement installation, among
+      other things. You may choose to disable this step and handle installing
+      pip manually if the current method of pip installation does not work for you.
+
     ``relax_passwd_permissions``
       This boolean value controls whether the ``root`` group (GID 0) is explicitly granted
       write permission to ``/etc/passwd`` in the final container image. The default entrypoint

--- a/src/ansible_builder/_target_scripts/assemble
+++ b/src/ansible_builder/_target_scripts/assemble
@@ -31,8 +31,6 @@ PKGMGR_PRESERVE_CACHE="${PKGMGR_PRESERVE_CACHE:-}"
 PYCMD="${PYCMD:=/usr/bin/python3}"
 PIPCMD="${PIPCMD:=$PYCMD -m pip}"
 
-$PYCMD -m ensurepip --root /
-
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.
     PKGMGR=/usr/bin/dnf

--- a/src/ansible_builder/_target_scripts/assemble
+++ b/src/ansible_builder/_target_scripts/assemble
@@ -31,7 +31,7 @@ PKGMGR_PRESERVE_CACHE="${PKGMGR_PRESERVE_CACHE:-}"
 PYCMD="${PYCMD:=/usr/bin/python3}"
 PIPCMD="${PIPCMD:=$PYCMD -m pip}"
 
-$PYCMD -m ensurepip
+$PYCMD -m ensurepip --root /
 
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.

--- a/src/ansible_builder/_target_scripts/install-from-bindep
+++ b/src/ansible_builder/_target_scripts/install-from-bindep
@@ -25,7 +25,7 @@ PYCMD="${PYCMD:=/usr/bin/python3}"
 PIPCMD="${PIPCMD:=$PYCMD -m pip}"
 PIP_OPTS="${PIP_OPTS-}"
 
-$PYCMD -m ensurepip
+$PYCMD -m ensurepip --root /
 
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.

--- a/src/ansible_builder/_target_scripts/install-from-bindep
+++ b/src/ansible_builder/_target_scripts/install-from-bindep
@@ -25,8 +25,6 @@ PYCMD="${PYCMD:=/usr/bin/python3}"
 PIPCMD="${PIPCMD:=$PYCMD -m pip}"
 PIP_OPTS="${PIP_OPTS-}"
 
-$PYCMD -m ensurepip --root /
-
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.
     PKGMGR=/usr/bin/dnf

--- a/src/ansible_builder/_target_scripts/pip_install
+++ b/src/ansible_builder/_target_scripts/pip_install
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#####################################################################
+# Script to encapsulate pip installation.
+#
+# Usage: pip_install <PYCMD>
+#
+# Options:
+#     PYCMD - The path to the python executable to use.
+#####################################################################
+
+set -x
+
+PYCMD=$1
+
+if [ -z "$PYCMD" ]
+then
+    echo "Usage: pip_install <PYCMD>"
+    exit 1
+fi
+
+if [ ! -x "$PYCMD" ]
+then
+    echo "$PYCMD is not an executable"
+    exit 1
+fi
+
+# This is going to be our default functionality for now. This will likely
+# need to change if we add support for non-RHEL distros.
+$PYCMD -m ensurepip --root /
+
+if [ $? -ne 0 ]
+then
+    cat<<EOF
+**********************************************************************
+ERROR - pip installation failed for Python $PYCMD
+**********************************************************************
+EOF
+    exit 1
+fi
+
+exit 0

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -127,7 +127,7 @@ class Containerfile:
         # Second stage (aka, builder): assemble (pip installs, bindep run)
         ######################################################################
 
-        if self.definition.builder_image:
+        if self.definition.builder_image or self.definition.version == 1:
             # Note: A builder image can be specified only in V1 or V2 schema.
             image = "$EE_BUILDER_IMAGE"
         else:
@@ -147,7 +147,9 @@ class Containerfile:
         if image == "base":
             self.steps.append("RUN $PYCMD -m pip install --no-cache-dir bindep pyyaml requirements-parser")
         else:
-            # For < v3 with a custom builder image, we always make sure pip is available.
+            # For an EE schema earlier than v3 with a custom builder image, we always make sure pip is available.
+            context_dir = Path(self.build_outputs_dir).stem
+            self.steps.append(f'COPY {context_dir}/scripts/pip_install /output/scripts/pip_install')
             self.steps.append("RUN /output/scripts/pip_install $PYCMD")
 
         self._insert_custom_steps('prepend_builder')

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -108,7 +108,6 @@ class Containerfile:
                 "",
                 "# Galaxy build stage",
                 "FROM base as galaxy",
-                "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
             ])
 
             self._insert_global_args()

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -106,6 +106,7 @@ class Containerfile:
                 "",
                 "# Galaxy build stage",
                 "FROM base as galaxy",
+                "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
             ])
 
             self._insert_global_args()
@@ -135,6 +136,7 @@ class Containerfile:
             "",
             "# Builder build stage",
             f"FROM {image} as builder",
+            "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
             "WORKDIR /build",
         ])
 
@@ -156,6 +158,7 @@ class Containerfile:
             "",
             "# Final build stage",
             "FROM base as final",
+            "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
         ])
 
         self._insert_global_args()

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -76,6 +76,7 @@ class Containerfile:
             "# Base build stage",
             "FROM $EE_BASE_IMAGE as base",
             "USER root",
+            "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
         ])
 
         self._insert_global_args()
@@ -87,7 +88,7 @@ class Containerfile:
                 self.steps.append(step)
 
             # We should always make sure pip is available for later stages.
-            self.steps.append('RUN $PYCMD -m ensurepip')
+            self.steps.append('RUN $PYCMD -m ensurepip --root /')
 
             if self.definition.ansible_ref_install_list:
                 self.steps.append('RUN $PYCMD -m pip install --no-cache-dir $ANSIBLE_INSTALL_REFS')

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -341,6 +341,10 @@ schema_v3 = {
                     "description": "Disables the check for Ansible/Runner in final image",
                     "type": "boolean",
                 },
+                "skip_pip_install": {
+                    "description": "Disables the installation of pip in the base image",
+                    "type": "boolean",
+                },
                 "workdir": {
                     "description": "Default working directory, also often the homedir for ephemeral UIDs",
                     "type": ["string", "null"],
@@ -444,6 +448,7 @@ def _handle_options_defaults(ee_def: dict):
     entrypoint_path = os.path.join(constants.FINAL_IMAGE_BIN_PATH, "entrypoint")
 
     options.setdefault('skip_ansible_check', False)
+    options.setdefault('skip_pip_install', False)
     options.setdefault('relax_passwd_permissions', True)
     options.setdefault('workdir', '/runner')
     options.setdefault('package_manager_path', '/usr/bin/dnf')

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -209,9 +209,9 @@ def test__handle_additional_build_files(build_dir_and_ee_yml):
     assert (config_dir / 'ansible.cfg').exists()
 
 
-def test_pep668_env_var_v1(build_dir_and_ee_yml):
+def test_pep668_v1(build_dir_and_ee_yml):
     """
-    Test that we add the pip env var to handle PEP668.
+    Test PEP668 handling with v1 format.
     """
     ee_data = """
     version: 1
@@ -220,11 +220,12 @@ def test_pep668_env_var_v1(build_dir_and_ee_yml):
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
     assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps
+    assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
 
 
-def test_pep668_env_var_v2(build_dir_and_ee_yml):
+def test_pep668_v2(build_dir_and_ee_yml):
     """
-    Test that we add the pip env var to handle PEP668.
+    Test PEP668 handling with v2 format.
     """
     ee_data = """
     version: 2
@@ -238,11 +239,12 @@ def test_pep668_env_var_v2(build_dir_and_ee_yml):
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
     assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps
+    assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
 
 
-def test_pep668_env_var_v3(build_dir_and_ee_yml):
+def test_pep668_v3(build_dir_and_ee_yml):
     """
-    Test that we add the pip env var to handle PEP668.
+    Test PEP668 handling with v3 format.
     """
     ee_data = """
     version: 3
@@ -254,3 +256,76 @@ def test_pep668_env_var_v3(build_dir_and_ee_yml):
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
     assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps
+    assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
+
+
+def test_pep668_v3_skip_pip_install(build_dir_and_ee_yml):
+    """
+    Test PEP668 handling with v3 format and skipping pip installation.
+    """
+    ee_data = """
+    version: 3
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+    options:
+      skip_pip_install: True
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps
+    assert "RUN /output/scripts/pip_install $PYCMD" not in c.steps
+
+
+def test_v1_builder_image(build_dir_and_ee_yml):
+    """
+    Test for issue 646 (https://github.com/ansible/ansible-builder/issues/646).
+    Also test that pip_install is installed into the custom builder image.
+    """
+    ee_data = """
+    version: 1
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "FROM $EE_BUILDER_IMAGE as builder" in c.steps
+    assert "COPY _build/scripts/pip_install /output/scripts/pip_install" in c.steps
+    assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
+
+
+def test_v2_builder_image(build_dir_and_ee_yml):
+    """
+    Test that pip_install is installed into the custom v2 builder image.
+    """
+    ee_data = """
+    version: 2
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+      builder_image:
+        name: quay.io/user/mycustombuilderimage:latest
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "FROM $EE_BUILDER_IMAGE as builder" in c.steps
+    assert "COPY _build/scripts/pip_install /output/scripts/pip_install" in c.steps
+    assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
+
+
+def test_v2_builder_image_default(build_dir_and_ee_yml):
+    """
+    Test that pip_install is NOT installed into the builder image when not defined.
+    """
+    ee_data = """
+    version: 2
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "FROM base as builder" in c.steps
+    assert "COPY _build/scripts/pip_install /output/scripts/pip_install" not in c.steps

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -207,3 +207,50 @@ def test__handle_additional_build_files(build_dir_and_ee_yml):
     config_dir = tmpdir / '_build' / 'configs'
     assert config_dir.exists()
     assert (config_dir / 'ansible.cfg').exists()
+
+
+def test_pep668_env_var_v1(build_dir_and_ee_yml):
+    """
+    Test that we add the pip env var to handle PEP668.
+    """
+    ee_data = """
+    version: 1
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps
+
+
+def test_pep668_env_var_v2(build_dir_and_ee_yml):
+    """
+    Test that we add the pip env var to handle PEP668.
+    """
+    ee_data = """
+    version: 2
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+      builder_image:
+        name: quay.io/user/mycustombuilderimage:latest
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps
+
+
+def test_pep668_env_var_v3(build_dir_and_ee_yml):
+    """
+    Test that we add the pip env var to handle PEP668.
+    """
+    ee_data = """
+    version: 3
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "ENV PIP_BREAK_SYSTEM_PACKAGES=1" in c.steps


### PR DESCRIPTION
- Set the PIP_BREAK_SYSTEM_PACKAGES environment variable anywhere pip is in use to account for PEP668 which would change pip to not allow us to install in the system environment for newer versions of pip.
- Adds new `pip_install` target script to encapsulate the pip install logic. This will be called to install pip in the `base` image, and thus inherited by the other images. For v1 EE schemas, we _always_ copy this script to the `builder` image and call it since it will be separate from `base`. For v2, we only copy `pip_install` to the builder image and call it when one is defined.
- Remove `ensurepip` calls from inside target scripts so we can control pip installation external to those scripts. Also, those calls are unnecessary since we install pip in the `base` image (caveat: see the builder image hoops outlined in previous step).
- Add new `skip_pip_install` option to EE schema to manage pip installation.
- BONUS fix for issue #646 which was preventing adding a somewhat decent test for this feature.

Fixes #604 
Fixes #646