### PR TITLE
Pin pytest to 8.1.1

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,7 @@
 coverage
 flake8==6.1.0
 mypy==1.6.0
-pytest
+pytest==8.1.1
 pytest-cov
 pytest-mock
 pytest-xdist


### PR DESCRIPTION
This is pinned in later releases, but the latest release of pytest 9 breaks our CI since a [warning is now an error](https://github.com/pytest-dev/pytest/issues/13779).