### PR TITLE
Fix pylint R0917 warnings and remove ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ disable = [
     "R0913",  # too-many-arguments
     "R0914",  # too-many-locals
     "R0915",  # too-many-statements
-    "R0917",  # too-many-positional-arguments
 
     "W0511",  # fixme
     "W1514",  # unspecified-encoding

--- a/src/ansible_builder/_target_scripts/introspect.py
+++ b/src/ansible_builder/_target_scripts/introspect.py
@@ -152,7 +152,8 @@ def process_collection(path):
     return (pip_lines, bindep_lines)
 
 
-def process(data_dir=BASE_COLLECTIONS_PATH,
+def process(*,
+            data_dir=BASE_COLLECTIONS_PATH,
             user_pip=None,
             user_bindep=None,
             exclude_pip=None,
@@ -389,7 +390,7 @@ def parse_args(args=None):
 
 
 def run_introspect(args, log):
-    data = process(args.folder,
+    data = process(data_dir=args.folder,
                    user_pip=args.user_pip,
                    user_bindep=args.user_bindep,
                    exclude_pip=args.exclude_pip,

--- a/src/ansible_builder/containerfile.py
+++ b/src/ansible_builder/containerfile.py
@@ -19,6 +19,7 @@ class Containerfile:
     newline_char = '\n'
 
     def __init__(self,
+                 *,
                  definition: UserDefinition,
                  build_context: str,
                  container_runtime: str,

--- a/src/ansible_builder/main.py
+++ b/src/ansible_builder/main.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class AnsibleBuilder:
     def __init__(self,
+                 *,
                  action: str,
                  filename: str | None = None,
                  build_args: dict[str, str] | None = None,

--- a/test/pulp_integration/test_policies.py
+++ b/test/pulp_integration/test_policies.py
@@ -85,7 +85,7 @@ class TestPolicies:
         assert f"Complete! The build context can be found at: {tmp_path}" in result.stdout
 
     @pytest.mark.parametrize('version', ('v2', 'v3'))
-    def test_system(self, cli, tmp_path, data_dir, podman_ee_tag, version):
+    def test_system(self, *, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that a system level policy.json file will be used with the
         `system` policy.
@@ -111,7 +111,7 @@ class TestPolicies:
         assert f"Complete! The build context can be found at: {tmp_path}" in result.stdout
 
     @pytest.mark.parametrize('version', ('v2', 'v3'))
-    def test_signature_required_success(self, cli, tmp_path, data_dir, podman_ee_tag, version):
+    def test_signature_required_success(self, *, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that signed images are validated when using the signature_required policy.
 
@@ -132,7 +132,7 @@ class TestPolicies:
         assert f"Complete! The build context can be found at: {tmp_path}" in result.stdout
 
     @pytest.mark.parametrize('version', ('v2', 'v3'))
-    def test_signature_required_fail(self, cli, tmp_path, data_dir, podman_ee_tag, version):
+    def test_signature_required_fail(self, *, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that failure to validate a signed image will fail.
 
@@ -150,7 +150,7 @@ class TestPolicies:
         assert "Source image rejected: None of the signatures were accepted" in einfo.value.stdout
 
     @pytest.mark.parametrize('version', ('v2', 'v3'))
-    def test_signature_required_no_orig(self, cli, tmp_path, data_dir, podman_ee_tag, version):
+    def test_signature_required_no_orig(self, *, cli, tmp_path, data_dir, podman_ee_tag, version):
         """
         Test that using a signed image, but not specifying the original image name, fails.
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -407,7 +407,7 @@ def test_extra_build_cli_args(exec_env_definition_file, tmp_path):
                              # CI environments
                              ('', '', 'xterm', '1', True),     # CI disables colors
                          ])
-def test__should_disable_colors(no_color, clicolor, term, ci, expected, monkeypatch, mocker):
+def test__should_disable_colors(*, no_color, clicolor, term, ci, expected, monkeypatch, mocker):
     # pylint: disable=W0613,W0621
     # Clear environment variables that could interfere with the test
     # monkeypatch.delenv is safe for concurrent execution

--- a/test/unit/test_containerfile.py
+++ b/test/unit/test_containerfile.py
@@ -11,7 +11,7 @@ def make_containerfile(tmpdir, ee_path, run_validate=False, **cf_kwargs):
     definition = UserDefinition(ee_path)
     if run_validate:
         definition.validate()
-    c = Containerfile(definition, build_context=str(tmpdir), container_runtime='podman', **cf_kwargs)
+    c = Containerfile(definition=definition, build_context=str(tmpdir), container_runtime='podman', **cf_kwargs)
     return c
 
 

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -9,7 +9,7 @@ from ansible_builder._target_scripts.introspect import (parse_args,
 
 
 def test_multiple_collection_metadata(data_dir):
-    files = process(data_dir)
+    files = process(data_dir=data_dir)
     files['python'] = filter_requirements(files['python'])
     files['system'] = filter_requirements(files['system'], is_python=False)
 
@@ -33,7 +33,7 @@ def test_process_returns_excluded_python(data_dir, tmp_path):
     pip_ignore_file = tmp_path / "exclude-requirements.txt"
     pip_ignore_file.write_text("req1\nreq2")
 
-    retval = process(data_dir, exclude_pip=str(pip_ignore_file))
+    retval = process(data_dir=data_dir, exclude_pip=str(pip_ignore_file))
 
     assert 'python' in retval
     assert 'exclude' in retval['python']
@@ -47,7 +47,7 @@ def test_process_returns_excluded_system(data_dir, tmp_path):
     bindep_ignore_file = tmp_path / "exclude-bindep.txt"
     bindep_ignore_file.write_text("req1\nreq2")
 
-    retval = process(data_dir, exclude_bindep=str(bindep_ignore_file))
+    retval = process(data_dir=data_dir, exclude_bindep=str(bindep_ignore_file))
 
     assert 'system' in retval
     assert 'exclude' in retval['system']
@@ -61,7 +61,7 @@ def test_process_returns_excluded_collections(data_dir, tmp_path):
     col_ignore_file = tmp_path / "ignored_collections"
     col_ignore_file.write_text("a.b\nc.d")
 
-    retval = process(data_dir, exclude_collections=str(col_ignore_file))
+    retval = process(data_dir=data_dir, exclude_collections=str(col_ignore_file))
 
     assert 'excluded_collections' in retval
     assert retval['excluded_collections'] == ['a.b', 'c.d']
@@ -116,7 +116,7 @@ def test_yaml_extension(data_dir):
     found.
     """
     col_path = os.path.join(data_dir, 'alternate_collections')
-    files = process(col_path)
+    files = process(data_dir=col_path)
     assert files == {
         'python': {'test_collection.test_yaml_extension': ['python-six']},
         'system': {},


### PR DESCRIPTION
Fixes code that triggered the Pylint R0917 warning ([too-many-positional-arguments](https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html)) and removes the ignore.