### PR TITLE
Resolve Ansible Builder Errors for Podman on Windows

### DIFF
--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -149,7 +149,7 @@ class Containerfile:
         else:
             # For an EE schema earlier than v3 with a custom builder image, we always make sure pip is available.
             context_dir = Path(self.build_outputs_dir).stem
-            self.steps.append(f'COPY {context_dir}/scripts/pip_install /output/scripts/pip_install')
+            self.steps.append(f'COPY --chmod=755 {context_dir}/scripts/pip_install /output/scripts/pip_install')
             self.steps.append("RUN /output/scripts/pip_install $PYCMD")
 
         self._insert_custom_steps('prepend_builder')
@@ -313,11 +313,11 @@ class Containerfile:
         # Later intermediate stages depend on base image containing these scripts.
         # Copy them to a location that we do not need in the final image.
         context_dir = Path(self.build_outputs_dir).stem
-        self.steps.append(f'COPY {context_dir}/scripts/ /output/scripts/')
+        self.steps.append(f'COPY --chmod=755 {context_dir}/scripts/ /output/scripts/')
 
         # The final image will have /output purged, but certain scripts we want
         # to retain in that image.
-        self.steps.append(f'COPY {context_dir}/scripts/entrypoint {constants.FINAL_IMAGE_BIN_PATH}/entrypoint')
+        self.steps.append(f'COPY --chmod=755 {context_dir}/scripts/entrypoint {constants.FINAL_IMAGE_BIN_PATH}/entrypoint')
 
     def _handle_additional_build_files(self) -> None:
         """

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 
 from jsonschema import validate, SchemaError, ValidationError
 
@@ -472,7 +473,7 @@ def _handle_options_defaults(ee_def: dict):
     """
     options = ee_def.setdefault('options', {})
 
-    entrypoint_path = os.path.join(constants.FINAL_IMAGE_BIN_PATH, "entrypoint")
+    entrypoint_path = posixpath.join(constants.FINAL_IMAGE_BIN_PATH, "entrypoint")
 
     options.setdefault('skip_ansible_check', False)
     options.setdefault('skip_pip_install', False)

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -189,6 +189,26 @@ def test_v3_various(build_dir_and_ee_yml):
     assert 'CMD ["csh"]' in c.steps
 
 
+def test__posix_separator_in_entrypoint_on_windows(build_dir_and_ee_yml, mocker):
+    """
+    Test that the generated entrypoint uses the POSIX separator on Windows.
+    """
+    ee_data = """
+    version: 3
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+    """
+    import ntpath
+    mocker.patch("os.path", ntpath)
+
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+
+    assert 'ENTRYPOINT ["/opt/builder/bin/entrypoint", "dumb-init"]' in c.steps
+
+
 def test__handle_additional_build_files(build_dir_and_ee_yml):
     """
     Test additional build file handling works as expected.

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -296,7 +296,7 @@ def test_v1_builder_image(build_dir_and_ee_yml):
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
     assert "FROM $EE_BUILDER_IMAGE AS builder" in c.steps
-    assert "COPY _build/scripts/pip_install /output/scripts/pip_install" in c.steps
+    assert "COPY --chmod=755 _build/scripts/pip_install /output/scripts/pip_install" in c.steps
     assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
 
 
@@ -315,8 +315,9 @@ def test_v2_builder_image(build_dir_and_ee_yml):
     tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
+    print(c.steps)
     assert "FROM $EE_BUILDER_IMAGE AS builder" in c.steps
-    assert "COPY _build/scripts/pip_install /output/scripts/pip_install" in c.steps
+    assert "COPY --chmod=755 _build/scripts/pip_install /output/scripts/pip_install" in c.steps
     assert "RUN /output/scripts/pip_install $PYCMD" in c.steps
 
 
@@ -334,7 +335,7 @@ def test_v2_builder_image_default(build_dir_and_ee_yml):
     c = make_containerfile(tmpdir, ee_path, run_validate=True)
     c.prepare()
     assert "FROM base AS builder" in c.steps
-    assert "COPY _build/scripts/pip_install /output/scripts/pip_install" not in c.steps
+    assert "COPY --chmod=755 _build/scripts/pip_install /output/scripts/pip_install" not in c.steps
 
 
 def test_prepare_introspect_assemble_steps(build_dir_and_ee_yml):


### PR DESCRIPTION
Hey team!

I recently tried using Ansible Builder to create Ansible execution environments on my Windows machine with Podman, and I ran into a few issues.

1. By default, [Podman on Windows creates files with insufficient permissions to execute copied scripts](https://github.com/containers/podman/issues/15299).
2. The Containerfile includes Windows path separators in the `ENTRYPOINT` path, preventing the container from running.

These changes add the `--chmod` flag to the `COPY` commands in the Containerfile, ensuring the scripts run correctly and ensuring behavioral parity between Podman and Docker.  They also use the POSIX path separator when creating the `ENTRYPOINT` directive.

I've added unit tests to validate the path character behavior, and I've updated existing tests for the COPY directive.  After applying these changes, I was able to use Ansible Builder to create a container with a usable Ansible installation inside (using Fedora as the base image).

If you guys could incorporate these changes into the project when you get the chance, I would deeply appreciate it (and please let me know if there is anything else I can do)!

Sincerely,
Kevin