### PR TITLE
Allow downstreams to enforce that the ansible_core ref must have a version specifier

### DIFF
--- a/src/ansible_builder/constants.py
+++ b/src/ansible_builder/constants.py
@@ -48,3 +48,5 @@ FINAL_IMAGE_BIN_PATH = "/opt/builder/bin"
 
 DEFAULT_EE_BASENAME = "execution-environment"
 YAML_FILENAME_EXTENSIONS = ('yml', 'yaml')
+
+REQUIRE_ANSIBLE_CORE_PIN = False

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -243,7 +243,7 @@ class UserDefinition:
     def _validate_ansible_core_ref(self):
         """
         If a downstream has patched REQUIRE_ANSIBLE_CORE_PIN validate
-        that the 'ansible_core' ref constains a version constraint.
+        that the 'ansible_core' ref contains a version constraint.
 
         :raises: DefinitionError exception if version constraint is invalid or missing
         """

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -159,20 +159,7 @@ class UserDefinition:
 
     @property
     def ansible_core_ref(self):
-        ref = self.raw.get('dependencies', {}).get('ansible_core', {}).get('package_pip', None)
-
-        if ref and constants.REQUIRE_ANSIBLE_CORE_PIN:
-            try:
-                req = Requirement(ref)
-            except InvalidRequirement as e:
-                raise DefinitionError("Invalid package requirement specified for 'ansible_core'") from e
-
-            if not req.specifier:
-                raise DefinitionError(
-                    "Value for 'ansible_core' must contain a version constraint, such as 'ansible-core==2.16.*'"
-                )
-
-        return ref
+        return self.raw.get('dependencies', {}).get('ansible_core', {}).get('package_pip', None)
 
     @property
     def ansible_runner_ref(self):
@@ -253,6 +240,30 @@ class UserDefinition:
             if dest.is_absolute() or '..' in dest.parts:
                 raise DefinitionError(f"'dest' must not be an absolute path or contain '..': {dest}")
 
+    def _validate_ansible_core_ref(self):
+        """
+        If a downstream has patched REQUIRE_ANSIBLE_CORE_PIN validate
+        that the 'ansible_core' ref constains a version constraint.
+
+        :raises: DefinitionError exception if version constraint is invalid or missing
+        """
+        if not constants.REQUIRE_ANSIBLE_CORE_PIN:
+            return
+
+        ref = self.ansible_core_ref
+        if not ref:
+            return
+
+        try:
+            req = Requirement(ref)
+        except InvalidRequirement as e:
+            raise DefinitionError("Invalid package requirement specified for 'ansible_core'") from e
+
+        if not req.specifier:
+            raise DefinitionError(
+                "Value for 'ansible_core' must contain a version constraint, such as 'ansible-core==2.16.*'"
+            )
+
     def validate(self):
         """
         Check that all specified keys in the definition file are valid.
@@ -260,6 +271,8 @@ class UserDefinition:
         :raises: DefinitionError exception if any errors are found.
         """
         validate_schema(self.raw)
+
+        self._validate_ansible_core_ref()
 
         for item in constants.CONTEXT_FILES:
             for exclude in (False, True):

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Callable
 
 import yaml
+from packaging.requirements import InvalidRequirement, Requirement
 
 from . import constants
 from .exceptions import DefinitionError
@@ -158,7 +159,20 @@ class UserDefinition:
 
     @property
     def ansible_core_ref(self):
-        return self.raw.get('dependencies', {}).get('ansible_core', {}).get('package_pip', None)
+        ref = self.raw.get('dependencies', {}).get('ansible_core', {}).get('package_pip', None)
+
+        if ref and constants.REQUIRE_ANSIBLE_CORE_PIN:
+            try:
+                req = Requirement(ref)
+            except InvalidRequirement as e:
+                raise DefinitionError("Invalid package requirement specified for 'ansible_core'") from e
+
+            if not req.specifier:
+                raise DefinitionError(
+                    "Value for 'ansible_core' must contain a version constraint, such as 'ansible-core==2.16.*'"
+                )
+
+        return ref
 
     @property
     def ansible_runner_ref(self):

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -173,7 +173,7 @@ class TestUserDefinition:
             {'version': 3,
              'images': { 'base_image': {'name': 'base_image:latest'}},
              'dependencies': {
-                'ansible_core': {'package_pip': 'ansible-core==2.13'},
+                'ansible_core': {'package_pip': 'ansible-core'},
                 'ansible_runner': { 'package_pip': 'ansible-runner==2.3.1'}
              }
             }
