### PR TITLE
Fix builder GH issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,23 +9,21 @@ body:
       value: |
         **Thank you for reporting a bug in Ansible Builder.**
 
-        If you are looking for community support, please visit
-        the [Community guide](https://ansible.readthedocs.io/projects/builder/en/latest/community/)
-        for information on how to get in touch.
+        If this is a question about using `ansible-builder`, please do not use a new issue for your question.
+        New issues should be used only for submitting a new bug report. Please consult the [Community guide](https://ansible.readthedocs.io/projects/builder/en/latest/community/)
+        for information on how to submit your question to the [Ansible Forum](https://forum.ansible.com/).
 
   - type: input
     attributes:
       label: Ansible Builder version
       description: Output from `ansible-builder --version`
-      render: console
     validations:
       required: true
 
-  - type: textarea
+  - type: input
     attributes:
       label: Python version
       description: Output from `python -VV`
-      render: console
     validations:
       required: true
 
@@ -42,7 +40,6 @@ body:
     attributes:
       label: Container Runtime
       description: Output from `podman|docker --version`
-      render: console
       placeholder: podman --version
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issue_enabled: false
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -10,13 +10,12 @@ body:
       value: |
         **Thank you reporting an issue with Ansible Builder documentation.**
 
-        If you are looking for community support, please visit
-        the [Community guide](https://ansible.readthedocs.io/projects/builder/en/latest/community/)
+        If you are looking for community support, please visit the [Community guide](https://ansible.readthedocs.io/projects/builder/en/latest/community/)
         for information on how to get in touch.
 
   - type: textarea
     attributes:
       label: Summary
       description: Describe the problem or suggestion with the documentation
-      validations:
-        required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,13 +10,12 @@ body:
       value: |
         **Thank you for suggesting a new feature for Ansible Builder.**
 
-        If you are looking for community support, please visit
-        the [Community guide](https://ansible.readthedocs.io/projects/builder/en/latest/community/)
+        If you are looking for community support, please visit the [Community guide](https://ansible.readthedocs.io/projects/builder/en/latest/community/)
         for information on how to get in touch.
 
   - type: textarea
     attributes:
       label: Summary
       description: Describe the new feature and how it would be used.
-      validations:
-        required: true
+    validations:
+      required: true


### PR DESCRIPTION
- Fixes spelling error in template chooser that prevented the templates from being used.
- Fixes some formatting issues with the templates.
- Updates bug report template to point the user to Ansible Forum.