### PR TITLE
Improve execution of pip during container building

### DIFF
--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -94,7 +94,8 @@ class Containerfile:
                 self.steps.append('RUN /output/scripts/pip_install $PYCMD')
 
             if self.definition.ansible_ref_install_list:
-                self.steps.append('RUN $PYCMD -m pip install --no-cache-dir $ANSIBLE_INSTALL_REFS')
+                self.steps.append(
+                    'RUN --mount=type=cache,dst=/root/.cache/pip $PYCMD -m pip install -q $ANSIBLE_INSTALL_REFS')
 
         self._insert_custom_steps('append_base')
 

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -184,7 +184,7 @@ def test_v3_various(build_dir_and_ee_yml):
     assert "RUN $PYCMD -m pip install --no-cache-dir 'dumb-init==x.y.z'" in c.steps
     assert "USER myuser" in c.steps
     assert "RUN $PKGMGR install $PYPKG -y ; if [ -z $PKGMGR_PRESERVE_CACHE ]; then $PKGMGR clean all; fi" in c.steps
-    assert "RUN $PYCMD -m pip install --no-cache-dir $ANSIBLE_INSTALL_REFS" in c.steps
+    assert "RUN --mount=type=cache,dst=/root/.cache/pip $PYCMD -m pip install -q $ANSIBLE_INSTALL_REFS" in c.steps
     assert 'ENTRYPOINT ["dumb-init"]' in c.steps
     assert 'CMD ["csh"]' in c.steps
 


### PR DESCRIPTION
- Make pip less verbose as this makes harder to investigate container
  building due to being too verbose.
- Use a bind mount to prevent pip cache from being written inside the
  container but still make use of it. This will speed-up the build
  process considerably.
