### PR TITLE
Fix the misspelled "PyPI" to use a capital "I"

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ Requirements
 - The ``--container-runtime`` option must correspond to the containerization tool you use.
 - ``ansible-builder`` version ``3.x`` requires Python ``3.9`` or higher.
 
-Install from PyPi
+Install from PyPI
 *****************
 
 .. code-block:: shell


### PR DESCRIPTION
It's because "I" stands for a separate word than "P", it should be like this: https://pypi.org/help/#pronunciation.