### PR TITLE
Fix pylint W0719: replace broad Exception with ValueError/RuntimeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,4 @@ disable = [
 
     "W0511",  # fixme
     "W1514",  # unspecified-encoding
-    "W0719",  # broad-exception-raised
 ]

--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -146,7 +146,7 @@ def copy_directory(source_dir: Path, dest: Path):
     """
 
     if not source_dir.is_dir():
-        raise Exception(f"Expected a directory at '{source_dir}'")
+        raise ValueError(f"Expected a directory at '{source_dir}'")
 
     for child in source_dir.iterdir():
         copy_location = dest / child.name
@@ -173,7 +173,7 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
 
     :returns: True if the file was copied, False if not.
 
-    :raises: Exception if called with the path to a directory. This helps to
+    :raises: ValueError if called with the path to a directory. This helps to
         catch programming errors.
     """
 
@@ -183,9 +183,9 @@ def copy_file(source: str, dest: str, ignore_mtime: bool = False) -> bool:
         logger.info("File %s was placed in build context by user, leaving unmodified.", dest)
         return False
     if Path(source).is_dir():
-        raise Exception(f"Source {source} can not be a directory. Please use copy_directory instead.")
+        raise ValueError(f"Source {source} can not be a directory. Please use copy_directory instead.")
     if Path(dest).is_dir():
-        raise Exception(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
+        raise ValueError(f"Destination {dest} can not be a directory. Please use copy_directory instead.")
     if Path(source).is_symlink() and Path(dest).is_symlink() and os.readlink(source) == os.readlink(dest):
         logger.debug("Symlink %s already exists and matches.", dest)
         should_copy = False

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -258,7 +258,7 @@ def delete_image(runtime, image_name):
     if r.rc != 0:
         if regexp.search(r.stdout) or regexp.search(r.stderr):
             return
-        raise Exception(f'Image cleanup failed (rc={r.rc}):\n{r.stdout}\n{r.stderr}')
+        raise RuntimeError(f'Image cleanup failed (rc={r.rc}):\n{r.stdout}\n{r.stderr}')
 
 
 @pytest.fixture

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -65,11 +65,11 @@ def test_copy_file_with_destination_directory(dest_file, source_file):
     # Change source file to trigger copy_file
     source_file.write_text('foo\nbar\nzoo')
 
-    with pytest.raises(Exception) as err:
+    with pytest.raises(ValueError) as err:
         copy_file(source_file, '/tmp')
     assert "can not be a directory" in str(err.value.args[0])
 
-    with pytest.raises(Exception) as err:
+    with pytest.raises(ValueError) as err:
         copy_file('/tmp', dest_file)
     assert "can not be a directory" in str(err.value.args[0])
 
@@ -131,7 +131,7 @@ def test_copy_directory_notadir(tmp_path):
     """
     notadir = tmp_path / 'xyz'
     notadir.touch()
-    with pytest.raises(Exception, match="Expected a directory at *"):
+    with pytest.raises(ValueError, match="Expected a directory at *"):
         copy_directory(notadir, 'abc')
 
 


### PR DESCRIPTION
- Enable W0719 (broad-exception-raised) in pyproject.toml
- utils.py: raise ValueError for invalid path/usage in copy_directory and copy_file
- test/conftest.py: raise RuntimeError for image cleanup failure in delete_image
- test/unit/test_utils.py: expect ValueError in tests for copy_file/copy_directory

Assisted-by: Cursor