### PR TITLE
Replace ansible-runner with ansible-dev-tools image

### DIFF
--- a/src/ansible_builder/constants.py
+++ b/src/ansible_builder/constants.py
@@ -16,7 +16,7 @@ build_arg_defaults = {
     # empty string values here still allow the build arg to be emitted into the generated Containerfile
     'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': '',
     'ANSIBLE_GALAXY_CLI_ROLE_OPTS': '',
-    'EE_BASE_IMAGE': 'quay.io/ansible/ansible-runner:latest',
+    'EE_BASE_IMAGE': 'ghcr.io/ansible/community-ansible-dev-tools:latest',
     # this value is removed elsewhere for v3+ schemas
     'EE_BUILDER_IMAGE': 'quay.io/ansible/ansible-builder:latest',
     'PKGMGR_PRESERVE_CACHE': '',

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -274,7 +274,7 @@ class UserDefinition:
 
             if (
                 self.version >= 3
-                and self.build_arg_defaults["EE_BASE_IMAGE"] == 'quay.io/ansible/ansible-runner:latest'
+                and self.build_arg_defaults["EE_BASE_IMAGE"] == 'ghcr.io/ansible/community-ansible-dev-tools:latest'
             ):
                 logging.warning(
                     "Using the outdated base image '%s' might "

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -232,7 +232,7 @@ def test_v2_default_images(cli, build_dir_and_ee_yml):
     assert containerfile.exists()
     text = containerfile.read_text()
 
-    assert 'ARG EE_BASE_IMAGE="quay.io/ansible/ansible-runner:latest"' in text
+    assert 'ARG EE_BASE_IMAGE="ghcr.io/ansible/community-ansible-dev-tools:latest"' in text
     assert 'ARG EE_BUILDER_IMAGE="quay.io/ansible/ansible-builder:latest"' in text
 
 
@@ -254,7 +254,7 @@ def test_v2_default_base_image(cli, build_dir_and_ee_yml):
     assert containerfile.exists()
     text = containerfile.read_text()
 
-    assert 'ARG EE_BASE_IMAGE="quay.io/ansible/ansible-runner:latest"' in text
+    assert 'ARG EE_BASE_IMAGE="ghcr.io/ansible/community-ansible-dev-tools:latest"' in text
     assert 'ARG EE_BUILDER_IMAGE="quay.io/ansible/awx-ee:latest"' in text
 
 


### PR DESCRIPTION
EE_BASE_IMAGE default was: quay.io/ansible/ansible-runner:latest which is a 2 years old image: https://quay.io/repository/ansible/ansible-runner?tab=tags&tag=latest

Now the default is: ghcr.io/ansible/community-ansible-dev-tools:latest which is the recommended image for execution environments according to https://github.com/ansible/creator-ee