### PR TITLE
Docs: change Getting started EE guide reference to point to the relevant location

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ Before you start using Ansible Builder, you should understand the following conc
 What are execution environments?
 ================================
 
-Refer to the `Getting started with Execution Environments guide <https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html>`_ for details.
+Refer to the `Getting started with Execution Environments guide <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_ for details.
 
 Quickstart for Ansible Builder
 ==============================


### PR DESCRIPTION
Docs: change Getting started EE guide reference to point to the relevant location. The stuff was moved yesterday.
The old one currently refers to a 404 page