### PR TITLE
Expose a way to exclude deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
           - name: '3.11'
             tox_env: integration-py311
 
+          - name: '3.12'
+            tox_env: integration-py312
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -172,6 +175,9 @@ jobs:
 
           - name: '3.11'
             tox_env: unit-py311
+
+          - name: '3.12'
+            tox_env: unit-py312
 
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ max-line-length=160
 include_package_data = true
 install_requires =
     PyYAML
-    requirements_parser
+    packaging
     bindep
     jsonschema
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development :: Build Tools
     Topic :: System :: Systems Administration

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -354,6 +354,7 @@ def sanitize_requirements(collection_py_reqs):
                     # An explicit install URL is preferred over none
                     # The first URL seen wins
                     prior_req.url = req.url
+                prior_req.extras.update(req.extras)
                 prior_req.collections.append(collection)
                 continue
             consolidated[key] = req

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -220,7 +220,7 @@ def simple_combine(reqs, exclude=None, name_only=False):
             base_line = line.split('#')[0].strip()
             pkg_name = base_line.split()[0].lower()
             if pkg_name in exclude:
-                logger.debug(f'# Explicitly excluding requirement {pkg_name} from {collection}')
+                logger.debug('# Explicitly excluding requirement %s from %s', pkg_name, collection)
                 continue
 
             if base_line in consolidated:
@@ -385,7 +385,7 @@ def sanitize_requirements(collection_py_reqs, exclude=None, name_only=False):
                 continue
             req.name = canonicalize_name(req.name)
             if req.name in exclude and collection != 'user':
-                logger.debug(f'# Explicitly excluding requirement {req.name} from {collection}')
+                logger.debug('# Explicitly excluding requirement %s from %s', req.name, collection)
                 continue
 
             req.collections = {collection: None}  # add backref for later

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -350,6 +350,10 @@ def sanitize_requirements(collection_py_reqs):
             if (prior_req := consolidated.get(key)):
                 specifiers = f'{prior_req.specifier},{req.specifier}'
                 prior_req.specifier = SpecifierSet(specifiers)
+                if not prior_req.url and req.url:
+                    # An explicit install URL is preferred over none
+                    # The first URL seen wins
+                    prior_req.url = req.url
                 prior_req.collections.append(collection)
                 continue
             consolidated[key] = req

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -346,16 +346,17 @@ def sanitize_requirements(collection_py_reqs):
                 continue
             req.name = canonicalize_name(req.name)
             req.collections = [collection]  # add backref for later
-            if (prior_req := consolidated.get(req.name)) and prior_req.marker == req.marker:
+            key = (req.name, req.marker)
+            if (prior_req := consolidated.get(key)):
                 specifiers = f'{prior_req.specifier},{req.specifier}'
                 prior_req.specifier = SpecifierSet(specifiers)
                 prior_req.collections.append(collection)
                 continue
-            consolidated[req.name] = req
+            consolidated[key] = req
 
     # removal of unwanted packages
     sanitized = []
-    for name, req in consolidated.items():
+    for (name, _marker), req in consolidated.items():
         # Exclude packages, unless it was present in the user supplied requirements.
         if name.lower() in EXCLUDE_REQUIREMENTS and 'user' not in req.collections:
             logger.debug('# Excluding requirement %s from %s', req.name, req.collections)

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -345,7 +345,7 @@ def sanitize_requirements(collection_py_reqs):
                 logger.warning('Warning: failed to parse requirements from %s, error: %s', collection, e)
                 continue
             req.name = canonicalize_name(req.name)
-            req.collections = [collection]  # add backref for later
+            req.collections = {collection: None}  # add backref for later
             key = (req.name, req.marker)
             if (prior_req := consolidated.get(key)):
                 specifiers = f'{prior_req.specifier},{req.specifier}'
@@ -355,7 +355,7 @@ def sanitize_requirements(collection_py_reqs):
                     # The first URL seen wins
                     prior_req.url = req.url
                 prior_req.extras.update(req.extras)
-                prior_req.collections.append(collection)
+                prior_req.collections.update({collection: None})
                 continue
             consolidated[key] = req
 

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -144,7 +144,7 @@ class Containerfile:
         self._insert_global_args()
 
         if image == "base":
