### PR TITLE
Deprecate v1 and v2 schema versions

### DIFF
--- a/docs/porting_guides/porting_guide.rst
+++ b/docs/porting_guides/porting_guide.rst
@@ -9,5 +9,6 @@ versions of ``ansible-builder``.
 .. toctree::
    :maxdepth: 1
 
+   porting_guide_v3.2
    porting_guide_v3.1
    porting_guide_v3.0

--- a/docs/porting_guides/porting_guide_v3.2.rst
+++ b/docs/porting_guides/porting_guide_v3.2.rst
@@ -1,0 +1,15 @@
+*********************************
+Ansible Builder 3.2 Porting Guide
+*********************************
+
+This section discusses the behavioral changes between ``ansible-builder`` version 3.1 and version 3.2.
+
+Deprecations
+============
+
+Execution environment schema versions 1 and 2 are deprecated and scheduled to be removed from a
+future release of Ansible Builder. If you are currently using one of these versions, you will need
+to update your ``execution-environment.yml`` files to the :ref:`version 3 format <version_3_format>`.
+
+A warning about the deprecation is sent to the logging output of the ``create`` or ``build`` commands when
+an execution environment definition file is found to be using one of the deprecated versions.

--- a/docs/porting_guides/porting_guide_v3.2.rst
+++ b/docs/porting_guides/porting_guide_v3.2.rst
@@ -7,9 +7,9 @@ This section discusses the behavioral changes between ``ansible-builder`` versio
 Deprecations
 ============
 
-Execution environment schema versions 1 and 2 are deprecated and scheduled to be removed from a
-future release of Ansible Builder. If you are currently using one of these versions, you will need
-to update your ``execution-environment.yml`` files to the :ref:`version 3 format <version_3_format>`.
+Execution environment schema versions 1 and 2 are deprecated and scheduled to be removed from Ansible Builder 3.3.
+If you are currently using one of these versions, you will need to update your ``execution-environment.yml``
+files to the :ref:`version 3 format <version_3_format>`.
 
 A warning about the deprecation is sent to the logging output of the ``create`` or ``build`` commands when
 an execution environment definition file is found to be using one of the deprecated versions.

--- a/src/ansible_builder/cli.py
+++ b/src/ansible_builder/cli.py
@@ -10,8 +10,7 @@ from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from .policies import PolicyChoices
 from ._target_scripts.introspect import create_introspect_parser, run_introspect
-from .utils import configure_logger
-
+from .utils import configure_logger, deprecation_notice
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +84,11 @@ def run():
 
     if args.action in ['create', 'build']:
         ab = AnsibleBuilder(**vars(args))
+
+        if ab.version in (1, 2):
+            deprecation_notice(f'Execution environment schema version {ab.version} is deprecated and will be '
+                               'removed in a future release. Version 3 will be the minimum version supported.')
+
         action = getattr(ab, ab.action)
         try:
             if action():

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -70,9 +70,6 @@ class AnsibleBuilder:
         self.definition = UserDefinition(filename=filename)
         self.definition.validate()
 
-        if self.definition.version < 3:
-            logger.warning('Found version %s, consider upgrading to version 3 or above', self.definition.version)
-
         self.tags = [constants.default_tag]
         if self.definition.version >= 3 and self.definition.options['tags']:
             self.tags = self.definition.options['tags']

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -57,6 +57,11 @@ def configure_logger(verbosity: int, disable_colors: bool = False):
     root_logger.addHandler(handler)
 
 
+def deprecation_notice(msg: str) -> None:
+    """Utility function to standardize deprecation notice logging."""
+    logger.warning("DEPRECATION NOTICE: %s", msg)
+
+
 def run_command(command, capture_output=False, allow_error=False):
     logger.info('Running command:')
     logger.info('  %s', ' '.join(command))

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -10,17 +10,15 @@ from ansible_builder import constants
 
 
 @pytest.mark.test_all_runtimes
-def test_version_1_warning(cli, runtime, ee_tag, tmp_path, data_dir):
-    """Test that warning about version 1.
-
-    """
+def test_schema_deprecation_warning(cli, runtime, ee_tag, tmp_path, data_dir):
+    """Test that a deprecation notice is emitted"""
     bc = tmp_path
     ee_def = data_dir / 'blank' / 'execution-environment.yml'
     r = cli(
-        f"ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3",
+        f"ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}",
         allow_error=True
     )
-    assert 'Found version 1, consider upgrading to version 3 or above' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+    assert 'DEPRECATION NOTICE' in (r.stdout + r.stderr), (r.stdout + r.stderr)
 
 
 @pytest.mark.test_all_runtimes

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -633,3 +633,11 @@ def test_exclude_files_created(cli, build_dir_and_ee_yml):
                                   f" --exclude-collection-reqs={constants.EXCL_COLLECTIONS_FILENAME}" \
                                   " --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt\n"
     assert expected_introspect_command in text
+
+
+def test_schema_deprecation_warning(cli, data_dir):
+    """Test that a deprecation notice is emitted"""
+    ee_def = os.path.join(data_dir, 'blank', 'execution-environment.yml')
+    r = cli(f'ansible-builder create -f {ee_def}', allow_error=True)
+    assert r.rc == 0
+    assert 'DEPRECATION NOTICE' in (r.stdout + r.stderr), (r.stdout + r.stderr)


### PR DESCRIPTION
Sends a deprecation notice to logging output when a v1 or v2 EE schema is encountered during the 'create' or 'build' commands.

Fixes #753 