### PR TITLE
introspect: add ability to specify requirements right in meta/execution-environment.yml

### DIFF
--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -63,14 +63,22 @@ def process_collection(path):
     CD = CollectionDefinition(path)
 
     py_file = CD.get_dependency('python')
-    pip_lines = []
-    if py_file:
-        pip_lines = pip_file_data(os.path.join(path, py_file))
+    # When requirements specified right in meta/execution-environment.yml:
+    if isinstance(py_file, list):
+        pip_lines = py_file
+    else:
+        pip_lines = []
+        if py_file:
+            pip_lines = pip_file_data(os.path.join(path, py_file))
 
     sys_file = CD.get_dependency('system')
-    bindep_lines = []
-    if sys_file:
-        bindep_lines = bindep_file_data(os.path.join(path, sys_file))
+    # When requirements specified right in meta/execution-environment.yml:
+    if isinstance(sys_file, list):
+        bindep_lines = sys_file
+    else:
+        bindep_lines = []
+        if sys_file:
+            bindep_lines = bindep_file_data(os.path.join(path, sys_file))
 
     return (pip_lines, bindep_lines)
 
@@ -181,6 +189,9 @@ class CollectionDefinition:
         req_file = self.raw.get('dependencies', {}).get(entry)
         if req_file is None:
             return None
+        # When requirements specified right in meta/execution-environment.yml:
+        if isinstance(req_file, list):
+            return req_file
         if os.path.isabs(req_file):
             raise RuntimeError(
                 'Collections must specify relative paths for requirements files. '

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -57,6 +57,8 @@ def process_collection(path):
     """Return a tuple of (python_dependencies, system_dependencies) for the
     collection install path given.
     Both items returned are a list of dependencies.
+    If a value is already a list of dependencies,
+    the function does nothing just returning the list.
 
     :param str path: root directory of collection (this would contain galaxy.yml file)
     """


### PR DESCRIPTION
In https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#collection-level-dependencies is written:
```
The meta/execution-environment.yml file containing the Python and/or bindep requirements
or referencing other files listing them. The .yaml extension is also valid on this file.
```
The `containing the Python and/or bindep requirements` part of the statement is not true. I tried and it throws a type error.
It would be nice if it works as it's convenient and it would allow not to pollute collection repos with additional files.
For the context, see https://forum.ansible.com/t/collection-inclusion-requirements-add-requirements-txt-and-bindep-txt/2611/8 (thanks @felixfontein for spotting this).

This PR allows to specify dependencies right in `meta/execution-environments.yml`. Tested locally and it works as expected.

NOTE: if you're OK with the idea and approve it in general, I'll try to fix the unit tests.