### PR TITLE
[PR ansible#731/1b659226 backport][release_3.0] 🧪 Use `reusable-tox.yml` @ `tox-dev/workflow`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,117 +5,167 @@ on:
   push:
 
 
+env:
+  UPSTREAM_REPOSITORY_ID: >-
+    245499251
+
+
 jobs:
+  pre-setup:
+    name: ⚙️ Pre-set global build settings
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 1
+
+    defaults:
+      run:
+        shell: python
+
+    outputs:
+      # NOTE: These aren't env vars because the `${{ env }}` context is
+      # NOTE: inaccessible when passing inputs to reusable workflows.
+      upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
+      is-debug-mode: ${{ toJSON(runner.debug == '1') }}
+
+    steps:
+    - name: No-op so that the computations can happen in the outputs
+      if: fromJSON(false)
+      run: |
+        print('No-op')
+
   sanity:
-    name: ${{ matrix.test.name }}
-    runs-on: ubuntu-22.04
-    env:
-      TOXENV: ${{ matrix.test.tox_env }}
+    name: 🧹 Linters${{ '' }}  # nest jobs under the same sidebar category
+    needs:
+    - pre-setup
 
     strategy:
       fail-fast: false
       matrix:
-        test:
-          - name: Lint
-            tox_env: linters-py310
+        runner-vm-os:
+        - ubuntu-22.04
+        python-version:
+        - >-
+          3.10
+        toxenv:
+        - linters
+        - docs
+        xfail:
+        - false
 
-          - name: Docs
-            tox_env: docs
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    with:
+      cache-key-for-dependency-files:  # FIXME
+      check-name: >-
+        ${{ matrix.toxenv }}
+        under 🐍${{ matrix.python-version }}
+      python-version: >-
+        ${{ matrix.python-version }}
+      require-successful-codecov-uploads: >-
+        ${{
+          toJSON(
+          needs.pre-setup.outputs.upstream-repository-id
+          == github.repository_id
+          )
+        }}
+      runner-vm-os: >-
+        ${{ matrix.runner-vm-os }}
+      timeout-minutes: 2
+      toxenv: >-
+        ${{ matrix.toxenv }}
+      xfail: >-
+        ${{ fromJSON(matrix.xfail) }}
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  tests:
+    name: 🧪 Tests${{ '' }}  # nest jobs under the same sidebar category
 
-      - name: Install tox
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install tox
-
-      - name: Create tox environment
-        run: tox --notest
-
-      - name: Run tests
-        run: tox
-
-  integration:
-    runs-on: ubuntu-22.04
-    name: Integration - ${{ matrix.py_version.name }}
-
-    env:
-      TOXENV: ${{ matrix.py_version.tox_env }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        py_version:
-          - name: '3.9'
-            tox_env: integration-py39
-
-          - name: '3.10'
-            tox_env: integration-py310
-
-          - name: '3.11'
-            tox_env: integration-py311
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # this is not ideal, but we need tags available to generate versions in tests
-
-      - name: Install Python ${{ matrix.py_version.name }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.py_version.name }}
-
-      - name: Install tox
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install tox
-
-      - name: Create tox environment
-        run: |
-          tox --notest
-
-      - name: Run integration tests (including destructive)
-        run: |
-          tox -- --run-destructive
-
-  unit:
-    name: Unit - ${{ matrix.py_version.name}}
-    runs-on: ubuntu-22.04
-    env:
-      TOXENV: ${{ matrix.py_version.tox_env }}
+    needs:
+    - pre-setup  # transitive, for accessing settings
 
     strategy:
-      fail-fast: false
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
-        py_version:
-          - name: '3.9'
-            tox_env: unit-py39
+        python-version:
+        # NOTE: The latest and the lowest supported Pythons are prioritized
+        # NOTE: to improve the responsiveness. It's nice to see the most
+        # NOTE: important results first.
+        - 3.11
+        - 3.9
+        - >-
+          3.10
+        runner-vm-os:
+        - ubuntu-22.04
+        toxenv:
+        - integration
+        - unit
+        xfail:
+        - false
 
-          - name: '3.10'
-            tox_env: unit-py310
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    with:
+      cache-key-for-dependency-files:  # FIXME
+      check-name: >-
+        ${{ matrix.toxenv }}
+        under 🐍${{ matrix.python-version }}
+      checkout-src-git-fetch-depth: >-
+        ${{ matrix.toxenv == 'unit' && 1 || 0 }}
+      job-dependencies-context: >-  # context for hooks
+        ${{ toJSON(needs) }}
+      python-version: >-
+        ${{ matrix.python-version }}
+      require-successful-codecov-uploads: >-
+        ${{
+          toJSON(
+          needs.pre-setup.outputs.upstream-repository-id
+          == github.repository_id
+          )
+        }}
+      runner-vm-os: >-
+        ${{ matrix.runner-vm-os }}
+      timeout-minutes: >-
+        ${{ matrix.toxenv == 'unit' && 2 || 7 }}
+      toxenv: >-
+        ${{ matrix.toxenv }}
+      tox-run-posargs: >-
+        --run-destructive
+        --cov-report=xml:.tox/.tmp/.test-results/pytest-${{
+          matrix.python-version
+        }}/cobertura.xml
+        --junitxml=.tox/.tmp/.test-results/pytest-${{
+          matrix.python-version
+        }}/test.xml
+      tox-rerun-posargs: >-
+        --run-destructive
+        --no-cov
+        -vvvvv
+        --lf
+      xfail: >-
+        ${{ fromJSON(matrix.xfail) }}
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-          - name: '3.11'
-            tox_env: unit-py311
+  check:  # This job does nothing and is only used for the branch protection
+    name: ✅ All tests passed
+    if: always()
+
+    needs:
+    - pre-setup  # transitive, for accessing settings
+    - sanity
+    - tests
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 1
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Python ${{ matrix.py_version.name }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.py_version.name }}
-
-      - name: Install tox
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install tox
-
-      - name: Create tox environment
-        run: tox --notest
-
-      - name: Run tests
-        run: tox
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/tox.ini
+++ b/tox.ini
@@ -24,15 +24,15 @@ commands =
 
 [testenv:unit{,-py39,-py310,-py311}]
 description = Run unit tests
