### PR TITLE
fix: capitalize 'as' to follow from-as-casing rule

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
-FROM $BASE_IMAGE as builder
+FROM $BASE_IMAGE AS builder
 # build this library (meaning ansible-builder)
 COPY . /tmp/src
 COPY ./src/ansible_builder/_target_scripts/* /output/scripts/

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -75,7 +75,7 @@ class Containerfile:
         # 'base' (possibly customized) will be used by future build stages
         self.steps.extend([
             "# Base build stage",
-            "FROM $EE_BASE_IMAGE as base",
+            "FROM $EE_BASE_IMAGE AS base",
             "USER root",
             "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
         ])
@@ -108,7 +108,7 @@ class Containerfile:
             self.steps.extend([
                 "",
                 "# Galaxy build stage",
-                "FROM base as galaxy",
+                "FROM base AS galaxy",
             ])
 
             self._insert_global_args()
@@ -137,7 +137,7 @@ class Containerfile:
         self.steps.extend([
             "",
             "# Builder build stage",
-            f"FROM {image} as builder",
+            f"FROM {image} AS builder",
             "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
             "WORKDIR /build",
         ])
@@ -164,7 +164,7 @@ class Containerfile:
         self.steps.extend([
             "",
             "# Final build stage",
-            "FROM base as final",
+            "FROM base AS final",
             "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
         ])
 

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -145,7 +145,7 @@ def test_v2_custom_builder_image(build_dir_and_ee_yml):
     c.prepare()
 
     assert 'ARG EE_BUILDER_IMAGE="quay.io/user/mycustombuilderimage:latest"' in c.steps
-    assert "FROM $EE_BUILDER_IMAGE as builder" in c.steps
+    assert "FROM $EE_BUILDER_IMAGE AS builder" in c.steps
 
 
 def test_v3_various(build_dir_and_ee_yml):
@@ -295,7 +295,7 @@ def test_v1_builder_image(build_dir_and_ee_yml):
     tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
-    assert "FROM $EE_BUILDER_IMAGE as builder" in c.steps
+    assert "FROM $EE_BUILDER_IMAGE AS builder" in c.steps
     assert "COPY _build/scripts/pip_install /output/scripts/pip_install" in c.steps
     assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
 
@@ -315,7 +315,7 @@ def test_v2_builder_image(build_dir_and_ee_yml):
     tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
-    assert "FROM $EE_BUILDER_IMAGE as builder" in c.steps
+    assert "FROM $EE_BUILDER_IMAGE AS builder" in c.steps
     assert "COPY _build/scripts/pip_install /output/scripts/pip_install" in c.steps
     assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
 
@@ -333,7 +333,7 @@ def test_v2_builder_image_default(build_dir_and_ee_yml):
     tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
-    assert "FROM base as builder" in c.steps
+    assert "FROM base AS builder" in c.steps
     assert "COPY _build/scripts/pip_install /output/scripts/pip_install" not in c.steps
 
 


### PR DESCRIPTION
Closes #686

This PR capitalizes `as` to follow the from-as-casing rule to supress warnings during build on Docker Engine 27+: https://docs.docker.com/reference/build-checks/from-as-casing/

Test:

```bash
# Install customized Ansible Builder
pip install .
```

```bash
# Ensure no warnings are displayed during build
$ ansible-builder build --tag registry.example.com/ansible/ee:2.17-minimal --container-runtime docker --verbosity 3
Ansible Builder is generating your execution environment build context.
...
Ansible Builder is building your execution environment image. Tags: registry.example.com/ansible/ee:2.17-minimal
Running command:
  docker build -f context/Dockerfile -t registry.example.com/ansible/ee:2.17-minimal context
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2.96kB done
#1 DONE 0.0s
...
#32 exporting to image
#32 exporting layers done
#32 writing image sha256:73227f703dbf35eb822caa325f0db8593fb10719bbb64d21615ea7ddd50df04e done
#32 naming to registry.example.com/ansible/ee:2.17-minimal done
#32 DONE 0.0s

Complete! The build context can be found at: /home/********/builder/context
```

```bash
# Ensure `AS` in the generated Dockerfile are capitalized
$ cat context/Dockerfile 
...
# Base build stage
FROM $EE_BASE_IMAGE AS base
...
# Galaxy build stage
FROM base AS galaxy
...
# Builder build stage
FROM base AS builder
...
# Final build stage
FROM base AS final
```

```bash
# Ensure `docker build --check .` passed
$ cd context/
$ docker build --check .
[+] Building 0.7s (3/3) FINISHED                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 2.96kB                                                                                                                                                0.0s
 => [internal] load metadata for quay.io/centos/centos:stream9-minimal                                                                                                                0.7s
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 2B  
```