### PR TITLE
Allow disabling text colors

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -203,6 +203,16 @@ will stack. For example, the following are equivalent to setting the verbosity l
    $ ansible-builder build -v -v -v
 
 
+``--no-colors``
+***************
+
+Disables ANSI text colors.
+
+If this option is not given, the default will be to enable text colors for the output.
+The ``NO_COLOR`` and ``FORCE_COLOR`` environment variables will be honored if this CLI option
+is not supplied.
+
+
 ``--prune-images``
 ******************
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -203,16 +203,6 @@ will stack. For example, the following are equivalent to setting the verbosity l
    $ ansible-builder build -v -v -v
 
 
-``--no-colors``
-***************
-
-Disables ANSI text colors.
-
-If this option is not given, the default will be to enable text colors for the output.
-The ``NO_COLOR`` and ``FORCE_COLOR`` environment variables will be honored if this CLI option
-is not supplied. If both environment variables are supplied, ``NO_COLOR`` will take precedence.
-
-
 ``--prune-images``
 ******************
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -210,7 +210,7 @@ Disables ANSI text colors.
 
 If this option is not given, the default will be to enable text colors for the output.
 The ``NO_COLOR`` and ``FORCE_COLOR`` environment variables will be honored if this CLI option
-is not supplied.
+is not supplied. If both environment variables are supplied, ``NO_COLOR`` will take precedence.
 
 
 ``--prune-images``

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,7 +7,8 @@ Ansible Builder can execute two separate steps. The first step is to create a bu
 
 .. note::
 
-   Ansible Builder honors the ``NO_COLOR`` environment variable. Set it to any non-empty value to avoid color output in the terminal.
+   Ansible Builder is colorized by default when outputting to a terminal. Color output can be disabled by setting the ``NO_COLOR`` environment variable to any non-empty value,
+   or by setting the ``CLICOLOR`` environment variable to ``0``.
 
 
 .. contents::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,6 +5,11 @@ CLI Usage
 
 Ansible Builder can execute two separate steps. The first step is to create a build instruction file (Containerfile for Podman, Dockerfile for Docker) and a build context based on your :ref:`definition <builder_ee_definition>` file. The second step is to run a containerization tool (Podman or Docker) to build an image based on the build instruction file and build context. The ``ansible-builder build`` command executes both steps, giving you a build instruction file, a build context, and a fully built container image. The ``ansible-builder create`` command only executes the first step, giving you a build instruction file and a build context. If you use ``ansible-builder create``, you can use the resulting build instruction file and build context to build your container images on the platform of your choice.
 
+.. note::
+
+   Ansible Builder honors the ``NO_COLOR`` environment variable. Set it to any non-empty value to avoid color output in the terminal.
+
+
 .. contents::
    :local:
 

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -44,7 +44,6 @@ def _should_disable_colors() -> bool:
     Check the environment to decide if text colorization should be disabled.
 
     This follows the no-color.org standard and related conventions:
-    - FORCE_COLOR: Force colors on, even when piping
     - NO_COLOR: Disable colors (no-color.org standard)
     - CLICOLOR: Enable/disable colors (0 = disabled)
     - TERM=dumb: Disable colors
