### PR TITLE
Feature: New 'template' sub-command to generate sample EE file

### DIFF
--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -10,6 +10,7 @@ from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from .policies import PolicyChoices
 from ._target_scripts.introspect import create_introspect_parser, run_introspect
+from .template import run_template
 from .utils import configure_logger
 
 
@@ -97,6 +98,10 @@ def run():
 
     elif args.action == 'introspect':
         run_introspect(args, logger)
+
+    elif args.action == 'template':
+        run_template(args)
+        sys.exit(0)
 
     logger.error("An error has occurred.")
     sys.exit(1)
@@ -238,6 +243,52 @@ def add_container_options(parser):
                             'Default is %(default)s.')
 
 
+def add_template_options(parser):
+    """
+    Add template sub-command and options.
+    """
+    template_command_parser = parser.add_parser(
+        'template',
+        help='Generate a sample execution environment YAML file from schema.',
+        description=(
+            'Generate a sample execution environment YAML file based on one of the '
+            'supported schema versions. This creates a template with example values '
+            'that can be used as a starting point for building execution environments.'
+        )
+    )
+
+    template_command_parser.add_argument(
+        '--schema-version',
+        type=int,
+        choices=[1, 2, 3],
+        default=3,
+        help='Schema version to generate template for (default: %(default)s)'
+    )
+
+    template_command_parser.add_argument(
+        '--output',
+        help='Output file path (default: write to stdout)'
+    )
+
+    template_command_parser.add_argument(
+        '--minimal',
+        action='store_true',
+        help='Generate minimal template with only required fields'
+    )
+
+    template_command_parser.add_argument(
+        '-v', '--verbosity',
+        dest='verbosity',
+        action=CustomVerbosityAction,
+        nargs='?',
+        default=constants.default_verbosity,
+        help='Set the verbosity output level. '
+             'Adding multiple -v will increase the verbosity to a max of 3 (-vvv). '
+             'Integer values are also accepted (for example, "-v3" or "--verbosity 3"). '
+             'Default is %(default)s.'
+    )
+
+
 def parse_args(args=None):
 
     parser = argparse.ArgumentParser(
@@ -259,6 +310,7 @@ def parse_args(args=None):
     )
 
     add_container_options(subparsers)
+    add_template_options(subparsers)
 
     return parser.parse_args(args)
 

