### PR TITLE
Fix container policy for version 3

### DIFF
--- a/.github/test-scripts/setup_pulp.sh
+++ b/.github/test-scripts/setup_pulp.sh
@@ -61,9 +61,9 @@ EOF
 PULP_IMAGE="pulp:3.23.3"
 podman pull docker.io/pulp/$PULP_IMAGE
 
-mkdir pulp
+mkdir -p pulp
 cd pulp
-mkdir settings pulp_storage pgsql containers
+mkdir -p settings pulp_storage pgsql containers
 
 echo "CONTENT_ORIGIN='http://$(hostname):8080'
 ANSIBLE_API_HOSTNAME='http://$(hostname):8080'
@@ -127,7 +127,7 @@ pulp container repository create --name testrepo
 ##############################################################################
 
 export XDG_RUNTIME_DIR=/tmp/pulptests
-mkdir $XDG_RUNTIME_DIR
+mkdir -p $XDG_RUNTIME_DIR
 
 skopeo login --username admin --password password localhost:8080 --tls-verify=false
 skopeo copy docker://registry.access.redhat.com/ubi9/ubi-minimal:latest docker://localhost:8080/testrepo/ubi-minimal --dest-tls-verify=false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,20 @@ requires = ["setuptools>=45, <=67.7.2", "setuptools-scm[toml]>=6.2, <=7.1.0"]  #
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.pylint.main]
+output-format = "colorized"
+max-line-length=120
+disable = [
+  "all",
+
+  # Some codes we will leave disabled
+  "C0103",  # invalid-name
+  "C0114",  # missing-module-docstring
+  "C0116",  # missing-function-docstring
+  "R0902",  # too-many-instance-attributes
+]
+
+enable = [
+  "W0102",  # dangerous-default-value
+]

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -208,7 +208,7 @@ def simple_combine(reqs):
     return fancy_lines
 
 
-def parse_args(args=sys.argv[1:]):
+def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
         prog='introspect',
@@ -217,14 +217,15 @@ def parse_args(args=sys.argv[1:]):
         )
     )
 
-    subparsers = parser.add_subparsers(help='The command to invoke.', dest='action')
-    subparsers.required = True
+    subparsers = parser.add_subparsers(
+        help='The command to invoke.',
+        dest='action',
+        required=True,
+    )
 
     create_introspect_parser(subparsers)
 
-    args = parser.parse_args(args)
-
-    return args
+    return parser.parse_args(args)
 
 
 def run_introspect(args, logger):

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -172,7 +172,7 @@ def add_container_options(parser):
                             'in value from 0 to 3) (default: %(default)s)')
 
 
-def parse_args(args=sys.argv[1:]):
+def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
         prog='ansible-builder',
@@ -186,14 +186,15 @@ def parse_args(args=sys.argv[1:]):
         help='Print ansible-builder version and exit.'
     )
 
-    subparsers = parser.add_subparsers(help='The command to invoke.', dest='action')
-    subparsers.required = True
+    subparsers = parser.add_subparsers(
+        help='The command to invoke.',
+        dest='action',
+        required=True,
+    )
 
     add_container_options(subparsers)
 
-    args = parser.parse_args(args)
-
-    return args
+    return parser.parse_args(args)
 
 
 class BuildArgAction(argparse.Action):

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -93,7 +93,7 @@ class AnsibleBuilder:
         resolved_keyring = None
 
         if policy is not None:
-            if self.version != 2:
+            if self.version == 1:
                 raise ValueError(f'--container-policy not valid with version {self.version} format')
 
             # Require podman runtime

--- a/test/data/v3/sig_req/ee-good.yml
+++ b/test/data/v3/sig_req/ee-good.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: localhost:8080/testrepo/ansible-builder-rhel8:latest
+    signature_original_name: registry.redhat.io/ansible-automation-platform-21/ansible-builder-rhel8:latest
+
+options:
+  skip_ansible_check: true
+  package_manager_path: /usr/bin/microdnf

--- a/test/data/v3/sig_req/ee-no-orig.yml
+++ b/test/data/v3/sig_req/ee-no-orig.yml
@@ -1,0 +1,10 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: localhost:8080/testrepo/ansible-builder-rhel8:latest
+
+options:
+  skip_ansible_check: true
+  package_manager_path: /usr/bin/microdnf

--- a/test/pulp_integration/test_policies.py
+++ b/test/pulp_integration/test_policies.py
@@ -83,7 +83,8 @@ class TestPolicies:
         assert f"--signature-policy={tmp_path}/policy.json" in result.stdout
         assert f"Complete! The build context can be found at: {tmp_path}" in result.stdout
 