@@ -53,28 +52,23 @@ def _should_disable_colors() -> bool:
 
     :returns: True if colors are disabled, False if enabled.
     """
-    # First priority: FORCE_COLOR overrides everything else
-    if os.environ.get('FORCE_COLOR', None):
-        return False  # Force colors ON
 
-    # Second priority: NO_COLOR standard
     if os.environ.get('NO_COLOR', None):
         return True
 
-    # Third priority: TERM=dumb
     if os.environ.get('TERM', '') == 'dumb':
         return True
 
-    # Fourth priority: CLICOLOR=0 explicitly disables colors
+    # CLICOLOR=0 explicitly disables colors
     if os.environ.get('CLICOLOR', '1') == '0':
         return True
 
-    # Fifth priority: Common CI environments (usually want plain output)
+    # Common CI environments (usually want plain output)
     ci_vars = ['CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS']
     if any(os.environ.get(var) for var in ci_vars):
         return True
 
-    # Sixth priority: TTY detection - disable if not outputting to terminal
+    # TTY detection - disable if not outputting to terminal
     if not sys.stdout.isatty():
         return True
 

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -47,7 +47,10 @@ def _should_disable_colors() -> bool:
     its value), text should not be colorized.
 
     According to force-color.org, if FORCE_COLOR is present, and not an empty string (regardless
-    of its value), text should be colorized, and should trump NO_COLOR.
+    of its value), text should be colorized.
+
+    If both NO_COLOR and FORCE_COLOR are present, NO_COLOR will take precedence so that we
+    will err on the safe side for those that use screen readers.
 
     :returns: True if colors are disabled, False if enabled.
     """
@@ -59,10 +62,10 @@ def _should_disable_colors() -> bool:
     no_color = os.environ.get('NO_COLOR', None)
     force_color = os.environ.get('FORCE_COLOR', None)
 
-    if no_color:
-        disabled = True
     if force_color:
         disabled = False
+    if no_color:
+        disabled = True
 
     return disabled
 

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -46,12 +46,6 @@ def _should_disable_colors() -> bool:
     According to no-color.org, if NO_COLOR is present, and not an empty string (regardless of
     its value), text should not be colorized.
 
-    According to force-color.org, if FORCE_COLOR is present, and not an empty string (regardless
-    of its value), text should be colorized.
-
-    If both NO_COLOR and FORCE_COLOR are present, NO_COLOR will take precedence so that we
-    will err on the safe side for those that use screen readers.
-
     :returns: True if colors are disabled, False if enabled.
     """
     disabled = False
@@ -59,12 +53,7 @@ def _should_disable_colors() -> bool:
     if os.environ.get('TERM', '') == 'dumb':
         return True
 
-    no_color = os.environ.get('NO_COLOR', None)
-    force_color = os.environ.get('FORCE_COLOR', None)
-
-    if force_color:
-        disabled = False
-    if no_color:
+    if os.environ.get('NO_COLOR', None):
         disabled = True
 
     return disabled

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -73,19 +73,12 @@ def _should_disable_colors() -> bool:
 def run():
     args = parse_args()
 
-    # If user explicitly requests to disable colors, that value takes precedence. Otherwise,
-    # we'll check the environment.
-    disable_colors = args.no_colors
-    if '--no-colors' not in sys.argv:
-        disable_colors = _should_disable_colors()
+    disable_colors = _should_disable_colors()
 
     configure_logger(args.verbosity, disable_colors)
 
     if args.action in ['create', 'build']:
-        kwargs = vars(args)
-        kwargs.pop('no_colors')  # not a value we should pass along
-
-        ab = AnsibleBuilder(**kwargs)
+        ab = AnsibleBuilder(**vars(args))
         action = getattr(ab, ab.action)
         try:
             if action():
@@ -237,12 +230,6 @@ def add_container_options(parser):
                             'Adding multiple -v will increase the verbosity to a max of 3 (-vvv). '
                             'Integer values are also accepted (for example, "-v3" or "--verbosity 3"). '
                             'Default is %(default)s.')
-
-        n.add_argument('--no-colors',
-                       dest='no_colors',
-                       action='store_true',
-                       help='Disable ANSI text colors (enabled by default). NO_COLOR and FORCE_COLOR environment '
-                            'variables will be honored if this option is not used.')
 
 
 def parse_args(args=None):

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -43,20 +43,43 @@ def _should_disable_colors() -> bool:
     """
     Check the environment to decide if text colorization should be disabled.
 