--- a/src/ansible_builder/template.py
+++ b/src/ansible_builder/template.py
@@ -1,0 +1,282 @@
+import sys
+from typing import Dict, Any, Optional, TextIO
+
+import yaml
+
+from . import ee_schema
+
+
+def generate_template_from_schema(schema_dict: Dict[str, Any], version: int, minimal: bool = False) -> Dict[str, Any]:
+    """
+    Generate a sample YAML structure from a JSON schema.
+
+    Args:
+        schema_dict: The JSON schema dictionary
+        version: Schema version number to use for the version field
+        minimal: If True, only include required fields
+
+    Returns:
+        Dictionary representing the sample YAML structure
+    """
+    template: Dict[str, Any] = {}
+
+    if 'properties' not in schema_dict:
+        return template
+
+    properties = schema_dict['properties']
+    required_fields = schema_dict.get('required', [])
+
+    for field_name, field_schema in properties.items():
+        if minimal and field_name not in required_fields:
+            continue
+
+        template[field_name] = _generate_value_from_schema(field_name, field_schema, version, minimal)
+
+    return template
+
+
+def _generate_value_from_schema(field_name: str, field_schema: Dict[str, Any], version: int,
+                                minimal: bool = False) -> Any:
+    """Generate a sample value based on the field schema."""
+
+    # Handle anyOf (like TYPE_StringOrListOfStrings)
+    if 'anyOf' in field_schema:
+        # Choose the first option that's a string type for simplicity
+        for option in field_schema['anyOf']:
+            if option.get('type') == 'string':
+                return _generate_string_value(field_name)
+        # Fallback to first option
+        return _generate_value_from_schema(field_name, field_schema['anyOf'][0], version, minimal)
+
+    field_type = field_schema.get('type')
+
+    if field_type == 'string':
+        return _generate_string_value(field_name)
+    if field_type == 'number':
+        return _generate_number_value(field_name, version)
+    if field_type == 'boolean':
+        return _generate_boolean_value(field_name)
+    if field_type == 'array':
+        items_schema = field_schema.get('items', {})
+        if items_schema.get('type') == 'string':
+            return _generate_string_array_value(field_name)
+        if items_schema.get('type') == 'object':
+            sample_item = _generate_value_from_schema(field_name, items_schema, version, minimal)
+            return [sample_item]
+        return []
+    if field_type == 'object':
+        return generate_template_from_schema(field_schema, version, minimal)
+    if isinstance(field_type, list):
+        # Handle type arrays like ["string", "null"]
+        for t in field_type:
+            if t != "null":
+                return _generate_value_from_schema(field_name, {"type": t}, version, minimal)
+
+    return None
+
+
+def _generate_string_value(field_name: str) -> str:
+    """Generate appropriate string values based on field name."""
+
+    string_samples = {
+        'ansible_config': 'ansible.cfg',
+        'python': 'requirements.txt',
+        'galaxy': 'requirements.yml',
+        'system': 'bindep.txt',
+        'package_system': 'python39',
+        'python_path': '/usr/bin/python3.9',
+        'package_pip': 'ansible-core>=2.12',
+        'package_manager_path': '/usr/bin/dnf',
+        'workdir': '/runner',
+        'user': '1000',
+        'entrypoint': '["entrypoint", "dumb-init"]',
+        'cmd': '["bash"]',
+        'src': 'files/config.cfg',
+        'dest': 'configs',
+        'ANSIBLE_GALAXY_CLI_COLLECTION_OPTS': '--pre',
+        'ANSIBLE_GALAXY_CLI_ROLE_OPTS': '--ignore-errors',
+        'PKGMGR_PRESERVE_CACHE': 'always'
+    }
+
+    # Special handling for image names
+    if field_name == 'name':
+        return 'quay.io/ansible/ee-minimal:latest'
+    if field_name == 'signature_original_name':
+        return 'registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest'
+
+    # Check for exact matches first
+    if field_name in string_samples:
+        return string_samples[field_name]
+
+    # Check for partial matches
+    if 'image' in field_name.lower():
+        return 'quay.io/ansible/ee-minimal:latest'
+    if 'path' in field_name.lower():
+        return '/usr/bin/example'
+    if 'package' in field_name.lower():
+        return 'example-package>=1.0'
+    if 'user' in field_name.lower():
+        return '1000'
+
+    return f'example-{field_name.lower()}'
+
+
+def _generate_number_value(field_name: str, version: int) -> int:
+    """Generate appropriate number values based on field name."""
+    if field_name == 'version':
+        return version
+    return 1
+
+
+def _generate_boolean_value(field_name: str) -> bool:
+    """Generate appropriate boolean values based on field name."""
+    # Most boolean options default to False for safety
+    boolean_defaults = {
+        'relax_passwd_permissions': True,
+        'skip_ansible_check': False,
+        'skip_pip_install': False
+    }
+    return boolean_defaults.get(field_name, False)
+
+
+def _generate_string_array_value(field_name: str) -> list:
+    """Generate appropriate string array values based on field name."""
+
+    array_samples = {
+        'python': ['requests>=2.25.0', 'pyyaml>=5.4.0'],
+        'system': ['git', 'rsync'],
+        'collections': ['community.general', 'ansible.posix'],
+        'roles': ['example.role1', 'example.role2'],
+        'tags': ['my-ee:latest', 'my-ee:v1.0']
+    }
+
+    if field_name in array_samples:
+        return array_samples[field_name]
+
+    # Check for partial matches
+    if 'python' in field_name.lower():
+        return ['requests>=2.25.0']
+    if 'system' in field_name.lower():
+        return ['git']
+    if 'collection' in field_name.lower():
+        return ['community.general']
+    if 'role' in field_name.lower():
+        return ['example.role']
+    if 'tag' in field_name.lower():
+        return ['my-ee:latest']
+
+    return [f'example-{field_name.lower()}']
+
+
+def generate_execution_environment_template(version: int = 3, minimal: bool = False) -> Dict[str, Any]:
+    """
+    Generate a complete execution environment template for the specified schema version.
+
+    Args:
+        version: Schema version (1, 2, or 3)
+        minimal: If True, only include required fields
+
+    Returns:
+        Dictionary representing the complete template
+    """
+    if version == 1:
+        schema = ee_schema.schema_v1
+    elif version == 2:
+        schema = ee_schema.schema_v2
+    elif version == 3:
+        schema = ee_schema.schema_v3
+    else:
+        raise ValueError(f"Unsupported schema version: {version}. Supported versions: 1, 2, 3")
+
+    template = generate_template_from_schema(schema, version, minimal)
+
+    # Ensure version is always set correctly
+    template['version'] = version
+
+    # Add some customization for better examples
+    if not minimal:
+        template = _enhance_template_examples(template, version)
+
+    return template
+
+
+def _enhance_template_examples(template: Dict[str, Any], version: int) -> Dict[str, Any]:
+    """Enhance the template with better examples and structure."""
+
+    # For version 3, provide more comprehensive examples
+    if version == 3:
+        if 'dependencies' in template and isinstance(template['dependencies'], dict):
+            deps = template['dependencies']
+
+            # Enhance galaxy section to show both collections and roles
+            if 'galaxy' in deps:
+                deps['galaxy'] = {
+                    'collections': ['community.general', 'ansible.posix'],
+                    'roles': ['example.role1', 'example.role2']
+                }
+
+            # Enhance exclude section with better examples
+            if 'exclude' in deps and isinstance(deps['exclude'], dict):
+                deps['exclude'] = {
+                    'python': ['outdated-package'],
+                    'system': ['unnecessary-package'],
+                    'all_from_collections': ['collection.with.conflicts']
+                }
+
+        # Enhance additional_build_files with better examples
+        if 'additional_build_files' in template:
+            template['additional_build_files'] = [
+                {'src': 'files/ansible.cfg', 'dest': 'configs'},
+                {'src': 'files/custom-scripts/', 'dest': 'scripts'}
+            ]
+
+    return template
+
+
+def write_template_to_file(template: Dict[str, Any], output_file: Optional[TextIO] = None) -> None:
+    """
+    Write the template to a file or stdout as YAML.
+
+    Args:
+        template: The template dictionary to write
+        output_file: File handle to write to, defaults to stdout
+    """
+    if output_file is None:
+        output_file = sys.stdout
+
+    # Use safe_dump for clean YAML output
+    yaml.safe_dump(
+        template,
+        output_file,
+        default_flow_style=False,
+        sort_keys=False,
+        indent=2,
+        allow_unicode=True
+    )
+
+
+def run_template(args) -> None:
+    """
+    Main function to handle the template command.
+
+    Args:
+        args: Parsed command line arguments
+    """
+    try:
+        template = generate_execution_environment_template(
+            version=args.schema_version,
+            minimal=args.minimal
+        )
+
+        if args.output:
+            with open(args.output, 'w') as f:
+                write_template_to_file(template, f)
+        else:
+            write_template_to_file(template)
+
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/test/integration/test_help.py
+++ b/test/integration/test_help.py
@@ -4,13 +4,13 @@ import re
 def test_help(cli):
     result = cli('ansible-builder --help', check=False)
     help_text = result.stdout