-    def test_system(self, cli, tmp_path, data_dir, podman_ee_tag):
+    @pytest.mark.parametrize('version', ('v2', 'v3'))
+    def test_system(self, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that a system level policy.json file will be used with the
         `system` policy.
@@ -91,7 +92,7 @@ class TestPolicies:
         Expect `--pull-always` to be present in the podman command and that
         a policy.json file is not present with the podman command.
         """
-        ee_def = data_dir / 'v2' / 'sig_req' / 'ee-good.yml'
+        ee_def = data_dir / version / 'sig_req' / 'ee-good.yml'
 
         # Make a system policy that accepts everything.
         policy = IgnoreAll()
@@ -108,13 +109,14 @@ class TestPolicies:
         assert f"--signature-policy={tmp_path}/policy.json" not in result.stdout
         assert f"Complete! The build context can be found at: {tmp_path}" in result.stdout
 
-    def test_signature_required_success(self, cli, tmp_path, data_dir, podman_ee_tag):
+    @pytest.mark.parametrize('version', ('v2', 'v3'))
+    def test_signature_required_success(self, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that signed images are validated when using the signature_required policy.
 
         ee-good.yml is valid and should pass with the RPM-GPG-KEY-redhat-release keyring.
         """
-        ee_def = data_dir / 'v2' / 'sig_req' / 'ee-good.yml'
+        ee_def = data_dir / version / 'sig_req' / 'ee-good.yml'
         keyring = data_dir / 'v2' / 'RPM-GPG-KEY-redhat-release'
         result = cli(
             f'ansible-builder build -c {tmp_path} -f {ee_def} -t {podman_ee_tag} '
@@ -128,13 +130,14 @@ class TestPolicies:
         assert "Checking if image destination supports signatures" in result.stdout
         assert f"Complete! The build context can be found at: {tmp_path}" in result.stdout
 
-    def test_signature_required_fail(self, cli, tmp_path, data_dir, podman_ee_tag):
+    @pytest.mark.parametrize('version', ('v2', 'v3'))
+    def test_signature_required_fail(self, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that failure to validate a signed image will fail.
 
         We force failure by supplying an empty keyring.
         """
-        ee_def = data_dir / 'v2' / 'sig_req' / 'ee-good.yml'
+        ee_def = data_dir / version / 'sig_req' / 'ee-good.yml'
         keyring = data_dir / 'v2' / 'invalid-keyring'
 
         with pytest.raises(subprocess.CalledProcessError) as einfo:
@@ -145,13 +148,14 @@ class TestPolicies:
 
         assert "Source image rejected: None of the signatures were accepted" in einfo.value.stdout
 
-    def test_signature_required_no_orig(self, cli, tmp_path, data_dir, podman_ee_tag):
+    @pytest.mark.parametrize('version', ('v2', 'v3'))
+    def test_signature_required_no_orig(self, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that using a signed image, but not specifying the original image name, fails.
 
         ee-no-orig.yml is identical to ee-good.yml, except the signature_original_name is missing on an image.
         """
-        ee_def = data_dir / 'v2' / 'sig_req' / 'ee-no-orig.yml'
+        ee_def = data_dir / version / 'sig_req' / 'ee-no-orig.yml'
         keyring = data_dir / 'v2' / 'invalid-keyring'
 
         with pytest.raises(subprocess.CalledProcessError) as einfo:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,3 +9,4 @@ types-jsonschema
 types-pyyaml
 tox
 yamllint
+pylint==2.17.4

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,6 @@
 coverage
-flake8
-mypy==1.0.1
+flake8==6.1.0
+mypy==1.6.0
 pytest
 pytest-cov
 pytest-mock
@@ -8,5 +8,5 @@ pytest-xdist
 types-jsonschema
 types-pyyaml
 tox
-yamllint
-pylint==2.17.4
+yamllint==1.32.0
+pylint==3.0.1

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -117,13 +117,14 @@ def test_build_prune_images(good_exec_env_definition_path, tmp_path):
     assert not aee_no_prune_images.prune_images
 
 
-def test_container_policy_default(exec_env_definition_file, tmp_path):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_default(exec_env_definition_file, tmp_path, version):
     '''
     Test default policy file behavior.
 
     Do not expect a policy file or forced pulls.
     '''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build', '-f', path, '-c', str(tmp_path)])
     assert aee.container_policy is None
@@ -131,13 +132,14 @@ def test_container_policy_default(exec_env_definition_file, tmp_path):
     assert '--pull-always' not in aee.build_command
 
 
-def test_container_policy_signature_required(exec_env_definition_file, tmp_path):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_signature_required(exec_env_definition_file, tmp_path, version):
     '''
     Test signature_required policy.
 
     Expect a policy file to be specified, and forced pulls.
     '''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
 
     keyring = tmp_path / 'keyring.gpg'
@@ -156,13 +158,14 @@ def test_container_policy_signature_required(exec_env_definition_file, tmp_path)
     assert '--pull-always' in aee.build_command
 
 
-def test_container_policy_system(exec_env_definition_file, tmp_path):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_system(exec_env_definition_file, tmp_path, version):
     '''
     Test system policy.
 
     Do NOT expect a policy file, but do expect forced pulls.
     '''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
     aee = prepare(['build',
                    '-f', path,
@@ -175,9 +178,10 @@ def test_container_policy_system(exec_env_definition_file, tmp_path):
     assert '--pull-always' in aee.build_command
 
 
-def test_container_policy_not_podman(exec_env_definition_file, tmp_path):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_not_podman(exec_env_definition_file, tmp_path, version):
     '''Test --container-policy usage fails with non-podman runtime'''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
 
     with pytest.raises(ValueError, match='--container-policy is only valid with the podman runtime'):
@@ -190,9 +194,10 @@ def test_container_policy_not_podman(exec_env_definition_file, tmp_path):
                  ])
 
 
-def test_container_policy_missing_keyring(exec_env_definition_file, tmp_path):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_missing_keyring(exec_env_definition_file, tmp_path, version):
     '''Test that a container policy that requires a keyring fails when it is missing.'''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
     with pytest.raises(ValueError, match='--container-policy=signature_required requires --container-keyring'):
         prepare(['build',
@@ -204,9 +209,10 @@ def test_container_policy_missing_keyring(exec_env_definition_file, tmp_path):
 
 
 @pytest.mark.parametrize('policy', ('system', 'ignore_all'))
-def test_container_policy_unnecessary_keyring(exec_env_definition_file, tmp_path, policy):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_unnecessary_keyring(exec_env_definition_file, tmp_path, policy, version):
     '''Test that a container policy that doesn't require a keyring fails when it is supplied.'''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
     with pytest.raises(ValueError, match=f'--container-keyring is not valid with --container-policy={policy}'):
         prepare(['build',
@@ -218,9 +224,10 @@ def test_container_policy_unnecessary_keyring(exec_env_definition_file, tmp_path
                  ])
 
 
-def test_container_policy_with_build_args_cli_opt(exec_env_definition_file, tmp_path):
+@pytest.mark.parametrize('version', (2, 3))
+def test_container_policy_with_build_args_cli_opt(exec_env_definition_file, tmp_path, version):
     '''Test specifying image with --build-arg opt will fail'''
-    content = {'version': 2}
+    content = {'version': version}
     path = str(exec_env_definition_file(content=content))
     with pytest.raises(ValueError, match='EE_BASE_IMAGE not allowed in --build-arg option with version 2 format'):
         prepare(['build',

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -1,6 +1,8 @@
 import os
+import pytest
 
 from ansible_builder._target_scripts.introspect import process, process_collection, simple_combine, sanitize_requirements
+from ansible_builder._target_scripts.introspect import parse_args
 
 
 def test_multiple_collection_metadata(data_dir):
@@ -32,3 +34,35 @@ def test_single_collection_metadata(data_dir):
 
     assert py_reqs == ['pyvcloud>=14']
     assert sys_reqs == []
+
+
+def test_parse_args_empty(capsys):
+    with pytest.raises(SystemExit):
+        parse_args()
+    dummy, err = capsys.readouterr()
+    assert 'usage: introspect' in err
+
+
+def test_parse_args_default_action():
+    action = 'introspect'
+    user_pip = '/tmp/user-pip.txt'
+    user_bindep = '/tmp/user-bindep.txt'
+    write_pip = '/tmp/write-pip.txt'
+    write_bindep = '/tmp/write-bindep.txt'
+
+    parser = parse_args(
+        [
+            action, '--sanitize',
+            f'--user-pip={user_pip}',
+            f'--user-bindep={user_bindep}',
+            f'--write-pip={write_pip}',
+            f'--write-bindep={write_bindep}',
+        ]
+    )
+
+    assert parser.action == action
+    assert parser.sanitize
+    assert parser.user_pip == user_pip
+    assert parser.user_bindep == user_bindep
+    assert parser.write_pip == write_pip
+    assert parser.write_bindep == write_bindep

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
     yamllint --version
     yamllint -s .
     mypy src/ansible_builder
+    pylint src/ansible_builder
 
 [testenv:unit{,-py39,-py310,-py311}]
 description = Run unit tests


### PR DESCRIPTION
Backport of PR #652 

Includes cherry-picks of these commits to get CI green:
  - `4ba7408` Add pylint to CI (#575)
  - `9f1303d` Bump linters: pylint==3.0.1, mypy==1.6.0 (#622)
  - `633a85b` Fix container policy for version 3 (#652)