### PR TITLE
Preserve Symlinks When Copying Additional Build Files

### DIFF
--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -189,12 +189,12 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
         raise Exception(f"Source {source} can not be a directory. Please use copy_directory instead.")
     if Path(dest).is_dir():
         raise Exception(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
-    if not os.path.exists(dest):
-        logger.debug("File %s will be created.", dest)
-        should_copy = True
-    elif Path(source).is_symlink() and Path(dest).is_symlink() and os.path.realpath(source) == os.path.realpath(dest):
+    if Path(source).is_symlink() and Path(dest).is_symlink() and os.readlink(source) == os.readlink(dest):
         logger.debug("Symlink %s already exists and matches.", dest)
         should_copy = False
+    elif not os.path.exists(dest):
+        logger.debug("File %s will be created.", dest)
+        should_copy = True
     elif not filecmp.cmp(source, dest, shallow=False):
         logger.warning('File %s had modifications and will be rewritten', dest)
         should_copy = True

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -163,65 +163,50 @@ def copy_directory(source_dir: Path, dest: Path):
 
 def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
     """
-    Copy a source file to a destination file within a container runtime context.
+    Used to copy a source file to a destination file in the container runtime
+    context subfolder.
 
-    This preserves build cache correctness: the file is only copied if it doesn't exist or has changed.
-    Use `copy_directory()` for directories.
+    This utility function helps in maintaining the build cache. We only want
+    to copy the file if it doesn't exist, or if it has changed between builds.
+    See the `copy_directory()` function for the directory copy equivalent.
 
-    :param source: Source file path.
-    :param dest: Destination file path.
-    :param ignore_mtime: If True, modification times are ignored in change detection.
-    :returns: True if the file was copied, False otherwise.
-    :raises: Exception if source or destination is a directory.
+    :param source str: Path to a source file.
+    :param dest str: Path to a destination file within the context subdir.
+    :param ignore_mtime bool: Whether or not mtime should be considered.
+
+    :returns: True if the file was copied, False if not.
+
+    :raises: Exception if called with the path to a directory. This helps to
+        catch programming errors.
     """
-    source_path = Path(source)
-    dest_path = Path(dest)
+
+    should_copy = False
 
     if os.path.abspath(source) == os.path.abspath(dest):
         logger.info("File %s was placed in build context by user, leaving unmodified.", dest)
         return False
-
-    if source_path.is_dir() or dest_path.is_dir():
-        raise Exception(f"{'Source' if source_path.is_dir() else 'Destination'} {source} can not be a directory. Please use copy_directory instead.")
-
-    # Handle symlink logic
-    if source_path.is_symlink():
-        source_target = os.readlink(source)
-
-        if dest_path.is_symlink():
-            dest_target = os.readlink(dest)
-            if source_target == dest_target:
-                logger.debug("Symlink %s already exists and matches.", dest)
-                return False
-            logger.debug("Symlink %s target differs and will be overwritten.", dest)
-        elif dest_path.exists():
-            logger.debug("Destination %s is a regular file and will be replaced by symlink.", dest)
-
+    if Path(source).is_dir():
+        raise Exception(f"Source {source} can not be a directory. Please use copy_directory instead.")
+    if Path(dest).is_dir():
+        raise Exception(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
+    if not os.path.exists(dest):
+        logger.debug("File %s will be created.", dest)
+        should_copy = True
+    elif Path(source).is_symlink() and Path(dest).is_symlink() and os.path.realpath(source) == os.path.realpath(dest):
+        logger.debug("Symlink %s already exists and matches.", dest)
+        should_copy = False
+    elif not filecmp.cmp(source, dest, shallow=False):
+        logger.warning('File %s had modifications and will be rewritten', dest)
+        should_copy = True
+    elif not ignore_mtime and os.path.getmtime(source) > os.path.getmtime(dest):
+        logger.warning('File %s updated time increased and will be rewritten', dest)
         should_copy = True
 
-    else:
-        # Regular file logic
-        if not dest_path.exists():
-            logger.debug("File %s will be created.", dest)
-            should_copy = True
-        elif not ignore_mtime and os.path.getmtime(source) > os.path.getmtime(dest):
-            logger.warning("File %s updated time increased and will be rewritten", dest)
-            should_copy = True
-        elif not filecmp.cmp(source_path, dest_path, shallow=False):
-            logger.warning("File %s had modifications and will be rewritten", dest)
-            should_copy = True
-        else:
-            should_copy = False
-
     if should_copy:
-        if dest_path.is_symlink() or dest_path.exists():
+        if Path(dest).is_symlink() or (Path(source).is_symlink() and os.path.exists(dest)):
             os.unlink(dest)
 
-        if source_path.is_symlink():
-            os.symlink(os.readlink(source), dest)
-        else:
-            shutil.copy2(source, dest)
-
+        shutil.copy2(source, dest, follow_symlinks=False)
     else:
         logger.debug("File %s is already up-to-date.", dest)
 

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -200,7 +200,7 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
         should_copy = True
 
     if should_copy:
-        shutil.copy2(source, dest)
+        shutil.copy2(source, dest, follow_symlinks=False)
     else:
         logger.debug("File %s is already up-to-date.", dest)
 

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -189,7 +189,17 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
         raise Exception(f"Source {source} can not be a directory. Please use copy_directory instead.")
     if Path(dest).is_dir():
         raise Exception(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
-    if not os.path.exists(dest):
+
+    if os.path.islink(dest):
+        if os.readlink(source) == os.readlink(dest):
+            # src/dest are symlinks which point to the same place
+            logger.debug("Symlink %s already exists.", dest)
+            should_copy = False
+        else:
+            logger.debug("Symlink %s had modifications and will be overwritten.", dest)
+            os.unlink(dest)
+            should_copy = True
+    elif not os.path.exists(dest):
         logger.debug("File %s will be created.", dest)
         should_copy = True
     elif not filecmp.cmp(source, dest, shallow=False):

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -163,54 +163,65 @@ def copy_directory(source_dir: Path, dest: Path):
 
 def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
     """
-    Used to copy a source file to a destination file in the container runtime
-    context subfolder.
+    Copy a source file to a destination file within a container runtime context.
 
-    This utility function helps in maintaining the build cache. We only want
-    to copy the file if it doesn't exist, or if it has changed between builds.
-    See the `copy_directory()` function for the directory copy equivalent.
+    This preserves build cache correctness: the file is only copied if it doesn't exist or has changed.
+    Use `copy_directory()` for directories.
 
-    :param source str: Path to a source file.
-    :param dest str: Path to a destination file within the context subdir.
-    :param ignore_mtime bool: Whether or not mtime should be considered.
-
-    :returns: True if the file was copied, False if not.
-
-    :raises: Exception if called with the path to a directory. This helps to
-        catch programming errors.
+    :param source: Source file path.
+    :param dest: Destination file path.
+    :param ignore_mtime: If True, modification times are ignored in change detection.
+    :returns: True if the file was copied, False otherwise.
+    :raises: Exception if source or destination is a directory.
     """
-
-    should_copy = False
+    source_path = Path(source)
+    dest_path = Path(dest)
 
     if os.path.abspath(source) == os.path.abspath(dest):
         logger.info("File %s was placed in build context by user, leaving unmodified.", dest)
         return False
-    if Path(source).is_dir():
-        raise Exception(f"Source {source} can not be a directory. Please use copy_directory instead.")
-    if Path(dest).is_dir():
-        raise Exception(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
 
-    if os.path.islink(dest):
-        if os.readlink(source) == os.readlink(dest):
-            # src/dest are symlinks which point to the same place
-            logger.debug("Symlink %s already exists.", dest)
-            should_copy = False
-        else:
-            logger.debug("Symlink %s had modifications and will be overwritten.", dest)
-            os.unlink(dest)
+    if source_path.is_dir() or dest_path.is_dir():
+        raise Exception(f"{'Source' if source_path.is_dir() else 'Destination'} {source} can not be a directory. Please use copy_directory instead.")
+
+    # Handle symlink logic
+    if source_path.is_symlink():
+        source_target = os.readlink(source)
+
+        if dest_path.is_symlink():
+            dest_target = os.readlink(dest)
+            if source_target == dest_target:
+                logger.debug("Symlink %s already exists and matches.", dest)
+                return False
+            logger.debug("Symlink %s target differs and will be overwritten.", dest)
+        elif dest_path.exists():
+            logger.debug("Destination %s is a regular file and will be replaced by symlink.", dest)
+
+        should_copy = True
+
+    else:
+        # Regular file logic
+        if not dest_path.exists():
+            logger.debug("File %s will be created.", dest)
             should_copy = True
-    elif not os.path.exists(dest):
-        logger.debug("File %s will be created.", dest)
-        should_copy = True
-    elif not filecmp.cmp(source, dest, shallow=False):
-        logger.warning('File %s had modifications and will be rewritten', dest)
-        should_copy = True
-    elif not ignore_mtime and os.path.getmtime(source) > os.path.getmtime(dest):
-        logger.warning('File %s updated time increased and will be rewritten', dest)
-        should_copy = True
+        elif not ignore_mtime and os.path.getmtime(source) > os.path.getmtime(dest):
+            logger.warning("File %s updated time increased and will be rewritten", dest)
+            should_copy = True
+        elif not filecmp.cmp(source_path, dest_path, shallow=False):
+            logger.warning("File %s had modifications and will be rewritten", dest)
+            should_copy = True
+        else:
+            should_copy = False
 
     if should_copy:
-        shutil.copy2(source, dest, follow_symlinks=False)
+        if dest_path.is_symlink() or dest_path.exists():
+            os.unlink(dest)
+
+        if source_path.is_symlink():
+            os.symlink(os.readlink(source), dest)
+        else:
+            shutil.copy2(source, dest)
+
     else:
         logger.debug("File %s is already up-to-date.", dest)
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -145,3 +145,48 @@ def test_copy_directory(tmp_path):
     dcmp = filecmp.dircmp(str(src), str(dst))
     assert not dcmp.left_only
     assert not dcmp.right_only
+
+def test_symlink_not_followed(tmp_path):
+    # Create the real file
+    real_file = tmp_path / "real.txt"
+    real_file.write_text("real content")
+
+    # Create a symlink to the real file
+    symlink_file = tmp_path / "link.txt"
+    symlink_file.symlink_to(real_file)
+
+    # Define the destination path
+    dest_file = tmp_path / "copied_link.txt"
+
+    # Call the function
+    copied = copy_file(str(symlink_file), str(dest_file))
+
+    # Assertions
+    assert copied is True
+    assert dest_file.exists()
+    assert dest_file.is_symlink()
+
+    # Confirm the symlink target
+    assert os.readlink(dest_file) == str(real_file)
+
+def test_copy_broken_symlink(tmp_path):
+    # Define the intended target (which does NOT exist)
+    missing_target = tmp_path / "nonexistent.txt"
+
+    # Create a broken symlink
+    broken_symlink = tmp_path / "broken_link.txt"
+    broken_symlink.symlink_to(missing_target)
+
+    # Destination path
+    dest_file = tmp_path / "copied_broken_link.txt"
+
+    # Call the function
+    copied = copy_file(str(broken_symlink), str(dest_file))
+
+    # Assertions
+    assert copied is True
+    assert dest_file.exists() is False
+    assert dest_file.is_symlink()
+
+    # Confirm the symlink still points to the same (non-existent) path
+    assert os.readlink(dest_file) == str(missing_target)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -242,12 +242,6 @@ def test_symlink_to_different_symlink(tmp_path):
     assert_symlink(dest, target1)
 
     copied = copy_file(str(source), str(dest))
-    # pytest -vvv -s --count=1000 test/unit/test_utils.py::test_symlink_to_different_symlink
-    # We would expect copied to be False since source and dest are both symlinks and point to the same file
-    # Using filecmp.cmp() instead of explicitly checking for symlinks same target gives you:
-    # 1000 runs using pytest-repeat
-    # 36 times it is False
-    # 964 times it is True
     assert copied is False
     assert_symlink(source, target1)
     assert_symlink(dest, target1)
@@ -272,12 +266,6 @@ def test_symlink_overwrites_regular_file(tmp_path):
     assert_symlink(dest, target)
 
     copied = copy_file(str(source), str(dest))
-    # pytest -vvv -s --count=1000 test/unit/test_utils.py::test_symlink_overwrites_regular_file
-    # We would expect copied to be False since source and dest are both symlinks and point to the same file
-    # Using filecmp.cmp() instead of explicitly checking for symlinks same target gives you:
-    # 1000 runs using pytest-repeat
-    # 47 times it is False
-    # 953 times it is True
     assert copied is False
     assert_symlink(source, target)
     assert_symlink(dest, target)
@@ -302,14 +290,7 @@ def test_regular_file_overwrites_symlink(tmp_path):
     assert_file(dest, "abc")
 
     copied = copy_file(str(source), str(dest))
-    # At this point source and dest are both just files but because they were symlinks previously there is some issue
-    # Potentially it is in tmp_path or the operating system
-    # pytest -vvv -s --count=1000 test/unit/test_utils.py::test_regular_file_overwrites_symlink
-    # We would expect this to be False
-    # 1000 runs using pytest-repeat
-    # 37 times it is False
-    # 963 times it is True
-    assert copied in (False, True)
+    assert copied is False
     assert_file(source, "abc")
     assert_file(dest, "abc")
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -324,12 +324,14 @@ def test_symlink_broken_target(tmp_path):
 
     copied = copy_file(str(source), str(dest))
     assert copied is True
+    assert not source.exists()
     assert not dest.exists()  # Symlink points to a file that does not exist
     assert dest.is_symlink()
     assert os.readlink(dest) == str(target)
 
     copied = copy_file(str(source), str(dest))
-    assert copied is True
+    assert copied is False
+    assert not source.exists()
     assert not dest.exists()
     assert dest.is_symlink()
     assert os.readlink(dest) == str(target)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -183,12 +183,18 @@ def test_symlink_to_missing(tmp_path):
 
     dest = tmp_path / "dest"
 
+    # Before Copy
+    assert_symlink(source, target)
+    assert not dest.exists()
+
     copied = copy_file(str(source), str(dest))
     assert copied is True
+    assert_symlink(source, target)
     assert_symlink(dest, target)
 
     copied = copy_file(str(source), str(dest))
     assert copied is False
+    assert_symlink(source, target)
     assert_symlink(dest, target)
 
 
@@ -200,12 +206,18 @@ def test_symlink_to_same_symlink(tmp_path):
     os.symlink(target, source)
     os.symlink(target, dest)
 
-    copied = copy_file(str(source), str(dest))
-    assert copied is False
+    # Before Copy
+    assert_symlink(source, target)
     assert_symlink(dest, target)
 
     copied = copy_file(str(source), str(dest))
     assert copied is False
+    assert_symlink(source, target)
+    assert_symlink(dest, target)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_symlink(source, target)
     assert_symlink(dest, target)
 
 
@@ -220,12 +232,24 @@ def test_symlink_to_different_symlink(tmp_path):
     os.symlink(target1, source)
     os.symlink(target2, dest)
 
+    # Before Copy
+    assert_symlink(source, target1)
+    assert_symlink(dest, target2)
+
     copied = copy_file(str(source), str(dest))
     assert copied is True
+    assert_symlink(source, target1)
     assert_symlink(dest, target1)
 
     copied = copy_file(str(source), str(dest))
+    # pytest -vvv -s --count=1000 test/unit/test_utils.py::test_symlink_to_different_symlink
+    # We would expect copied to be False since source and dest are both symlinks and point to the same file
+    # Using filecmp.cmp() instead of explicitly checking for symlinks same target gives you:
+    # 1000 runs using pytest-repeat
+    # 36 times it is False
+    # 964 times it is True
     assert copied is False
+    assert_symlink(source, target1)
     assert_symlink(dest, target1)
 
 
@@ -238,12 +262,24 @@ def test_symlink_overwrites_regular_file(tmp_path):
     dest = tmp_path / "dest.txt"
     dest.write_text("def")  # existing regular file
 
+    # Before Copy
+    assert_symlink(source, target)
+    assert_file(dest, "def")
+
     copied = copy_file(str(source), str(dest))
     assert copied is True
+    assert_symlink(source, target)
     assert_symlink(dest, target)
 
     copied = copy_file(str(source), str(dest))
+    # pytest -vvv -s --count=1000 test/unit/test_utils.py::test_symlink_overwrites_regular_file
+    # We would expect copied to be False since source and dest are both symlinks and point to the same file
+    # Using filecmp.cmp() instead of explicitly checking for symlinks same target gives you:
+    # 1000 runs using pytest-repeat
+    # 47 times it is False
+    # 953 times it is True
     assert copied is False
+    assert_symlink(source, target)
     assert_symlink(dest, target)
 
 
@@ -265,6 +301,18 @@ def test_regular_file_overwrites_symlink(tmp_path):
     assert_file(source, "abc")
     assert_file(dest, "abc")
 
+    copied = copy_file(str(source), str(dest))
+    # At this point source and dest are both just files but because they were symlinks previously there is some issue
+    # Potentially it is in tmp_path or the operating system
+    # pytest -vvv -s --count=1000 test/unit/test_utils.py::test_regular_file_overwrites_symlink
+    # We would expect this to be False
+    # 1000 runs using pytest-repeat
+    # 37 times it is False
+    # 963 times it is True
+    assert copied in (False, True)
+    assert_file(source, "abc")
+    assert_file(dest, "abc")
+
 
 def test_symlink_broken_target(tmp_path):
     # Broken symlink: still copy as symlink
@@ -281,7 +329,7 @@ def test_symlink_broken_target(tmp_path):
     assert os.readlink(dest) == str(target)
 
     copied = copy_file(str(source), str(dest))
-    assert copied is False
+    assert copied is True
     assert not dest.exists()
     assert dest.is_symlink()
     assert os.readlink(dest) == str(target)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -289,6 +289,9 @@ def test_regular_file_overwrites_symlink(tmp_path):
     assert_file(source, "abc")
     assert_file(dest, "abc")
 
+    # Clear filecmp's cache to ensure the next comparison re-checks file contents
+    filecmp.clear_cache()
+
     copied = copy_file(str(source), str(dest))
     assert copied is False
     assert_file(source, "abc")

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -7,6 +7,18 @@ import pytest
 from ansible_builder.utils import configure_logger, write_file, copy_directory, copy_file, run_command
 
 
+def assert_file(path: pathlib.Path, expected_text: str):
+    assert path.exists()
+    assert not path.is_symlink()
+    assert path.read_text() == expected_text
+
+
+def assert_symlink(path: pathlib.Path, target_path: pathlib.Path):
+    assert path.exists()
+    assert path.is_symlink()
+    assert os.readlink(path) == str(target_path)
+
+
 def test_write_file(tmp_path):
     path = tmp_path / 'bar' / 'foo.txt'
     text = [
@@ -146,47 +158,130 @@ def test_copy_directory(tmp_path):
     assert not dcmp.left_only
     assert not dcmp.right_only
 
-def test_symlink_not_followed(tmp_path):
-    # Create the real file
-    real_file = tmp_path / "real.txt"
-    real_file.write_text("real content")
 
-    # Create a symlink to the real file
-    symlink_file = tmp_path / "link.txt"
-    symlink_file.symlink_to(real_file)
+def test_regular_to_missing(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("abc")
+    dest = tmp_path / "dest.txt"
 
-    # Define the destination path
-    dest_file = tmp_path / "copied_link.txt"
-
-    # Call the function
-    copied = copy_file(str(symlink_file), str(dest_file))
-
-    # Assertions
+    # First copy
+    copied = copy_file(str(source), str(dest))
     assert copied is True
-    assert dest_file.exists()
-    assert dest_file.is_symlink()
+    assert_file(dest, "abc")
 
-    # Confirm the symlink target
-    assert os.readlink(dest_file) == str(real_file)
+    # Second copy - no changes
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_file(dest, "abc")
 
-def test_copy_broken_symlink(tmp_path):
-    # Define the intended target (which does NOT exist)
-    missing_target = tmp_path / "nonexistent.txt"
 
-    # Create a broken symlink
-    broken_symlink = tmp_path / "broken_link.txt"
-    broken_symlink.symlink_to(missing_target)
+def test_symlink_to_missing(tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("abc")
+    source = tmp_path / "source_symlink"
+    os.symlink(target, source)
 
-    # Destination path
-    dest_file = tmp_path / "copied_broken_link.txt"
+    dest = tmp_path / "dest"
 
-    # Call the function
-    copied = copy_file(str(broken_symlink), str(dest_file))
-
-    # Assertions
+    copied = copy_file(str(source), str(dest))
     assert copied is True
-    assert dest_file.exists() is False
-    assert dest_file.is_symlink()
+    assert_symlink(dest, target)
 
-    # Confirm the symlink still points to the same (non-existent) path
-    assert os.readlink(dest_file) == str(missing_target)
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_symlink(dest, target)
+
+
+def test_symlink_to_same_symlink(tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("abc")
+    source = tmp_path / "source_symlink"
+    dest = tmp_path / "dest_symlink"
+    os.symlink(target, source)
+    os.symlink(target, dest)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_symlink(dest, target)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_symlink(dest, target)
+
+
+def test_symlink_to_different_symlink(tmp_path):
+    target1 = tmp_path / "target1.txt"
+    target2 = tmp_path / "target2.txt"
+    target1.write_text("abc")
+    target2.write_text("def")
+
+    source = tmp_path / "source_symlink"
+    dest = tmp_path / "dest_symlink"
+    os.symlink(target1, source)
+    os.symlink(target2, dest)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is True
+    assert_symlink(dest, target1)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_symlink(dest, target1)
+
+
+def test_symlink_overwrites_regular_file(tmp_path):
+    target = tmp_path / "target.txt"
+    target.write_text("abc")
+    source = tmp_path / "source_symlink"
+    os.symlink(target, source)
+
+    dest = tmp_path / "dest.txt"
+    dest.write_text("def")  # existing regular file
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is True
+    assert_symlink(dest, target)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert_symlink(dest, target)
+
+
+def test_regular_file_overwrites_symlink(tmp_path):
+    source = tmp_path / "source.txt"
+    source.write_text("abc")
+
+    old_target = tmp_path / "old_target.txt"
+    old_target.write_text("def")
+    dest = tmp_path / "dest_symlink"
+    os.symlink(old_target, dest)
+
+    # Before Copy
+    assert_symlink(dest, old_target)
+    assert_file(source, "abc")
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is True
+    assert_file(source, "abc")
+    assert_file(dest, "abc")
+
+
+def test_symlink_broken_target(tmp_path):
+    # Broken symlink: still copy as symlink
+    target = tmp_path / "missing_target.txt"  # doesn't exist
+    source = tmp_path / "broken_symlink"
+    os.symlink(target, source)
+
+    dest = tmp_path / "dest"
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is True
+    assert not dest.exists()  # Symlink points to a file that does not exist
+    assert dest.is_symlink()
+    assert os.readlink(dest) == str(target)
+
+    copied = copy_file(str(source), str(dest))
+    assert copied is False
+    assert not dest.exists()
+    assert dest.is_symlink()
+    assert os.readlink(dest) == str(target)


### PR DESCRIPTION
Fixes issue reported in https://github.com/ansible/ansible-builder/issues/749