### PR TITLE
Bump test requirements versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,25 +59,26 @@ include-package-data = true
 output-format = "colorized"
 max-line-length=120
 disable = [
-  # Some codes we will leave disabled
-  "C0103",  # invalid-name
-  "C0114",  # missing-module-docstring
-  "C0115",  # missing-class-docstring
-  "C0116",  # missing-function-docstring
+    # Some codes we will leave disabled
+    "C0103",  # invalid-name
+    "C0114",  # missing-module-docstring
+    "C0115",  # missing-class-docstring
+    "C0116",  # missing-function-docstring
 
-  "R0801",  # duplicate-code
-  "R0902",  # too-many-instance-attributes
-  "R0903",  # too-few-public-methods
-  "R0904",  # too-many-public-methods
-  "R0911",  # too-many-return-statements
-  "R0912",  # too-many-branches
-  "R0913",  # too-many-arguments
-  "R0914",  # too-many-locals
-  "R0915",  # too-many-statements
-  "R1702",  # too-many-nested-blocks
+    "R0801",  # duplicate-code
+    "R0902",  # too-many-instance-attributes
+    "R0903",  # too-few-public-methods
+    "R0904",  # too-many-public-methods
+    "R0911",  # too-many-return-statements
+    "R0912",  # too-many-branches
+    "R0913",  # too-many-arguments
+    "R0914",  # too-many-locals
+    "R0915",  # too-many-statements
+    "R0917",  # too-many-positional-arguments
+    "R1702",  # too-many-nested-blocks
 
-  "W0511",  # fixme
-  "W1514",  # unspecified-encoding
-  "W0718",  # broad-exception-caught
-  "W0719",  # broad-exception-raised
+    "W0511",  # fixme
+    "W1514",  # unspecified-encoding
+    "W0718",  # broad-exception-caught
+    "W0719",  # broad-exception-raised
 ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -270,7 +270,6 @@ def podman_ee_tag(request):
 
 
 @pytest.fixture
-@pytest.mark.test_all_runtimes
 def ee_tag(request, runtime):
     image_name = gen_image_name(request)
     WORKER_IMAGES.setdefault(runtime, [])

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,12 +1,12 @@
 coverage
-flake8==6.1.0
-mypy==1.6.0
-pytest==8.1.1
+flake8==7.3.0
+mypy==1.19.1
+pytest<=9.0.2
 pytest-cov
 pytest-mock
 pytest-xdist
 types-jsonschema
 types-pyyaml
 tox
-yamllint==1.32.0
-pylint==3.0.1
+yamllint<=1.38.0
+pylint<=4.0.5


### PR DESCRIPTION
Bump all of our test dependencies.

- Added R0917 to pylint ignores.
- Fix ignored mark on a fixture that is [now an error](https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function) with Pytest 9.