### PR TITLE
Document RPM-based base image requirement

### DIFF
--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -78,12 +78,14 @@ requirements and extra files, but does demonstrate more complete EE file syntax.
     images:
       base_image:
         name: docker.io/redhat/ubi9:latest
-        # Other available base images:
+        # NOTE: Ansible Builder requires RPM-based images (those using dnf/yum package management).
+        # Other RPM-based base images that should work:
         #   - quay.io/rockylinux/rockylinux:9
         #   - quay.io/centos/centos:stream9
         #   - registry.fedoraproject.org/fedora:38
         #   - registry.redhat.io/ansible-automation-platform-23/ee-minimal-rhel8:latest
         #     (needs an account)
+        # Non-RPM images (Debian, Ubuntu, Alpine, etc.) are not supported.
 
     # Custom package manager path for the RHEL based images
     # options:
@@ -440,10 +442,19 @@ builder runtime functionality. Valid keys for this section are:
         The default value is ``dumb-init==1.2.5``.
 
     ``package_manager_path``
-      A string with the path to the package manager (For example - ``dnf`` or ``microdnf``) to use.
-      The default is ``/usr/bin/dnf``. This value will be used to install a
-      Python interpreter, if specified in ``dependencies``, and during the
-      build phase by the ``assemble`` script.
+      A string with the path to the package manager to use.
+      The default is ``/usr/bin/dnf``, which is required for supported RPM-based distributions.
+
+      This option allows you to choose between different RPM package managers available on
+      your base image, such as ``/usr/bin/dnf`` or ``/usr/bin/microdnf``. The package manager
+      is used to install system packages, and if specified in ``dependencies``, to install
+      a Python interpreter during the build phase.
+
+      .. warning::
+
+          Only RPM-based package managers (dnf, yum, microdnf) are supported. Non-RPM package
+          managers such as apt-get (Debian/Ubuntu) or apk (Alpine) are not supported and will
+          cause build failures.
 
     ``skip_ansible_check``
       This boolean value controls whether or not the check for an installation

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -78,7 +78,7 @@ requirements and extra files, but does demonstrate more complete EE file syntax.
     images:
       base_image:
         name: docker.io/redhat/ubi9:latest
-        # NOTE: Ansible Builder requires RPM-based images (those using dnf/yum package management).
+        # NOTE: Ansible Builder requires RPM-based images (those using dnf package management).
         # Other RPM-based base images that should work:
         #   - quay.io/rockylinux/rockylinux:9
         #   - quay.io/centos/centos:stream9
@@ -442,8 +442,7 @@ builder runtime functionality. Valid keys for this section are:
         The default value is ``dumb-init==1.2.5``.
 
     ``package_manager_path``
-      A string with the path to the package manager to use.
-      The default is ``/usr/bin/dnf``, which is required for supported RPM-based distributions.
+      A string with the path to the package manager to use. The default is ``/usr/bin/dnf``.
 
       This option allows you to choose between different RPM package managers available on
       your base image, such as ``/usr/bin/dnf`` or ``/usr/bin/microdnf``. The package manager
@@ -452,8 +451,8 @@ builder runtime functionality. Valid keys for this section are:
 
       .. warning::
 
-          Only RPM-based package managers (dnf, yum, microdnf) are supported. Non-RPM package
-          managers such as apt-get (Debian/Ubuntu) or apk (Alpine) are not supported and will
+          Only RPM-based package managers (for example, ``dnf`` or ``microdnf``) are supported. Non-RPM package
+          managers such as ``apt-get`` (Debian/Ubuntu) or ``apk`` (Alpine) are not supported and will
           cause build failures.
 
     ``skip_ansible_check``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,44 +59,25 @@ execution environment. You can specify these items:
  .. _choosing_base_image:
 
 Choosing a base image
----------------------
+=====================
 
-RPM-based distributions are required
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ansible Builder requires RPM-based container images that use the ``dnf`` or ``microdnf`` package manager.
+Non-RPM-based distributions (such as Debian, Ubuntu, or Alpine) are not supported and will fail to build.
 
-.. warning::
+Ansible Builder's default configuration and internal tooling assume the use of ``dnf`` package management, which is present
+on RPM-based Linux distributions. The following are examples of images that should work with Ansible Builder:
 
-    Ansible Builder requires RPM-based container images that use the dnf or yum package manager.
-    Non-RPM-based distributions (such as Debian, Ubuntu, or Alpine) are not supported and will fail to build.
-
-Ansible Builder's default configuration and internal tooling assume the use of dnf/yum package management, which is present on RPM-based Linux distributions. The following examples are images that should work with Ansible Builder (this is not an exhaustive list):
-
-- **Red Hat Universal Base Image (UBI)**: ``registry.access.redhat.com/ubi9/ubi:latest`` or ``docker.io/redhat/ubi9:latest``
 - **CentOS Stream**: ``quay.io/centos/centos:stream9``
 - **Rocky Linux**: ``quay.io/rockylinux/rockylinux:9``
 - **Fedora**: ``registry.fedoraproject.org/fedora:43``
-- **RHEL-based Ansible Automation Platform images**: ``registry.redhat.io/ansible-automation-platform-*/ee-*`` (requires Red Hat account)
+- **Red Hat Universal Base Image (UBI)**: ``registry.access.redhat.com/ubi9/ubi:latest``
+- **RHEL-based Ansible Automation Platform images**: ``registry.redhat.io/ansible-automation-platform-*/ee-*``
 