-    According to no-color.org, if NO_COLOR is present, and not an empty string (regardless of
-    its value), text should not be colorized.
+    This follows the no-color.org standard and related conventions:
+    - FORCE_COLOR: Force colors on, even when piping
+    - NO_COLOR: Disable colors (no-color.org standard)
+    - CLICOLOR: Enable/disable colors (0 = disabled)
+    - TERM=dumb: Disable colors
+    - TTY detection: Disable colors when not outputting to terminal
+    - CI detection: Disable colors in common CI environments
 
     :returns: True if colors are disabled, False if enabled.
     """
-    disabled = False
+    # First priority: FORCE_COLOR overrides everything else
+    if os.environ.get('FORCE_COLOR', None):
+        return False  # Force colors ON
 
+    # Second priority: NO_COLOR standard
+    if os.environ.get('NO_COLOR', None):
+        return True
+
+    # Third priority: TERM=dumb
     if os.environ.get('TERM', '') == 'dumb':
         return True
 
-    if os.environ.get('NO_COLOR', None):
-        disabled = True
+    # Fourth priority: CLICOLOR=0 explicitly disables colors
+    if os.environ.get('CLICOLOR', '1') == '0':
+        return True
 
-    return disabled
+    # Fifth priority: Common CI environments (usually want plain output)
+    ci_vars = ['CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS']
+    if any(os.environ.get(var) for var in ci_vars):
+        return True
+
+    # Sixth priority: TTY detection - disable if not outputting to terminal
+    if not sys.stdout.isatty():
+        return True
+
+    # Default: colors enabled
+    return False
 
 
 def run():

--- a/src/ansible_builder/colors.py
+++ b/src/ansible_builder/colors.py
@@ -1,7 +1,0 @@
-class MessageColors:
-    HEADER = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[1m'
-    OK = '\033[95m'
-    ENDC = '\033[0m'

--- a/src/ansible_builder/constants.py
+++ b/src/ansible_builder/constants.py
@@ -48,3 +48,5 @@ FINAL_IMAGE_BIN_PATH = "/opt/builder/bin"
 
 DEFAULT_EE_BASENAME = "execution-environment"
 YAML_FILENAME_EXTENSIONS = ('yml', 'yaml')
+
+SUCCESS_LOGLEVEL = 100

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -37,8 +37,7 @@ class ColorFilter(logging.Filter):
     }
 
     def filter(self, record):
-        if sys.stdout.isatty():
-            record.msg = self.color_map[record.levelno] + record.msg + ColorFilter.MessageColors.DEFAULT
+        record.msg = self.color_map[record.levelno] + record.msg + ColorFilter.MessageColors.DEFAULT
         return record
 
 

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import filecmp
 import logging
 import logging.config
@@ -10,58 +12,50 @@ import sys
 from collections import deque
 from pathlib import Path
 
-from .colors import MessageColors
 from . import constants
 
 
 logger = logging.getLogger(__name__)
-logging_levels = {
-    '0': 'ERROR',
-    '1': 'WARNING',
-    '2': 'INFO',
-    '3': 'DEBUG',
-}
 
 
 class ColorFilter(logging.Filter):
+    class MessageColors:
+        ERROR = '\033[91m'    # bright red
+        WARNING = '\033[93m'  # bright yellow
+        INFO = '\033[94m'     # bright blue
+        DEBUG = '\033[95m'    # bright magenta
+        OKGREEN = '\033[92m'  # bright green
+        DEFAULT = '\033[0m'   # terminal default
+
     color_map = {
-        'ERROR': MessageColors.FAIL,
-        'WARNING': MessageColors.WARNING,
-        'INFO': MessageColors.HEADER,
-        'DEBUG': MessageColors.OK
+        logging.CRITICAL: MessageColors.ERROR,
+        logging.ERROR: MessageColors.ERROR,
+        logging.WARNING: MessageColors.WARNING,
+        logging.INFO: MessageColors.INFO,
+        logging.DEBUG: MessageColors.DEBUG,
+        constants.SUCCESS_LOGLEVEL: MessageColors.OKGREEN,
     }
 
     def filter(self, record):
         if sys.stdout.isatty():
-            record.msg = self.color_map[record.levelname] + record.msg + MessageColors.ENDC
+            record.msg = self.color_map[record.levelno] + record.msg + ColorFilter.MessageColors.DEFAULT
         return record
 
 
-LOGGING = {
-    'version': 1,
-    'filters': {
-        'colorize': {
-            '()': ColorFilter
-        }
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'filters': ['colorize'],
-            'stream': 'ext://sys.stdout'
-        }
-    },
-    'loggers': {
-        'ansible_builder': {
-            'handlers': ['console'],
-        }
+def configure_logger(verbosity: int, disable_colors: bool = False):
+    logging_levels = {
+        0: 'ERROR',
+        1: 'WARNING',
+        2: 'INFO',
+        3: 'DEBUG',
     }
-}
 
-
-def configure_logger(verbosity):
-    LOGGING['loggers']['ansible_builder']['level'] = logging_levels[str(verbosity)]
-    logging.config.dictConfig(LOGGING)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging_levels[verbosity])
+    handler = logging.StreamHandler(sys.stdout)
+    if not disable_colors:
+        handler.addFilter(ColorFilter())
+    root_logger.addHandler(handler)
 
 
 def run_command(command, capture_output=False, allow_error=False):
@@ -119,7 +113,7 @@ def run_command(command, capture_output=False, allow_error=False):
         logger.error("An error occurred (rc=%s), see output line(s) above for details.", rc)
         sys.exit(1)
 
-    return (rc, output)
+    return rc, output
 
 
 def write_file(filename: str, lines: list) -> bool:
@@ -171,9 +165,9 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
     to copy the file if it doesn't exist, or if it has changed between builds.
     See the `copy_directory()` function for the directory copy equivalent.
 
-    :param source str: Path to a source file.
-    :param dest str: Path to a destination file within the context subdir.
-    :param ignore_mtime bool: Whether or not mtime should be considered.
+    :param str source: Path to a source file.
+    :param str dest: Path to a destination file within the context subdir.
+    :param bool ignore_mtime: Whether mtime should be considered.
 
     :returns: True if the file was copied, False if not.
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -12,7 +12,9 @@ from ansible_builder.policies import PolicyChoices
 
 def prepare(args):
     args = parse_args(args)
-    return AnsibleBuilder(**vars(args))
+    kwargs = vars(args)
+    kwargs.pop('no_colors')
+    return AnsibleBuilder(**kwargs)
 
 
 def test_custom_image(exec_env_definition_file, tmp_path):

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -408,7 +408,7 @@ def env_save():
                              ('', '', 'xterm', False),
                              ('1', '', 'xterm', True),
                              ('', '1', 'xterm', False),
-                             ('1', '1', 'xterm', False),
+                             ('1', '1', 'xterm', True),  # NO_COLOR trumps FORCE_COLOR
                              ('', '', 'dumb', True),
                              ('', '1', 'dumb', True),
                          ])

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,7 +1,6 @@
 import os
 import runpy
 import shlex
-import unittest.mock
 
 import pytest
 
@@ -391,82 +390,69 @@ def test_extra_build_cli_args(exec_env_definition_file, tmp_path):
         assert extra in aee.build_command
 
 
-@pytest.fixture
-def env_save():
-    orig = {}
-    for val in ('NO_COLOR', 'FORCE_COLOR', 'TERM', 'CLICOLOR',
-                'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS'):
-        orig[val] = os.environ.get(val, None)
-    yield
-    for key, value in orig.items():
-        if value:
-            os.environ[key] = value
-        elif key in os.environ:
-            del os.environ[key]
-
-
 @pytest.mark.parametrize('force_color,no_color,clicolor,term,ci,expected',
                          [
                              # FORCE_COLOR overrides everything
                              ('1', '1', '0', 'dumb', '1', False),  # Force color on despite all other indicators
-                             ('1', '', '', 'xterm', '', False),   # Force color on in normal case
+                             ('1', '', '', 'xterm', '', False),    # Force color on in normal case
 
                              # NO_COLOR standard
-                             ('', '1', '', 'xterm', '', True),    # NO_COLOR disables
-                             ('', '1', '1', 'xterm', '', True),   # NO_COLOR overrides CLICOLOR
+                             ('', '1', '', 'xterm', '', True),     # NO_COLOR disables
+                             ('', '1', '1', 'xterm', '', True),    # NO_COLOR overrides CLICOLOR
 
                              # TERM=dumb
-                             ('', '', '', 'dumb', '', True),      # TERM=dumb disables
+                             ('', '', '', 'dumb', '', True),       # TERM=dumb disables
 
                              # CLICOLOR
-                             ('', '', '0', 'xterm', '', True),    # CLICOLOR=0 disables
-                             ('', '', '1', 'xterm', '', False),   # CLICOLOR=1 enables
-                             ('', '', '', 'xterm', '', False),    # Default CLICOLOR behavior (enabled)
+                             ('', '', '0', 'xterm', '', True),     # CLICOLOR=0 disables
+                             ('', '', '1', 'xterm', '', False),    # CLICOLOR=1 enables
+                             ('', '', '', 'xterm', '', False),     # Default CLICOLOR behavior (enabled)
 
                              # CI environments
-                             ('', '', '', 'xterm', '1', True),    # CI disables colors
+                             ('', '', '', 'xterm', '1', True),     # CI disables colors
 
                              # Original test cases for backward compatibility
-                             ('', '', '', 'xterm', '', False),    # Normal case - colors enabled
-                             ('', '1', '', 'xterm', '', True),    # NO_COLOR disables
-                             ('', '', '', 'dumb', '', True),      # TERM=dumb disables
+                             ('', '', '', 'xterm', '', False),     # Normal case - colors enabled
+                             ('', '1', '', 'xterm', '', True),     # NO_COLOR disables
+                             ('', '', '', 'dumb', '', True),       # TERM=dumb disables
                          ])
-def test__should_disable_colors(force_color, no_color, clicolor, term, ci, expected, env_save):
+def test__should_disable_colors(force_color, no_color, clicolor, term, ci, expected, monkeypatch, mocker):
     # pylint: disable=W0613,W0621
-    # Clear environment first
-    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM', 'CI']:
-        if var in os.environ:
-            del os.environ[var]
+    # Clear environment variables that could interfere with the test
+    # monkeypatch.delenv is safe for concurrent execution
+    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM',
+                'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS']:
+        monkeypatch.delenv(var, raising=False)
 
-    # Set test values
+    # Set test values using monkeypatch (thread-safe)
     if force_color:
-        os.environ['FORCE_COLOR'] = force_color
+        monkeypatch.setenv('FORCE_COLOR', force_color)
     if no_color:
-        os.environ['NO_COLOR'] = no_color
+        monkeypatch.setenv('NO_COLOR', no_color)
     if clicolor:
-        os.environ['CLICOLOR'] = clicolor
+        monkeypatch.setenv('CLICOLOR', clicolor)
     if term:
-        os.environ['TERM'] = term
+        monkeypatch.setenv('TERM', term)
     if ci:
-        os.environ['CI'] = ci
+        monkeypatch.setenv('CI', ci)
 
     # Mock TTY detection to return True (simulating terminal environment)
     # This prevents test environment from interfering with color detection logic
-    with unittest.mock.patch('sys.stdout.isatty', return_value=True):
-        assert _should_disable_colors() == expected
+    mocker.patch('sys.stdout.isatty', return_value=True)
+    assert _should_disable_colors() == expected
 
 
 @pytest.mark.parametrize('isatty_result,expected', [
     (True, False),   # TTY - colors enabled
     (False, True),   # Not TTY - colors disabled
 ])
-def test__should_disable_colors_tty_detection(isatty_result, expected, env_save):
+def test__should_disable_colors_tty_detection(isatty_result, expected, monkeypatch, mocker):
     # pylint: disable=W0613,W0621
-    # Clear all color-related environment variables
-    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM', 'CI']:
-        if var in os.environ:
-            del os.environ[var]
+    # Clear all color-related environment variables using monkeypatch
+    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM',
+                'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS']:
+        monkeypatch.delenv(var, raising=False)
 
     # Mock sys.stdout.isatty to control TTY detection
-    with unittest.mock.patch('sys.stdout.isatty', return_value=isatty_result):
-        assert _should_disable_colors() == expected
+    mocker.patch('sys.stdout.isatty', return_value=isatty_result)
+    assert _should_disable_colors() == expected

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import runpy
 import shlex
+import unittest.mock
 
 import pytest
 
@@ -393,22 +394,79 @@ def test_extra_build_cli_args(exec_env_definition_file, tmp_path):
 @pytest.fixture
 def env_save():
     orig = {}
-    for val in ('NO_COLOR', 'FORCE_COLOR', 'TERM'):
+    for val in ('NO_COLOR', 'FORCE_COLOR', 'TERM', 'CLICOLOR',
+                'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS'):
         orig[val] = os.environ.get(val, None)
     yield
     for key, value in orig.items():
         if value:
             os.environ[key] = value
+        elif key in os.environ:
+            del os.environ[key]
 
 
-@pytest.mark.parametrize('no_color,term,expected',
+@pytest.mark.parametrize('force_color,no_color,clicolor,term,ci,expected',
                          [
-                             ('', 'xterm', False),
-                             ('1', 'xterm', True),
-                             ('', 'dumb', True),
+                             # FORCE_COLOR overrides everything
+                             ('1', '1', '0', 'dumb', '1', False),  # Force color on despite all other indicators
+                             ('1', '', '', 'xterm', '', False),   # Force color on in normal case
+
+                             # NO_COLOR standard
+                             ('', '1', '', 'xterm', '', True),    # NO_COLOR disables
+                             ('', '1', '1', 'xterm', '', True),   # NO_COLOR overrides CLICOLOR
+
+                             # TERM=dumb
+                             ('', '', '', 'dumb', '', True),      # TERM=dumb disables
+
+                             # CLICOLOR
+                             ('', '', '0', 'xterm', '', True),    # CLICOLOR=0 disables
+                             ('', '', '1', 'xterm', '', False),   # CLICOLOR=1 enables
+                             ('', '', '', 'xterm', '', False),    # Default CLICOLOR behavior (enabled)
+
+                             # CI environments
+                             ('', '', '', 'xterm', '1', True),    # CI disables colors
+
+                             # Original test cases for backward compatibility
+                             ('', '', '', 'xterm', '', False),    # Normal case - colors enabled
+                             ('', '1', '', 'xterm', '', True),    # NO_COLOR disables
+                             ('', '', '', 'dumb', '', True),      # TERM=dumb disables
                          ])
-def test__should_disable_colors(no_color, term, expected, env_save):
+def test__should_disable_colors(force_color, no_color, clicolor, term, ci, expected, env_save):
     # pylint: disable=W0613,W0621
-    os.environ['NO_COLOR'] = no_color
-    os.environ['TERM'] = term
-    assert _should_disable_colors() == expected
+    # Clear environment first
+    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM', 'CI']:
+        if var in os.environ:
+            del os.environ[var]
+
+    # Set test values
+    if force_color:
+        os.environ['FORCE_COLOR'] = force_color
+    if no_color:
+        os.environ['NO_COLOR'] = no_color
+    if clicolor:
+        os.environ['CLICOLOR'] = clicolor
+    if term:
+        os.environ['TERM'] = term
+    if ci:
+        os.environ['CI'] = ci
+
+    # Mock TTY detection to return True (simulating terminal environment)
+    # This prevents test environment from interfering with color detection logic
+    with unittest.mock.patch('sys.stdout.isatty', return_value=True):
+        assert _should_disable_colors() == expected
+
+
+@pytest.mark.parametrize('isatty_result,expected', [
+    (True, False),   # TTY - colors enabled
+    (False, True),   # Not TTY - colors disabled
+])
+def test__should_disable_colors_tty_detection(isatty_result, expected, env_save):
+    # pylint: disable=W0613,W0621
+    # Clear all color-related environment variables
+    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM', 'CI']:
+        if var in os.environ:
+            del os.environ[var]
+
+    # Mock sys.stdout.isatty to control TTY detection
+    with unittest.mock.patch('sys.stdout.isatty', return_value=isatty_result):
+        assert _should_disable_colors() == expected

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -401,18 +401,14 @@ def env_save():
             os.environ[key] = value
 
 
-@pytest.mark.parametrize('no_color,force_color,term,expected',
+@pytest.mark.parametrize('no_color,term,expected',
                          [
-                             ('', '', 'xterm', False),
-                             ('1', '', 'xterm', True),
-                             ('', '1', 'xterm', False),
-                             ('1', '1', 'xterm', True),  # NO_COLOR trumps FORCE_COLOR
-                             ('', '', 'dumb', True),
-                             ('', '1', 'dumb', True),
+                             ('', 'xterm', False),
+                             ('1', 'xterm', True),
+                             ('', 'dumb', True),
                          ])
-def test__should_disable_colors(no_color, force_color, term, expected, env_save):
+def test__should_disable_colors(no_color, term, expected, env_save):
     # pylint: disable=W0613,W0621
     os.environ['NO_COLOR'] = no_color
-    os.environ['FORCE_COLOR'] = force_color
     os.environ['TERM'] = term
     assert _should_disable_colors() == expected

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -12,9 +12,7 @@ from ansible_builder.policies import PolicyChoices
 
 def prepare(args):
     args = parse_args(args)
-    kwargs = vars(args)
-    kwargs.pop('no_colors')
-    return AnsibleBuilder(**kwargs)
+    return AnsibleBuilder(**vars(args))
 
 
 def test_custom_image(exec_env_definition_file, tmp_path):

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -390,43 +390,32 @@ def test_extra_build_cli_args(exec_env_definition_file, tmp_path):
         assert extra in aee.build_command
 
 
-@pytest.mark.parametrize('force_color,no_color,clicolor,term,ci,expected',
+@pytest.mark.parametrize('no_color,clicolor,term,ci,expected',
                          [
-                             # FORCE_COLOR overrides everything
-                             ('1', '1', '0', 'dumb', '1', False),  # Force color on despite all other indicators
-                             ('1', '', '', 'xterm', '', False),    # Force color on in normal case
-
                              # NO_COLOR standard
-                             ('', '1', '', 'xterm', '', True),     # NO_COLOR disables
-                             ('', '1', '1', 'xterm', '', True),    # NO_COLOR overrides CLICOLOR
+                             ('1', '', 'xterm', '', True),     # NO_COLOR disables
+                             ('1', '1', 'xterm', '', True),    # NO_COLOR overrides CLICOLOR
 
                              # TERM=dumb
-                             ('', '', '', 'dumb', '', True),       # TERM=dumb disables
+                             ('', '', 'dumb', '', True),       # TERM=dumb disables
 
                              # CLICOLOR
-                             ('', '', '0', 'xterm', '', True),     # CLICOLOR=0 disables
-                             ('', '', '1', 'xterm', '', False),    # CLICOLOR=1 enables
-                             ('', '', '', 'xterm', '', False),     # Default CLICOLOR behavior (enabled)
+                             ('', '0', 'xterm', '', True),     # CLICOLOR=0 disables
+                             ('', '1', 'xterm', '', False),    # CLICOLOR=1 enables
+                             ('', '', 'xterm', '', False),     # Default CLICOLOR behavior (enabled)
 
                              # CI environments
-                             ('', '', '', 'xterm', '1', True),     # CI disables colors
-
-                             # Original test cases for backward compatibility
-                             ('', '', '', 'xterm', '', False),     # Normal case - colors enabled
-                             ('', '1', '', 'xterm', '', True),     # NO_COLOR disables
-                             ('', '', '', 'dumb', '', True),       # TERM=dumb disables
+                             ('', '', 'xterm', '1', True),     # CI disables colors
                          ])
-def test__should_disable_colors(force_color, no_color, clicolor, term, ci, expected, monkeypatch, mocker):
+def test__should_disable_colors(no_color, clicolor, term, ci, expected, monkeypatch, mocker):
     # pylint: disable=W0613,W0621
     # Clear environment variables that could interfere with the test
     # monkeypatch.delenv is safe for concurrent execution
-    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM',
+    for var in ['NO_COLOR', 'CLICOLOR', 'TERM',
                 'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS']:
         monkeypatch.delenv(var, raising=False)
 
     # Set test values using monkeypatch (thread-safe)
-    if force_color:
-        monkeypatch.setenv('FORCE_COLOR', force_color)
     if no_color:
         monkeypatch.setenv('NO_COLOR', no_color)
     if clicolor:
@@ -449,7 +438,7 @@ def test__should_disable_colors(force_color, no_color, clicolor, term, ci, expec
 def test__should_disable_colors_tty_detection(isatty_result, expected, monkeypatch, mocker):
     # pylint: disable=W0613,W0621
     # Clear all color-related environment variables using monkeypatch
-    for var in ['FORCE_COLOR', 'NO_COLOR', 'CLICOLOR', 'TERM',
+    for var in ['NO_COLOR', 'CLICOLOR', 'TERM',
                 'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER', 'GITHUB_ACTIONS']:
         monkeypatch.delenv(var, raising=False)
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ usedevelop = True
 # Set env var to get a working Python 3.13 environment (see https://github.com/PyO3/pyo3/pull/3821)
 setenv =
     UNSAFE_PYO3_SKIP_VERSION_CHECK=1
-    NO_COLOR=1
 
 deps =
     -r {toxinidir}/test/requirements.txt
@@ -33,6 +32,10 @@ commands =
 
 [testenv:unit{,-py39,-py310,-py311,-py312,-py313,-py314}]
 description = Run unit tests
+setenv =
+    NO_COLOR=1
+passenv =
+    NO_COLOR
 commands = pytest -n auto test/unit {[shared]pytest_cov_args} {posargs}
 
 [testenv:pulp-integration{-py39,-py310,-py311,-py312,-py313,-py314}]
@@ -45,10 +48,13 @@ commands =
 
 [testenv:integration{,-py39,-py310,-py311,-py312,-py313,-py314}]
 description = Run integration tests
+setenv =
+    NO_COLOR=1
 # rootless podman reads $HOME
 passenv =
     HOME
     KEEP_IMAGES
+    NO_COLOR
 commands =
     pytest -n auto -m "not serial" test/integration {[shared]pytest_cov_args} {posargs}
     pytest -n 0 -m "serial" test/integration {[shared]pytest_cov_args} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ usedevelop = True
 # Set env var to get a working Python 3.13 environment (see https://github.com/PyO3/pyo3/pull/3821)
 setenv =
     UNSAFE_PYO3_SKIP_VERSION_CHECK=1
+    NO_COLOR=1
 
 deps =
     -r {toxinidir}/test/requirements.txt


### PR DESCRIPTION
Allows control of when builder output text is colorized.

Bonus fix: This makes the Python 3.14 tests work.

Fixes #716 

Assisted-by: Cursor