### PR TITLE
Update EE getting started URL to point to new location

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Before you start using Ansible Builder, you should understand the following conc
 What are execution environments?
 ================================
 
-Refer to the `Getting started with Execution Environments guide <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_ for details.
+Refer to the `Getting started with Execution Environments guide <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ for details.
 
 Quickstart for Ansible Builder
 ==============================


### PR DESCRIPTION
This PR fixes the URL for getting started with EE
Fixes https://github.com/ansible/ansible-builder/issues/632