-commands = pytest -n auto test/unit {posargs} {[shared]pytest_cov_args}
+commands = pytest -n auto test/unit {[shared]pytest_cov_args} {posargs}
 
 [testenv:pulp-integration{-py39,-py310,-py311}]
 # Some of these tests must run serially because of a shared resource
 # (the system policy.json file).
 description = Run pulp integration tests
 commands =
-    pytest -n auto -m "not serial" test/pulp_integration {posargs} {[shared]pytest_cov_args}
-    pytest -n 0 -m "serial" test/pulp_integration {posargs} {[shared]pytest_cov_args}
+    pytest -n auto -m "not serial" test/pulp_integration {[shared]pytest_cov_args} {posargs}
+    pytest -n 0 -m "serial" test/pulp_integration {[shared]pytest_cov_args} {posargs}
 
 [testenv:integration{,-py39,-py310,-py311}]
 description = Run integration tests
@@ -41,8 +41,8 @@ passenv =
     HOME
     KEEP_IMAGES
 commands =
-    pytest -n auto -m "not serial" test/integration {posargs} {[shared]pytest_cov_args}
-    pytest -n 0 -m "serial" test/integration {posargs} {[shared]pytest_cov_args}
+    pytest -n auto -m "not serial" test/integration {[shared]pytest_cov_args} {posargs}
+    pytest -n 0 -m "serial" test/integration {[shared]pytest_cov_args} {posargs}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
**This is a backport of PR #731 as merged into devel (1b6592267bbc0cc9a4118657faeb8680bd13ac55).**

This patch integrates the upstream workflow hosted at [[1]]. It features a set of steps that are common for when having tox-centric CI configurations. In addition to that, it also integrates automatic verbose reruns on test failures and publishing coverage and test results to Codecov (currently disabled).

The reusable workflow is customizable through hook points that run in-repo actions with defined names hosted under
`.github/reusables/tox-dev/workflow/reusable-tox/hooks/`.

Additionally, an integration is added with `alls-green` [[2]] that lets us migrate to using just a single branch protection check for the CI instead of enumerating each possible job name in there.

The usage of `tox-uv` improved the tox env provisioning speed and built-in caching does the same on the pip level.

PR #731

[1]: https://github.com/tox-dev/workflow
[2]: https://github.com/marketplace/actions/alls-green#why

(cherry picked from commit 1b6592267bbc0cc9a4118657faeb8680bd13ac55)