-    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect} ...' in help_text
+    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect,template} ...' in help_text
 
 
 def test_no_args(cli):
     result = cli('ansible-builder', check=False)
     stderr = result.stderr
-    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect} ...' in stderr
+    assert 'usage: ansible-builder [-h] [--version] {create,build,introspect,template} ...' in stderr
     assert 'ansible-builder: error: the following arguments are required: action' in stderr
 
 
@@ -40,3 +40,10 @@ def test_introspect_help(cli):
     help_text = result.stdout
     assert 'usage: ansible-builder introspect [-h]' in help_text
     assert re.search(r'Loops over collections in folder', help_text)
+
+
+def test_template_help(cli):
+    result = cli('ansible-builder template --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder template [-h]' in help_text
+    assert re.search(r'Generate a sample execution environment', help_text)

--- a/test/integration/test_template_cli.py
+++ b/test/integration/test_template_cli.py
@@ -1,0 +1,196 @@
+import os
+import tempfile
+import yaml
+
+
+def test_template_help(cli):
+    """Test template command help output."""
+    result = cli('ansible-builder template --help', check=False)
+    help_text = result.stdout
+    assert 'usage: ansible-builder template [-h]' in help_text
+    assert 'Generate a sample execution environment YAML file' in help_text
+    assert '--schema-version' in help_text
+    assert '--output' in help_text
+    assert '--minimal' in help_text
+
+
+def test_template_default_version(cli):
+    """Test template command with default settings (version 3)."""
+    result = cli('ansible-builder template', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    assert template_data['version'] == 3
+    assert 'dependencies' in template_data
+    assert 'options' in template_data
+    assert 'images' in template_data
+
+
+def test_template_version_1(cli):
+    """Test template command with schema version 1."""
+    result = cli('ansible-builder template --schema-version 1', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    assert template_data['version'] == 1
+    assert 'build_arg_defaults' in template_data
+    assert 'EE_BASE_IMAGE' in template_data['build_arg_defaults']
+    assert 'EE_BUILDER_IMAGE' in template_data['build_arg_defaults']
+    # v1 should not have images section
+    assert 'images' not in template_data
+
+
+def test_template_version_2(cli):
+    """Test template command with schema version 2."""
+    result = cli('ansible-builder template --schema-version 2', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    assert template_data['version'] == 2
+    assert 'images' in template_data
+    assert 'base_image' in template_data['images']
+    assert 'builder_image' in template_data['images']
+    # v2 should not have EE_BASE_IMAGE in build args
+    if 'build_arg_defaults' in template_data:
+        assert 'EE_BASE_IMAGE' not in template_data['build_arg_defaults']
+
+
+def test_template_version_3(cli):
+    """Test template command with schema version 3."""
+    result = cli('ansible-builder template --schema-version 3', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    assert template_data['version'] == 3
+    assert 'dependencies' in template_data
+    assert 'options' in template_data
+    # v3 should have enhanced features
+    if 'dependencies' in template_data and 'galaxy' in template_data['dependencies']:
+        galaxy = template_data['dependencies']['galaxy']
+        if isinstance(galaxy, dict):
+            assert 'collections' in galaxy or 'roles' in galaxy
+
+
+def test_template_minimal_mode(cli):
+    """Test template command with minimal flag."""
+    result = cli('ansible-builder template --minimal', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    # Minimal should only have required fields (version is always added)
+    assert template_data['version'] == 3
+    # The schema doesn't actually require any fields, so minimal should be just version
+    assert len(template_data) >= 1
+
+
+def test_template_output_to_file(cli):
+    """Test template command with file output."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as tmp_file:
+        tmp_path = tmp_file.name
+
+    try:
+        result = cli(f'ansible-builder template --output {tmp_path}', check=False)
+
+        # Command should run without output to stdout
+        assert result.stdout.strip() == ''
+
+        # File should contain the template
+        assert os.path.exists(tmp_path)
+        with open(tmp_path, 'r') as f:
+            content = f.read()
+            template_data = yaml.safe_load(content)
+
+        assert template_data['version'] == 3
+        assert 'dependencies' in template_data
+
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def test_template_invalid_schema_version(cli):
+    """Test template command with invalid schema version."""
+    result = cli('ansible-builder template --schema-version 99', check=False)
+
+    # Should exit with error
+    assert result.returncode != 0
+    assert "invalid choice:" in result.stderr
+
+
+def test_template_all_versions_valid_yaml(cli):
+    """Test that all supported schema versions produce valid YAML."""
+    for version in [1, 2, 3]:
+        result = cli(f'ansible-builder template --schema-version {version}', check=False)
+
+        # Should be able to parse as YAML
+        template_data = yaml.safe_load(result.stdout)
+        assert isinstance(template_data, dict)
+        assert template_data['version'] == version
+
+
+def test_template_schema_version_and_minimal(cli):
+    """Test template command with both schema version and minimal flags."""
+    result = cli('ansible-builder template --schema-version 2 --minimal', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    assert template_data['version'] == 2
+    # Should be minimal output for version 2
+
+
+def test_template_realistic_examples(cli):
+    """Test that generated templates contain realistic examples."""
+    result = cli('ansible-builder template --schema-version 3', check=False)
+    output = result.stdout
+
+    # Parse YAML output
+    template_data = yaml.safe_load(output)
+
+    # Check for realistic values
+    if 'images' in template_data and 'base_image' in template_data['images']:
+        base_image = template_data['images']['base_image']['name']
+        assert 'quay.io' in base_image or 'registry' in base_image
+
+    if 'dependencies' in template_data:
+        deps = template_data['dependencies']
+        if 'python' in deps and isinstance(deps['python'], list):
+            # Should contain realistic Python package names
+            python_deps = deps['python']
+            assert any('requests' in str(dep) or 'pyyaml' in str(dep) for dep in python_deps)
+
+
+def test_template_verbosity_option(cli):
+    """Test template command with verbosity option."""
+    # Test that verbosity option is accepted (though template doesn't use it much)
+    result = cli('ansible-builder template -v', check=False)
+
+    # Should still produce valid output
+    template_data = yaml.safe_load(result.stdout)
+    assert template_data['version'] == 3
+
+
+def test_template_exit_code_success(cli):
+    """Test that template command exits with code 0 on success."""
+    result = cli('ansible-builder template', check=False)
+    assert result.returncode == 0
+
+
+def test_template_file_permissions_error(cli):
+    """Test template command with invalid output path."""
+    # Try to write to a directory that doesn't exist
+    result = cli('ansible-builder template --output /nonexistent/path/template.yml', check=False)
+
+    # Should exit with error code
+    assert result.returncode != 0

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -445,3 +445,46 @@ def test__should_disable_colors_tty_detection(isatty_result, expected, monkeypat
     # Mock sys.stdout.isatty to control TTY detection
     mocker.patch('sys.stdout.isatty', return_value=isatty_result)
     assert _should_disable_colors() == expected
+
+
+class TestTemplateArgParsing:
+    """Test template command argument parsing."""
+
+    def test_template_parse_args_default(self):
+        """Test template command with default arguments."""
+        args = parse_args(['template'])
+        assert args.action == 'template'
+        assert args.schema_version == 3
+        assert args.output is None
+        assert args.minimal is False
+
+    def test_template_parse_args_schema_version(self):
+        """Test template command with schema version."""
+        for version in [1, 2, 3]:
+            args = parse_args(['template', '--schema-version', str(version)])
+            assert args.schema_version == version
+
+    def test_template_parse_args_output(self):
+        """Test template command with output file."""
+        args = parse_args(['template', '--output', '/tmp/test.yml'])
+        assert args.output == '/tmp/test.yml'
+
+    def test_template_parse_args_minimal(self):
+        """Test template command with minimal flag."""
+        args = parse_args(['template', '--minimal'])
+        assert args.minimal is True
+
+    def test_template_parse_args_all_options(self):
+        """Test template command with all options."""
+        args = parse_args([
+            'template',
+            '--schema-version', '2',
+            '--output', '/tmp/test.yml',
+            '--minimal',
+            '-v'
+        ])
+        assert args.action == 'template'
+        assert args.schema_version == 2
+        assert args.output == '/tmp/test.yml'
+        assert args.minimal is True
+        assert args.verbosity == 1

--- a/test/unit/test_template.py
+++ b/test/unit/test_template.py
@@ -1,0 +1,322 @@
+from io import StringIO
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from ansible_builder import template
+
+
+class TestGenerateTemplateFromSchema:
+    """Test the generate_template_from_schema function."""
+
+    def test_empty_schema(self):
+        """Test with empty schema."""
+        result = template.generate_template_from_schema({}, 3)
+        assert not result
+
+    def test_schema_without_properties(self):
+        """Test with schema that has no properties."""
+        schema = {"type": "object"}
+        result = template.generate_template_from_schema(schema, 3)
+        assert not result
+
+    def test_simple_string_property(self):
+        """Test generating a simple string property."""
+        schema = {
+            "properties": {
+                "name": {"type": "string"}
+            }
+        }
+        result = template.generate_template_from_schema(schema, 3)
+        assert result == {"name": "quay.io/ansible/ee-minimal:latest"}
+
+    def test_version_property_uses_schema_version(self):
+        """Test that version property uses the provided schema version."""
+        schema = {
+            "properties": {
+                "version": {"type": "number"}
+            }
+        }
+        result = template.generate_template_from_schema(schema, 2)
+        assert result == {"version": 2}
+
+        result = template.generate_template_from_schema(schema, 1)
+        assert result == {"version": 1}
+
+    def test_minimal_mode_only_required(self):
+        """Test minimal mode only includes required fields."""
+        schema = {
+            "properties": {
+                "version": {"type": "number"},
+                "optional_field": {"type": "string"},
+                "required_field": {"type": "string"}
+            },
+            "required": ["version", "required_field"]
+        }
+        result = template.generate_template_from_schema(schema, 3, minimal=True)
+        assert "version" in result
+        assert "required_field" in result
+        assert "optional_field" not in result
+
+    def test_anyof_string_selection(self):
+        """Test anyOf selects string type when available."""
+        schema = {
+            "properties": {
+                "test_field": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "string"}
+                    ]
+                }
+            }
+        }
+        result = template.generate_template_from_schema(schema, 3)
+        assert isinstance(result["test_field"], str)
+
+    def test_nested_object(self):
+        """Test nested object generation."""
+        schema = {
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "properties": {
+                        "inner_field": {"type": "string"}
+                    }
+                }
+            }
+        }
+        result = template.generate_template_from_schema(schema, 3)
+        assert "nested" in result
+        assert isinstance(result["nested"], dict)
+        assert "inner_field" in result["nested"]
+
+
+class TestValueGeneration:
+    """Test individual value generation functions."""
+    # pylint: disable=protected-access
+
+    def test_generate_string_value_special_cases(self):
+        """Test string value generation for special field names."""
+        assert template._generate_string_value("name") == "quay.io/ansible/ee-minimal:latest"
+        assert template._generate_string_value("package_system") == "python39"
+        assert template._generate_string_value("workdir") == "/runner"
+        assert template._generate_string_value("user") == "1000"
+
+    def test_generate_string_value_partial_matches(self):
+        """Test string value generation for partial matches."""
+        assert "quay.io" in template._generate_string_value("base_image_name")
+        assert "/usr/bin" in template._generate_string_value("some_path")
+        assert "package" in template._generate_string_value("custom_package")
+
+    def test_generate_number_value(self):
+        """Test number value generation."""
+        assert template._generate_number_value("version", 2) == 2
+        assert template._generate_number_value("other_number", 3) == 1
+
+    def test_generate_boolean_value(self):
+        """Test boolean value generation."""
+        assert template._generate_boolean_value("relax_passwd_permissions") is True
+        assert template._generate_boolean_value("skip_ansible_check") is False
+        assert template._generate_boolean_value("unknown_field") is False
+
+    def test_generate_string_array_value(self):
+        """Test string array value generation."""
+        python_deps = template._generate_string_array_value("python")
+        assert isinstance(python_deps, list)
+        assert len(python_deps) > 0
+        assert any("requests" in dep for dep in python_deps)
+
+        collections = template._generate_string_array_value("collections")
+        assert isinstance(collections, list)
+        assert "community.general" in collections
+
+
+class TestGenerateExecutionEnvironmentTemplate:
+    """Test the main template generation function."""
+
+    def test_unsupported_schema_version(self):
+        """Test that unsupported schema versions raise ValueError."""
+        with pytest.raises(ValueError, match="Unsupported schema version: 4"):
+            template.generate_execution_environment_template(4)
+
+    def test_version_1_template(self):
+        """Test generating version 1 template."""
+        result = template.generate_execution_environment_template(1)
+        assert result["version"] == 1
+        assert "build_arg_defaults" in result
+        assert "EE_BASE_IMAGE" in result["build_arg_defaults"]
+        assert "images" not in result  # v1 doesn't have images section
+
+    def test_version_2_template(self):
+        """Test generating version 2 template."""
+        result = template.generate_execution_environment_template(2)
+        assert result["version"] == 2
+        assert "images" in result
+        assert "base_image" in result["images"]
+        assert "builder_image" in result["images"]
+
+    def test_version_3_template(self):
+        """Test generating version 3 template."""
+        result = template.generate_execution_environment_template(3)
+        assert result["version"] == 3
+        assert "dependencies" in result
+        assert "options" in result
+        assert "additional_build_files" in result
+
+    def test_minimal_template(self):
+        """Test generating minimal template."""
+        result = template.generate_execution_environment_template(3, minimal=True)
+        assert result["version"] == 3
+        # Should only have required fields (none are actually required in the schema)
+        # But version is always added
+        assert len(result) >= 1
+
+    def test_enhanced_examples_v3(self):
+        """Test that v3 templates get enhanced examples."""
+        result = template.generate_execution_environment_template(3)
+
+        # Check galaxy enhancement
+        if "dependencies" in result and "galaxy" in result["dependencies"]:
+            galaxy = result["dependencies"]["galaxy"]
+            if isinstance(galaxy, dict):
+                assert "collections" in galaxy or "roles" in galaxy
+
+        # Check additional_build_files enhancement
+        if "additional_build_files" in result:
+            build_files = result["additional_build_files"]
+            assert isinstance(build_files, list)
+            if build_files:
+                assert "src" in build_files[0]
+                assert "dest" in build_files[0]
+
+
+class TestWriteTemplateToFile:
+    """Test the write_template_to_file function."""
+
+    def test_write_to_stdout(self):
+        """Test writing template to stdout."""
+        template_dict = {"version": 3, "test": "value"}
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            template.write_template_to_file(template_dict)
+            output = mock_stdout.getvalue()
+
+        assert "version: 3" in output
+        assert "test: value" in output
+
+    def test_write_to_file(self):
+        """Test writing template to file."""
+        template_dict = {"version": 3, "test": "value"}
+        mock_file = StringIO()
+
+        template.write_template_to_file(template_dict, mock_file)
+        output = mock_file.getvalue()
+
+        assert "version: 3" in output
+        assert "test: value" in output
+
+
+class TestRunTemplate:
+    """Test the run_template function."""
+
+    def test_run_template_stdout(self):
+        """Test run_template with stdout output."""
+        # Mock args object
+        class MockArgs:
+            schema_version = 3
+            minimal = False
+            output = None
+
+        args = MockArgs()
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            template.run_template(args)
+            output = mock_stdout.getvalue()
+
+        assert "version: 3" in output
+
+    def test_run_template_file_output(self):
+        """Test run_template with file output."""
+        # Mock args object
+        class MockArgs:
+            schema_version = 2
+            minimal = True
+            output = "/tmp/test.yml"
+
+        args = MockArgs()
+
+        with patch("builtins.open", mock_open()) as mock_file:
+            template.run_template(args)
+            mock_file.assert_called_once_with("/tmp/test.yml", 'w')
+
+    def test_run_template_invalid_version(self):
+        """Test run_template with invalid schema version."""
+        # Mock args object
+        class MockArgs:
+            schema_version = 99
+            minimal = False
+            output = None
+
+        args = MockArgs()
+
+        with patch('sys.stderr', new_callable=StringIO):
+            with pytest.raises(SystemExit) as exc_info:
+                template.run_template(args)
+            assert exc_info.value.code == 1
+
+    def test_run_template_file_error(self):
+        """Test run_template with file write error."""
+        # Mock args object
+        class MockArgs:
+            schema_version = 3
+            minimal = False
+            output = "/invalid/path/test.yml"
+
+        args = MockArgs()
+
+        with patch("builtins.open", side_effect=OSError("Permission denied")):
+            with patch('sys.stderr', new_callable=StringIO):
+                with pytest.raises(SystemExit) as exc_info:
+                    template.run_template(args)
+                assert exc_info.value.code == 1
+
+
+class TestSchemaCompatibility:
+    """Test compatibility with actual schema definitions."""
+
+    def test_all_schema_versions_generate(self):
+        """Test that all schema versions can generate templates."""
+        for version in [1, 2, 3]:
+            result = template.generate_execution_environment_template(version)
+            assert result["version"] == version
+            assert isinstance(result, dict)
+
+    def test_v1_schema_fields(self):
+        """Test that v1 template contains expected fields."""
+        result = template.generate_execution_environment_template(1)
+
+        # Check for v1 specific fields
+        if "build_arg_defaults" in result:
+            assert "EE_BASE_IMAGE" in result["build_arg_defaults"]
+            assert "EE_BUILDER_IMAGE" in result["build_arg_defaults"]
+
+    def test_v2_schema_fields(self):
+        """Test that v2 template contains expected fields."""
+        result = template.generate_execution_environment_template(2)
+
+        # Check for v2 specific fields
+        assert "images" in result
+        if "images" in result:
+            assert "base_image" in result["images"]
+
+    def test_v3_schema_fields(self):
+        """Test that v3 template contains expected fields."""
+        result = template.generate_execution_environment_template(3)
+
+        # Check for v3 specific fields
+        if "dependencies" in result:
+            deps = result["dependencies"]
+            # These fields should use the enhanced types in v3
+            if "python" in deps:
+                # In v3, python can be string or array
+                assert isinstance(deps["python"], (str, list))


### PR DESCRIPTION
*************
WARNING - This is just an experiment. This may, or may not, turn into a feature.
*************

This new feature allows users to generate sample YAML files based on the JSON schemas defined for execution environments. The template command supports all three schema versions (v1, v2, v3) and can generate either complete templates with example values or minimal templates with only required fields.

Key features:
- Generate templates for schema versions 1, 2, or 3 (defaults to 3)
- Support for minimal mode to show only required fields
- Output to stdout or specified file
- Realistic example values based on field names and types
- Enhanced examples for v3 schema with comprehensive galaxy and build file examples

Assisted-by: Claude Code