### PR TITLE
Add pip check feature

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -457,6 +457,12 @@ builder runtime functionality. Valid keys for this section are:
       pip manually if the current method of pip installation does not work for you.
       The default is ``False``.
 
+    ``skip_pip_check``
+      This boolean value controls whether or not a call to ``pip check`` is performed in the final
+      build stage of the build process. If this call errors because it finds incompatible dependencies
+      of installed Python packages, the build will fail. To disable this validation, set the value to ``True``.
+      The default is ``False``.
+
     ``relax_passwd_permissions``
       This boolean value controls whether the ``root`` group (GID 0) is explicitly granted
       write permission to ``/etc/passwd`` in the final container image. The default entrypoint

--- a/docs/porting_guides/porting_guide.rst
+++ b/docs/porting_guides/porting_guide.rst
@@ -9,5 +9,6 @@ versions of ``ansible-builder``.
 .. toctree::
    :maxdepth: 1
 
+   porting_guide_v3.2
    porting_guide_v3.1
    porting_guide_v3.0

--- a/docs/porting_guides/porting_guide_v3.2.rst
+++ b/docs/porting_guides/porting_guide_v3.2.rst
@@ -1,0 +1,23 @@
+*********************************
+Ansible Builder 3.2 Porting Guide
+*********************************
+
+This section discusses the behavioral changes between ``ansible-builder`` version 3.1 and version 3.2.
+
+.. contents:: Topics
+
+New Dependency Check of Installed Python Packages
+=================================================
+
+During the final build stage, immediately after all Python packages have been installed, a call
+has been added to ``pip check`` to perform validation of installed package dependencies in the image.
+If any dependency errors are identified, the build will now fail.
+
+By default, this check is enabled. If you wish to disable this check, a new ``skip_pip_check`` option
+has been added to the :ref:`options` section of the execution environment schema. Set this value to ``true``
+to skip the new validation, as shown in the example below.
+
+.. code-block:: yaml
+
+   options:
+     skip_pip_check: true

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -500,6 +500,9 @@ class Containerfile:
             "RUN /output/scripts/install-from-bindep && rm -rf /output/wheels",
         ])
 
+        if self.definition.version >= 3 and not self.definition.options['skip_pip_check']:
+            self.steps.append("RUN $PYCMD -m pip check")
+
     def _prepare_galaxy_copy_steps(self) -> None:
         if self.definition.get_dep_abs_path('galaxy'):
             dir_name = os.path.dirname(constants.base_collections_path.rstrip('/'))  # /usr/share/ansible

--- a/src/ansible_builder/ee_schema.py
+++ b/src/ansible_builder/ee_schema.py
@@ -372,6 +372,10 @@ schema_v3 = {
                     "description": "Disables the installation of pip in the base image",
                     "type": "boolean",
                 },
+                "skip_pip_check": {
+                    "description": "Disables verifying installed Python packages have compatible dependencies",
+                    "type": "boolean",
+                },
                 "workdir": {
                     "description": "Default working directory, also often the homedir for ephemeral UIDs",
                     "type": ["string", "null"],
@@ -476,6 +480,7 @@ def _handle_options_defaults(ee_def: dict):
 
     options.setdefault('skip_ansible_check', False)
     options.setdefault('skip_pip_install', False)
+    options.setdefault('skip_pip_check', False)
     options.setdefault('relax_passwd_permissions', True)
     options.setdefault('workdir', '/runner')
     options.setdefault('package_manager_path', '/usr/bin/dnf')

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -377,3 +377,37 @@ def test_prepare_introspect_assemble_steps(build_dir_and_ee_yml):
                                   f" --exclude-collection-reqs={constants.EXCL_COLLECTIONS_FILENAME}" \
                                   " --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt"
     assert expected_introspect_command in c.steps
+
+
+def test_pip_check_v3(build_dir_and_ee_yml):
+    """Make sure we pip check in v3 unless disabled"""
+    ee_data = """
+    version: 3
+    images:
+      base_image:
+        name: quay.io/user/mycustombaseimage:latest
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "RUN $PYCMD -m pip check" in c.steps
+
+    ee_data += """
+    options:
+      skip_pip_check: true
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "RUN $PYCMD -m pip check" not in c.steps
+
+
+def test_pip_check_v1(build_dir_and_ee_yml):
+    """Make sure we do not pip check versions older than v3"""
+    ee_data = """
+    version: 1
+    """
+    tmpdir, ee_path = build_dir_and_ee_yml(ee_data)
+    c = make_containerfile(tmpdir, ee_path, run_validate=True)
+    c.prepare()
+    assert "RUN $PYCMD -m pip check" not in c.steps


### PR DESCRIPTION
New Feature: Validate installed Python dependencies in final build stage

- Calls `pip check` immediately after Python dependencies are installed in final build stage.
- Adds `skip_pip_check` option to the EE schema to control the new behavior (enabled by default).

Fixes #416