### PR TITLE
Make failed codecov uploads not fail CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           files: test/coverage/reports/coverage.xml
           flags: ${{ matrix.py_version.tox_env }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   unit:
@@ -204,5 +204,5 @@ jobs:
         with:
           files: test/coverage/reports/coverage.xml
           flags: ${{ matrix.py_version.tox_env }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
The Codecov [rate limiting issue](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954) has become a CI roadblock. Just disable CI failures.