### PR TITLE
Apply follow-up fixes for PR #731

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
       toxenv: >-
         ${{ matrix.toxenv }}
       tox-run-posargs: >-
+        --run-destructive
         --cov-report=xml:.tox/.tmp/.test-results/pytest-${{
           matrix.python-version
         }}/cobertura.xml
@@ -141,6 +142,7 @@ jobs:
           matrix.python-version
         }}/test.xml
       tox-rerun-posargs: >-
+        --run-destructive
         --no-cov
         -vvvvv
         --lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       # NOTE: These aren't env vars because the `${{ env }}` context is
       # NOTE: inaccessible when passing inputs to reusable workflows.
       upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
-      is-debug-mode: ${{ runner.debug == '1' && false || true }}
+      is-debug-mode: ${{ toJSON(runner.debug == '1') }}
 
     steps:
     - name: No-op so that the computations can happen in the outputs


### PR DESCRIPTION
In particular, this fixes computing is-debug-mode in CI and re-adds running destructive tests in CI (PR #731 / 1b65922 missed the `--run-destructive` arg passed to pytest initially).