### PR TITLE
Drop requirements-parser in favor of pep508

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
           - name: '3.11'
             tox_env: integration-py311
 
+          - name: '3.12'
+            tox_env: integration-py312
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -172,6 +175,9 @@ jobs:
 
           - name: '3.11'
             tox_env: unit-py311
+
+          - name: '3.12'
+            tox_env: unit-py312
 
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ max-line-length=160
 include_package_data = true
 install_requires =
     PyYAML
-    requirements_parser
+    packaging
     bindep
     jsonschema
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development :: Build Tools
     Topic :: System :: Systems Administration

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -354,6 +354,7 @@ def sanitize_requirements(collection_py_reqs):
                     # An explicit install URL is preferred over none
                     # The first URL seen wins
                     prior_req.url = req.url
+                prior_req.extras.update(req.extras)
                 prior_req.collections.append(collection)
                 continue
             consolidated[key] = req

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -350,6 +350,10 @@ def sanitize_requirements(collection_py_reqs):
             if (prior_req := consolidated.get(key)):
                 specifiers = f'{prior_req.specifier},{req.specifier}'
                 prior_req.specifier = SpecifierSet(specifiers)
+                if not prior_req.url and req.url:
+                    # An explicit install URL is preferred over none
+                    # The first URL seen wins
+                    prior_req.url = req.url
                 prior_req.collections.append(collection)
                 continue
             consolidated[key] = req

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -346,16 +346,17 @@ def sanitize_requirements(collection_py_reqs):
                 continue
             req.name = canonicalize_name(req.name)
             req.collections = [collection]  # add backref for later
-            if (prior_req := consolidated.get(req.name)) and prior_req.marker == req.marker:
+            key = (req.name, req.marker)
+            if (prior_req := consolidated.get(key)):
                 specifiers = f'{prior_req.specifier},{req.specifier}'
                 prior_req.specifier = SpecifierSet(specifiers)
                 prior_req.collections.append(collection)
                 continue
-            consolidated[req.name] = req
+            consolidated[key] = req
 
     # removal of unwanted packages
     sanitized = []
-    for name, req in consolidated.items():
+    for (name, _marker), req in consolidated.items():
         # Exclude packages, unless it was present in the user supplied requirements.
         if name.lower() in EXCLUDE_REQUIREMENTS and 'user' not in req.collections:
             logger.debug('# Excluding requirement %s from %s', req.name, req.collections)

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -345,7 +345,7 @@ def sanitize_requirements(collection_py_reqs):
                 logger.warning('Warning: failed to parse requirements from %s, error: %s', collection, e)
                 continue
             req.name = canonicalize_name(req.name)
-            req.collections = [collection]  # add backref for later
+            req.collections = {collection: None}  # add backref for later
             key = (req.name, req.marker)
             if (prior_req := consolidated.get(key)):
                 specifiers = f'{prior_req.specifier},{req.specifier}'
@@ -355,7 +355,7 @@ def sanitize_requirements(collection_py_reqs):
                     # The first URL seen wins
                     prior_req.url = req.url
                 prior_req.extras.update(req.extras)
-                prior_req.collections.append(collection)
+                prior_req.collections.update({collection: None})
                 continue
             consolidated[key] = req
 

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -144,7 +144,7 @@ class Containerfile:
         self._insert_global_args()
 
         if image == "base":
-            self.steps.append("RUN $PYCMD -m pip install --no-cache-dir bindep pyyaml requirements-parser")
+            self.steps.append("RUN $PYCMD -m pip install --no-cache-dir bindep pyyaml packaging")
         else:
             # For an EE schema earlier than v3 with a custom builder image, we always make sure pip is available.
             context_dir = Path(self.build_outputs_dir).stem

--- a/test/data/ansible_collections/test/reqfile/extra_req.txt
+++ b/test/data/ansible_collections/test/reqfile/extra_req.txt
@@ -1,2 +1,0 @@
-tacacs_plus
-pyvcloud>=18.0.10  # duplicate with test.metadata collection

--- a/test/data/ansible_collections/test/reqfile/requirements.txt
+++ b/test/data/ansible_collections/test/reqfile/requirements.txt
@@ -1,4 +1,5 @@
 pytz
 python-dateutil>=2.8.2    # intentional dash
 jinja2>=3.0    # intentional lowercase
--r extra_req.txt
+tacacs_plus
+pyvcloud>=18.0.10  # duplicate with test.metadata collection

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -50,9 +50,9 @@ def test_introspect_write_python_and_sanitize(cli, data_dir, tmp_path):
     assert dest_file.read_text() == '\n'.join([
         'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
         'pytz  # from collection test.reqfile',
-        'python_dateutil>=2.8.2  # from collection test.reqfile',
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
         'jinja2>=3.0  # from collection test.reqfile',
-        'tacacs_plus  # from collection test.reqfile',
+        'tacacs-plus  # from collection test.reqfile',
         '',
     ])
 

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -17,11 +17,11 @@ def test_multiple_collection_metadata(data_dir):
         'pytz  # from collection test.reqfile',
         # python-dateutil should appear only once even though referenced in
         # multiple places, once with a dash and another with an underscore in the name.
-        'python_dateutil>=2.8.2  # from collection test.reqfile',
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
         # jinja2 should appear only once even though referenced in multiple
         # places, once with uppercase and another with lowercase in the name.
         'jinja2>=3.0  # from collection test.reqfile',
-        'tacacs_plus  # from collection test.reqfile'
+        'tacacs-plus  # from collection test.reqfile'
     ], 'system': [
         'subversion [platform:rpm]  # from collection test.bindep',
         'subversion [platform:dpkg]  # from collection test.bindep'

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     -r {toxinidir}/test/requirements.txt
 commands = pytest -n auto {posargs}
 
-[testenv:linters{,-py39,-py310,-py311}]
+[testenv:linters{,-py39,-py310,-py311,-py312}]
 description = Run code linters
 commands =
     flake8 --version
@@ -22,11 +22,11 @@ commands =
     mypy src/ansible_builder
     pylint src/ansible_builder test
 
-[testenv:unit{,-py39,-py310,-py311}]
+[testenv:unit{,-py39,-py310,-py311,-py312}]
 description = Run unit tests
 commands = pytest -n auto test/unit {posargs} {[shared]pytest_cov_args}
 
-[testenv:pulp-integration{-py39,-py310,-py311}]
+[testenv:pulp-integration{-py39,-py310,-py311,-py312}]
 # Some of these tests must run serially because of a shared resource
 # (the system policy.json file).
 description = Run pulp integration tests
@@ -34,7 +34,7 @@ commands =
     pytest -n auto -m "not serial" test/pulp_integration {posargs} {[shared]pytest_cov_args}
     pytest -n 0 -m "serial" test/pulp_integration {posargs} {[shared]pytest_cov_args}
 
-[testenv:integration{,-py39,-py310,-py311}]
+[testenv:integration{,-py39,-py310,-py311,-py312}]
 description = Run integration tests
 # rootless podman reads $HOME
 passenv =


### PR DESCRIPTION
This PR is not backwards compatible, as it changes the expectations of what a "requirement" are, from the pip definition, to the definition dictated by pep508. Although it should be mentioned that we never gauranteed full support of pip requirements.txt, so with that in mind, this is technically not a breaking PR, but should be noted that it _could_ break some uses.

See:
* https://github.com/ansible/ansible-builder/issues/644