@@ -181,9 +181,28 @@ class TestUserDefinition:
         )
         definition = UserDefinition(path)
         definition.validate()
-        assert definition.ansible_core_ref == "ansible-core==2.13"
+        assert definition.ansible_core_ref == "ansible-core"
         assert definition.ansible_runner_ref == "ansible-runner==2.3.1"
-        assert definition.ansible_ref_install_list == "ansible-core==2.13 ansible-runner==2.3.1"
+        assert definition.ansible_ref_install_list == "ansible-core ansible-runner==2.3.1"
+
+    def test_v3_ansible_install_ref_pin_required(self, monkeypatch, exec_env_definition_file):
+        path = exec_env_definition_file(
+            """
+            {'version': 3,
+             'images': { 'base_image': {'name': 'base_image:latest'}},
+             'dependencies': {
+                'ansible_core': {'package_pip': 'ansible-core'},
+                'ansible_runner': { 'package_pip': 'ansible-runner==2.3.1'}
+             }
+            }
+            """
+        )
+        monkeypatch.setattr(constants, 'REQUIRE_ANSIBLE_CORE_PIN', True)
+        definition = UserDefinition(path)
+        definition.validate()
+        with pytest.raises(DefinitionError) as error:
+            _ = definition.ansible_core_ref
+        assert "Value for 'ansible_core' must contain a version constraint" in str(error.value.args[0])
 
     def test_v3_inline_python(self, exec_env_definition_file):
         """

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -220,6 +220,7 @@ class TestUserDefinition:
         with pytest.raises(DefinitionError) as error:
             definition.validate()
         assert "Invalid package requirement specified for 'ansible_core'" in str(error.value.args[0])
+
     def test_v3_inline_python(self, exec_env_definition_file):
         """
         Test that inline values for dependencies.python work.

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -199,9 +199,8 @@ class TestUserDefinition:
         )
         monkeypatch.setattr(constants, 'REQUIRE_ANSIBLE_CORE_PIN', True)
         definition = UserDefinition(path)
-        definition.validate()
         with pytest.raises(DefinitionError) as error:
-            _ = definition.ansible_core_ref
+            definition.validate()
         assert "Value for 'ansible_core' must contain a version constraint" in str(error.value.args[0])
 
     def test_v3_inline_python(self, exec_env_definition_file):

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -203,6 +203,23 @@ class TestUserDefinition:
             definition.validate()
         assert "Value for 'ansible_core' must contain a version constraint" in str(error.value.args[0])
 
+    def test_v3_ansible_install_ref_bad_req(self, monkeypatch, exec_env_definition_file):
+        path = exec_env_definition_file(
+            """
+            {'version': 3,
+             'images': { 'base_image': {'name': 'base_image:latest'}},
+             'dependencies': {
+                'ansible_core': {'package_pip': 'ansible-core=2.6.0'},
+                'ansible_runner': { 'package_pip': 'ansible-runner==2.3.1'}
+             }
+            }
+            """
+        )
+        monkeypatch.setattr(constants, 'REQUIRE_ANSIBLE_CORE_PIN', True)
+        definition = UserDefinition(path)
+        with pytest.raises(DefinitionError) as error:
+            definition.validate()
+        assert "Invalid package requirement specified for 'ansible_core'" in str(error.value.args[0])
     def test_v3_inline_python(self, exec_env_definition_file):
         """
         Test that inline values for dependencies.python work.


### PR DESCRIPTION
This PR allows downstreams to patch `REQUIRE_ANSIBLE_CORE_PIN` in `constants.py` to a value of `True` to force EE definitions to contain a pin for the `ansible-core` specification.

This would help ensure that users building custom EEs would have to put thought into the version of ansible-core that they intend to be using, without unexpected upgrades in the building process pulling in a newer version they have not tested against.

No evaluation of the pin is done, this is a minor safety net.