-.. note::
+The examples above demonstrate compatible images, but any RPM-based image with ``dnf`` or ``microdnf`` should work.
 
-    These images are expected to work based on their use of RPM packaging and dnf/yum package managers.
-
-When choosing a base image, prefer smaller images when possible, as they result in smaller final execution environment images. However, ensure you understand what packages are already installed on the base image to avoid redundant installations. For example, some base images already have Python installed, while others do not.
-
-Non-RPM-based images are not supported
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. warning::
-
-    Do not use Debian, Ubuntu, Alpine, or other non-RPM-based distributions as base images.
-    These will fail during the build process because Ansible Builder's tooling expects dnf or yum package management.
-
-Common errors when attempting to use non-RPM images include:
-
-- **Package manager incompatibility**: The default package manager path (``/usr/bin/dnf``) does not exist on non-RPM distributions
-- **System package installation failures**: Target scripts assume RPM-based package management tools
-
-If you encounter build failures with your base image, ensure you are using an RPM-based distribution with dnf, yum, or microdnf available.
+When choosing a base image, prefer smaller images when possible, as they result in smaller final execution environment
+images. However, ensure you understand what packages are already installed on the base image to avoid redundant installations.
+For example, some base images already have Python installed, while others do not.
 
 How Ansible Builder executes
 ============================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,16 +56,47 @@ execution environment. You can specify these items:
 - Python packages, with version restrictions
 - other items to download, install, or configure
 
+ .. _choosing_base_image:
+
 Choosing a base image
 ---------------------
 
-You can use any base image you choose.
-The smaller the base image, generally, the smaller the final image.
-However, to make Ansible Builder more efficient, you should know what packages, if any, are already installed on the base image you use.
+RPM-based distributions are required
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For example, some base images already have Python installed. Others do not.
-If you use a base image that already has Python installed, you can omit Python in your execution environment definition file.
-Not all base images have package managers installed.
+.. warning::
+
+    Ansible Builder requires RPM-based container images that use the dnf or yum package manager.
+    Non-RPM-based distributions (such as Debian, Ubuntu, or Alpine) are not supported and will fail to build.
+
+Ansible Builder's default configuration and internal tooling assume the use of dnf/yum package management, which is present on RPM-based Linux distributions. The following examples are images that should work with Ansible Builder (this is not an exhaustive list):
+
+- **Red Hat Universal Base Image (UBI)**: ``registry.access.redhat.com/ubi9/ubi:latest`` or ``docker.io/redhat/ubi9:latest``
+- **CentOS Stream**: ``quay.io/centos/centos:stream9``
+- **Rocky Linux**: ``quay.io/rockylinux/rockylinux:9``
+- **Fedora**: ``registry.fedoraproject.org/fedora:43``
+- **RHEL-based Ansible Automation Platform images**: ``registry.redhat.io/ansible-automation-platform-*/ee-*`` (requires Red Hat account)
+
+.. note::
+
+    These images are expected to work based on their use of RPM packaging and dnf/yum package managers.
+
+When choosing a base image, prefer smaller images when possible, as they result in smaller final execution environment images. However, ensure you understand what packages are already installed on the base image to avoid redundant installations. For example, some base images already have Python installed, while others do not.
+
+Non-RPM-based images are not supported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+    Do not use Debian, Ubuntu, Alpine, or other non-RPM-based distributions as base images.
+    These will fail during the build process because Ansible Builder's tooling expects dnf or yum package management.
+
+Common errors when attempting to use non-RPM images include:
+
+- **Package manager incompatibility**: The default package manager path (``/usr/bin/dnf``) does not exist on non-RPM distributions
+- **System package installation failures**: Target scripts assume RPM-based package management tools
+
+If you encounter build failures with your base image, ensure you are using an RPM-based distribution with dnf, yum, or microdnf available.
 
 How Ansible Builder executes
 ============================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,6 +13,13 @@ Requirements
 - The ``--container-runtime`` option must correspond to the containerization tool you use.
 - ``ansible-builder`` version ``3.x`` requires Python ``3.9`` or higher.
 
+Base Image Requirements
+************************
+
+Ansible Builder requires RPM-based container images (those using dnf or yum package management) as the base for execution environments. Non-RPM-based distributions such as Debian, Ubuntu, or Alpine are not supported.
+
+For detailed information about choosing an appropriate base image and a list of images that should work, see the :ref:`choosing_base_image` section.
+
 Install from PyPI
 *****************
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ Requirements
 Base Image Requirements
 ************************
 
-Ansible Builder requires RPM-based container images (those using dnf or yum package management) as the base for execution environments. Non-RPM-based distributions such as Debian, Ubuntu, or Alpine are not supported.
+Ansible Builder requires RPM-based container images (those using ``dnf`` or ``microdnf`` package management) as the base for execution environments. Non-RPM-based distributions such as Debian, Ubuntu, or Alpine are not supported.
 
 For detailed information about choosing an appropriate base image and a list of images that should work, see the :ref:`choosing_base_image` section.
 


### PR DESCRIPTION
Update documentation to clarify that Ansible Builder requires RPM-based container images (those using dnf/yum package management) and that non-RPM-based distributions like Debian, Ubuntu, and Alpine are not supported.

Changes:
- index.rst: Replace "Choosing a base image" section with detailed requirements and warnings about RPM-based vs non-RPM images
- definition.rst: Add notes to base_image examples and expand package_manager_path documentation with warnings
- installation.rst: Add "Base Image Requirements" section

Fixes #692 

Co-Authored-By: Claude Code