### PR TITLE
Set file permissions on context files created from inline reqs

### DIFF
--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -13,6 +13,8 @@ import yaml
 from . import constants
 from .exceptions import DefinitionError
 from .ee_schema import validate_schema
+from .utils import set_read_permissions
+
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +209,7 @@ class UserDefinition:
             tf.flush()  # don't close, it'll clean up on GC
             _tempfiles.append(tf)
             req_file = tf.name
+            set_read_permissions(req_file)
         elif (is_list := isinstance(req_file, list)) or (isinstance(req_file, str) and '\n' in req_file):
             # pylint: disable=R1732
             tf = tempfile.NamedTemporaryFile('w')
@@ -217,6 +220,7 @@ class UserDefinition:
             _tempfiles.append(tf)
             tf.flush()  # don't close, it'll clean up on GC
             req_file = tf.name
+            set_read_permissions(req_file)
         if not isinstance(req_file, str):
             return None
 

--- a/src/ansible_builder/user_definition.py
+++ b/src/ansible_builder/user_definition.py
@@ -13,7 +13,7 @@ import yaml
 from . import constants
 from .exceptions import DefinitionError
 from .ee_schema import validate_schema
-from .utils import set_read_permissions
+from .utils import set_default_file_permissions
 
 
 logger = logging.getLogger(__name__)
@@ -209,7 +209,7 @@ class UserDefinition:
             tf.flush()  # don't close, it'll clean up on GC
             _tempfiles.append(tf)
             req_file = tf.name
-            set_read_permissions(req_file)
+            set_default_file_permissions(req_file)
         elif (is_list := isinstance(req_file, list)) or (isinstance(req_file, str) and '\n' in req_file):
             # pylint: disable=R1732
             tf = tempfile.NamedTemporaryFile('w')
@@ -220,7 +220,7 @@ class UserDefinition:
             _tempfiles.append(tf)
             tf.flush()  # don't close, it'll clean up on GC
             req_file = tf.name
-            set_read_permissions(req_file)
+            set_default_file_permissions(req_file)
         if not isinstance(req_file, str):
             return None
 

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 import os
 import shutil
+import stat
 import subprocess
 import sys
 
@@ -205,3 +206,13 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
         logger.debug("File %s is already up-to-date.", dest)
 
     return should_copy
+
+
+def set_read_permissions(filename: str) -> None:
+    """Set user/grp/other read permissions, respecting umask"""
+    umask = os.umask(0o777)
+    os.umask(umask)
+    os.chmod(
+        filename,
+        os.stat(filename).st_mode | ((stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH) & ~umask)
+    )

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -208,11 +208,11 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
     return should_copy
 
 
-def set_read_permissions(filename: str) -> None:
-    """Set user/grp/other read permissions, respecting umask"""
+def set_default_file_permissions(filename: str) -> None:
+    """Set user+rw/grp+r/other+r read permissions, respecting umask"""
     umask = os.umask(0o777)
     os.umask(umask)
     os.chmod(
         filename,
-        os.stat(filename).st_mode | ((stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH) & ~umask)
+        os.stat(filename).st_mode | ((stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH) & ~umask)
     )

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -1,4 +1,5 @@
 import os
+import stat
 
 import yaml
 
@@ -112,6 +113,40 @@ def test_inline_mapping_galaxy_requirements(cli, build_dir_and_ee_yml):
     req_out_content = req_out.read_text()
     expected_output = {'collections': [{'name': 'community.general'}], 'roles': [{'name': 'foo.bar'}]}
     assert yaml.safe_load(req_out_content) == expected_output
+
+
+def test_inline_requirements_file_perms(cli, build_dir_and_ee_yml):
+    """Validate that inline requirements are written to files with proper permissions"""
+    ee_str = """
+    version: 3
+    images:
+      base_image:
+        name: 'base_image:latest'
+    dependencies:
+      galaxy:
+        collections:
+        - name: community.general
+      python:
+        - six
+      system:
+        - gcc
+    """
+    umask = os.umask(0o777)
+    os.umask(umask)
+
+    tmpdir, eeyml = build_dir_and_ee_yml(ee_str)
+    cli(f'ansible-builder create -c {tmpdir} -f {eeyml} --output-filename Containerfile')
+
+    galaxy_req = tmpdir / f'_build/{constants.STD_GALAXY_FILENAME}'
+    python_req = tmpdir / f'_build/{constants.STD_PIP_FILENAME}'
+    system_req = tmpdir / f'_build/{constants.STD_BINDEP_FILENAME}'
+
+    for out_file in (galaxy_req, python_req, system_req):
+        assert out_file.exists()
+        for bit in (stat.S_IRUSR, stat.S_IRGRP, stat.S_IROTH):
+            # If umask doesn't specifically prevent us from setting it, check that we set it
+            if bit & ~umask:
+                assert out_file.stat().st_mode & bit
 
 
 def test_collection_verification_off(cli, build_dir_and_ee_yml):

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -143,7 +143,7 @@ def test_inline_requirements_file_perms(cli, build_dir_and_ee_yml):
 
     for out_file in (galaxy_req, python_req, system_req):
         assert out_file.exists()
-        for bit in (stat.S_IRUSR, stat.S_IRGRP, stat.S_IROTH):
+        for bit in (stat.S_IRUSR, stat.S_IWUSR, stat.S_IRGRP, stat.S_IROTH):
             # If umask doesn't specifically prevent us from setting it, check that we set it
             if bit & ~umask:
                 assert out_file.stat().st_mode & bit


### PR DESCRIPTION
When we create a requirements file within the context directory from an inline set of requirements, make sure we set full read permissions on it (as much as allowed by umask value).

Fixes #747 