### PR TITLE
Increase integration test timeout to 9m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       runner-vm-os: >-
         ${{ matrix.runner-vm-os }}
       timeout-minutes: >-
-        ${{ matrix.toxenv == 'unit' && 2 || 7 }}
+        ${{ matrix.toxenv == 'unit' && 2 || 9 }}
       toxenv: >-
         ${{ matrix.toxenv }}
       tox-run-posargs: >-


### PR DESCRIPTION
Some integration tests are taking a bit longer than 7 minutes to complete. Increase our timeout from 7m to 9m.