-            self.steps.append("RUN $PYCMD -m pip install --no-cache-dir bindep pyyaml requirements-parser")
+            self.steps.append("RUN $PYCMD -m pip install --no-cache-dir bindep pyyaml packaging")
         else:
             # For an EE schema earlier than v3 with a custom builder image, we always make sure pip is available.
             context_dir = Path(self.build_outputs_dir).stem

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -476,7 +476,7 @@ class Containerfile:
                     constants.user_content_subfolder,
                     f"exclude-{constants.CONTEXT_FILES['system']}"
                 )
-                self.steps.append(f"COPY {relative_bindep_path} exclude-{constants.CONTEXT_FILES['system']}")
+                self.steps.append(f"COPY {relative_exclude_bindep_path} exclude-{constants.CONTEXT_FILES['system']}")
                 introspect_cmd += f" --user-bindep-exclude=exclude-{constants.CONTEXT_FILES['system']}"
 
             introspect_cmd += " --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt"

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -387,10 +387,10 @@ class Containerfile:
         ])
 
     def _prepare_build_context(self) -> None:
-        deps = []
+        deps: list[str] = []
         for exclude in (False, True):
             deps.extend(
-                self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')
+                self.definition.get_dep_abs_path(thing, exclude=exclude) for thing in ('galaxy', 'system', 'python')
             )
         if any(deps):
             self.steps.extend([
@@ -431,10 +431,10 @@ class Containerfile:
 
     def _prepare_introspect_assemble_steps(self) -> None:
         # The introspect/assemble block is valid if there are any form of requirements
-        deps = []
+        deps: list[str] = []
         for exclude in (False, True):
             deps.extend(
-                self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')
+                self.definition.get_dep_abs_path(thing, exclude=exclude) for thing in ('galaxy', 'system', 'python')
             )
         if any(deps):
             introspect_cmd = "RUN $PYCMD /output/scripts/introspect.py introspect --sanitize"

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -259,16 +259,19 @@ class Containerfile:
             if not new_name:
                 continue
 
-            requirement_path = self.definition.get_dep_abs_path(item)
-            if requirement_path is None:
-                continue
-            dest = os.path.join(
-                self.build_context, constants.user_content_subfolder, new_name)
+            for exclude in (False, True):
+                if exclude is True:
+                    new_name = f'exclude-{new_name}'
+                requirement_path = self.definition.get_dep_abs_path(item, exclude=exclude)
+                if requirement_path is None:
+                    continue
+                dest = os.path.join(
+                    self.build_context, constants.user_content_subfolder, new_name)
 
-            # Ignore modification time of the requirement file because we could
-            # be writing it out dynamically (inline EE reqs), and we only care
-            # about the contents anyway.
-            copy_file(requirement_path, dest, ignore_mtime=True)
+                # Ignore modification time of the requirement file because we could
+                # be writing it out dynamically (inline EE reqs), and we only care
+                # about the contents anyway.
+                copy_file(requirement_path, dest, ignore_mtime=True)
 
         if self.original_galaxy_keyring:
             copy_file(
@@ -384,7 +387,12 @@ class Containerfile:
         ])
 
     def _prepare_build_context(self) -> None:
-        if any(self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')):
+        deps = []
+        for exclude in (False, True):
+            deps.extend(
+                self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')
+            )
+        if any(deps):
             self.steps.extend([
                 f"COPY {constants.user_content_subfolder} /build",
                 "WORKDIR /build",
@@ -423,14 +431,17 @@ class Containerfile:
 
     def _prepare_introspect_assemble_steps(self) -> None:
         # The introspect/assemble block is valid if there are any form of requirements
-        if any(self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')):
-
+        deps = []
+        for exclude in (False, True):
+            deps.extend(
+                self.definition.get_dep_abs_path(thing) for thing in ('galaxy', 'system', 'python')
+            )
+        if any(deps):
             introspect_cmd = "RUN $PYCMD /output/scripts/introspect.py introspect --sanitize"
 
             requirements_file_exists = os.path.exists(os.path.join(
                 self.build_outputs_dir, constants.CONTEXT_FILES['python']
             ))
-
             if requirements_file_exists:
                 relative_requirements_path = os.path.join(
                     constants.user_content_subfolder,
@@ -439,11 +450,34 @@ class Containerfile:
                 self.steps.append(f"COPY {relative_requirements_path} {constants.CONTEXT_FILES['python']}")
                 # WORKDIR is /build, so we use the (shorter) relative paths there
                 introspect_cmd += f" --user-pip={constants.CONTEXT_FILES['python']}"
+
+            pip_exclude_exists = os.path.exists(os.path.join(
+                self.build_outputs_dir, f"exclude-{constants.CONTEXT_FILES['python']}"
+            ))
+            if pip_exclude_exists:
+                relative_pip_exclude_path = os.path.join(
+                    constants.user_content_subfolder,
+                    f"exclude-{constants.CONTEXT_FILES['python']}"
+                )
+                self.steps.append(f"COPY {relative_pip_exclude_path} exclude-{constants.CONTEXT_FILES['python']}")
+                introspect_cmd += f" --user-pip-exclude=exclude-{constants.CONTEXT_FILES['python']}"
+
             bindep_exists = os.path.exists(os.path.join(self.build_outputs_dir, constants.CONTEXT_FILES['system']))
             if bindep_exists:
                 relative_bindep_path = os.path.join(constants.user_content_subfolder, constants.CONTEXT_FILES['system'])
                 self.steps.append(f"COPY {relative_bindep_path} {constants.CONTEXT_FILES['system']}")
                 introspect_cmd += f" --user-bindep={constants.CONTEXT_FILES['system']}"
+
+            exclude_bindep_exists = os.path.exists(os.path.join(
+                self.build_outputs_dir, f"exclude-{constants.CONTEXT_FILES['system']}"
+            ))
+            if exclude_bindep_exists:
+                relative_exclude_bindep_path = os.path.join(
+                    constants.user_content_subfolder,
+                    f"exclude-{constants.CONTEXT_FILES['system']}"
+                )
+                self.steps.append(f"COPY {relative_bindep_path} exclude-{constants.CONTEXT_FILES['system']}")
+                introspect_cmd += f" --user-bindep-exclude=exclude-{constants.CONTEXT_FILES['system']}"
 
             introspect_cmd += " --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt"
 

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -391,7 +391,7 @@ schema_v3 = {
     },
 }
 
-schema_v31 = deepcopy(schema_v3)
+schema_v31: dict = deepcopy(schema_v3)
 schema_v31['properties']['dependencies']['properties']['exclude'] = {
     "python": TYPE_StringOrListOfStrings,
     "system": TYPE_StringOrListOfStrings,
@@ -401,7 +401,7 @@ schema_v31['properties']['dependencies']['properties']['exclude'] = {
 def float_or_int(v):
     if isinstance(v, (float, int)):
         return v
-    elif isinstance(v, str):
+    if isinstance(v, str):
         if '.' in v:
             return float(v)
     return int(v)

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -394,7 +394,6 @@ schema_v3 = {
 schema_v31 = deepcopy(schema_v3)
 schema_v31['properties']['dependencies']['properties']['exclude'] = {
     "python": TYPE_StringOrListOfStrings,
-    "galaxy": TYPE_DictOrStringOrListOfStrings,
     "system": TYPE_StringOrListOfStrings,
 }
 

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -406,6 +406,7 @@ def float_or_int(v):
             return float(v)
     return int(v)
 
+
 def validate_schema(ee_def: dict):
     schema_version = 1
     if 'version' in ee_def:

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -180,7 +180,7 @@ class UserDefinition:
     def options(self):
         return self.raw.get('options', {})
 
-    @functools.cache
+    @functools.lru_cache(maxsize=6)
     def get_dep_abs_path(self, entry, exclude=False):
         """Unique to the user EE definition, files can be referenced by either
         an absolute path or a path relative to the EE definition folder

--- a/test/data/ansible_collections/test/reqfile/extra_req.txt
+++ b/test/data/ansible_collections/test/reqfile/extra_req.txt
@@ -1,2 +1,0 @@
-tacacs_plus
-pyvcloud>=18.0.10  # duplicate with test.metadata collection

--- a/test/data/ansible_collections/test/reqfile/requirements.txt
+++ b/test/data/ansible_collections/test/reqfile/requirements.txt
@@ -1,4 +1,5 @@
 pytz
 python-dateutil>=2.8.2    # intentional dash
 jinja2>=3.0    # intentional lowercase
--r extra_req.txt
+tacacs_plus
+pyvcloud>=18.0.10  # duplicate with test.metadata collection

--- a/test/integration/test_introspect_cli.py
+++ b/test/integration/test_introspect_cli.py
@@ -50,9 +50,9 @@ def test_introspect_write_python_and_sanitize(cli, data_dir, tmp_path):
     assert dest_file.read_text() == '\n'.join([
         'pyvcloud>=14,>=18.0.10  # from collection test.metadata,test.reqfile',
         'pytz  # from collection test.reqfile',
-        'python_dateutil>=2.8.2  # from collection test.reqfile',
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
         'jinja2>=3.0  # from collection test.reqfile',
-        'tacacs_plus  # from collection test.reqfile',
+        'tacacs-plus  # from collection test.reqfile',
         '',
     ])
 

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -17,11 +17,11 @@ def test_multiple_collection_metadata(data_dir):
         'pytz  # from collection test.reqfile',
         # python-dateutil should appear only once even though referenced in
         # multiple places, once with a dash and another with an underscore in the name.
-        'python_dateutil>=2.8.2  # from collection test.reqfile',
+        'python-dateutil>=2.8.2  # from collection test.reqfile',
         # jinja2 should appear only once even though referenced in multiple
         # places, once with uppercase and another with lowercase in the name.
         'jinja2>=3.0  # from collection test.reqfile',
-        'tacacs_plus  # from collection test.reqfile'
+        'tacacs-plus  # from collection test.reqfile'
     ], 'system': [
         'subversion [platform:rpm]  # from collection test.bindep',
         'subversion [platform:dpkg]  # from collection test.bindep'

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     -r {toxinidir}/test/requirements.txt
 commands = pytest -n auto {posargs}
 
-[testenv:linters{,-py39,-py310,-py311}]
+[testenv:linters{,-py39,-py310,-py311,-py312}]
 description = Run code linters
 commands =
     flake8 --version
@@ -22,11 +22,11 @@ commands =
     mypy src/ansible_builder
     pylint src/ansible_builder test
 
-[testenv:unit{,-py39,-py310,-py311}]
+[testenv:unit{,-py39,-py310,-py311,-py312}]
 description = Run unit tests
 commands = pytest -n auto test/unit {posargs} {[shared]pytest_cov_args}
 
-[testenv:pulp-integration{-py39,-py310,-py311}]
+[testenv:pulp-integration{-py39,-py310,-py311,-py312}]
 # Some of these tests must run serially because of a shared resource
 # (the system policy.json file).
 description = Run pulp integration tests
@@ -34,7 +34,7 @@ commands =
     pytest -n auto -m "not serial" test/pulp_integration {posargs} {[shared]pytest_cov_args}
     pytest -n 0 -m "serial" test/pulp_integration {posargs} {[shared]pytest_cov_args}
 
-[testenv:integration{,-py39,-py310,-py311}]
+[testenv:integration{,-py39,-py310,-py311,-py312}]
 description = Run integration tests
 # rootless podman reads $HOME
 passenv =


### PR DESCRIPTION
Note: This is based off of https://github.com/ansible/ansible-builder/pull/645 right now

~At the moment, this is only fully wired up for `python` deps, as it was kind of an experiment.~

```yaml
---
version: 3.1

images:
  base_image:
    name: quay.io/centos/centos:stream9

dependencies:
  python_interpreter:
    package_system: python3.11
    python_path: /usr/bin/python3.11

  ansible_core:
    package_pip: ansible-core

  ansible_runner:
    package_pip: ansible-runner

  galaxy:
    collections:
      - name: community.docker

  exclude:
    python:
      - docker
```

TODO:

- [x] python excludes should work
- [x] excludes should not apply to user deps
- [x] system excludes should work
- [ ] should there be a means to exclude collections? 

NOTES:

- Only supports exclusion of first level deps, does not offer a way to exclude deps of deps