### PR TITLE
Detect and report bindep parse errors in assemble script

### DIFF
--- a/docs/porting_guides/porting_guide_v3.2.rst
+++ b/docs/porting_guides/porting_guide_v3.2.rst
@@ -4,6 +4,31 @@ Ansible Builder 3.2 Porting Guide
 
 This section discusses the behavioral changes between ``ansible-builder`` version 3.1 and version 3.2.
 
+Behavior Changes
+================
+
+Bindep Parse Error Detection
+----------------------------
+
+The 3.2 release adds improved error detection and reporting for invalid ``bindep.txt`` files.
+Previously, when ``bindep`` encountered unparsable content in a ``bindep.txt`` file, the build
+would continue and potentially fail later with unclear error messages. Now, the build will fail
+immediately with a clear error message when bindep reports a parse error.
+
+When the ``bindep`` program exits with code 2 (indicating unparsable content in ``bindep.txt``),
+the build process will now:
+
+#. Stop immediately at the point where the parse error is detected
+#. Output a clear error message: ``Error: bindep.txt contains unparsable content``
+#. Exit with code 2
+
+This change affects the ``assemble`` script that runs during the builder phase of execution
+environment creation.
+
+.. note::
+  This behavior change requires your container image have ``bindep`` version 2.14.0 or higher installed.
+  Versions below this will not halt execution on unparsable content.
+
 Deprecations
 ============
 

--- a/src/ansible_builder/_target_scripts/assemble
+++ b/src/ansible_builder/_target_scripts/assemble
@@ -63,12 +63,26 @@ function install_bindep {
     # sibling packages in here too
     if [ -f bindep.txt ] ; then
         bindep -l newline | sort >> /output/bindep/run.txt || true
+        rc=${PIPESTATUS[0]}
+        if [ $rc -eq 2 ] ; then
+            echo "Error: bindep.txt contains unparsable content" >&2
+            exit 2
+        fi
         if [ "$RELEASE" == "centos" ] ; then
             bindep -l newline -b epel | sort >> /output/bindep/stage.txt || true
+            rc=${PIPESTATUS[0]}
+            if [ $rc -eq 2 ] ; then
+                echo "Error: bindep.txt contains unparsable content" >&2
+                exit 2
+            fi
             grep -Fxvf /output/bindep/run.txt /output/bindep/stage.txt >> /output/bindep/epel.txt || true
             rm -rf /output/bindep/stage.txt
         fi
-        compile_packages=$(bindep -b compile || true)
+        compile_packages=$(bindep -b compile) || rc=$?
+        if [ "${rc:-0}" -eq 2 ] ; then
+            echo "Error: bindep.txt contains unparsable content" >&2
+            exit 2
+        fi
         if [ ! -z "$compile_packages" ] ; then
             $PKGMGR install -y $PKGMGR_OPTS ${compile_packages}
         fi

--- a/test/data/bindep_invalid/bindep.txt
+++ b/test/data/bindep_invalid/bindep.txt
@@ -1,0 +1,3 @@
+# This is invalid bindep syntax that should cause exit code 2
+package-name [[[invalid-selector]]]
+another-package []]]

--- a/test/data/bindep_invalid/execution-environment.yml
+++ b/test/data/bindep_invalid/execution-environment.yml
@@ -1,0 +1,17 @@
+version: 3
+
+dependencies:
+  system: bindep.txt
+
+images:
+  base_image:
+    name: quay.io/centos/centos:stream9
+
+# Tests using this data depend on a specific version of bindep, so make certain we have it installed.
+additional_build_steps:
+  prepend_builder:
+    - RUN $PYCMD -m pip install "bindep>=2.14.0"
+
+options:
+  package_manager_path: '/bin/true'
+  skip_ansible_check: yes

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -53,6 +53,23 @@ def test_build_fail_exitcode(cli, runtime, ee_tag, tmp_path, data_dir):
 
 
 @pytest.mark.test_all_runtimes
+def test_build_fail_invalid_bindep(cli, runtime, ee_tag, tmp_path, data_dir):
+    """Test that build fails with proper error when bindep.txt contains unparsable content.
+
+    Bindep exits with code 2 when it encounters unparsable content in bindep.txt.
+    The assemble script should detect this and exit with an error message.
+    """
+    bc = tmp_path
+    ee_def = data_dir / 'bindep_invalid' / 'execution-environment.yml'
+    r = cli(
+        f"ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3",
+        allow_error=True
+    )
+    assert r.rc != 0, (r.stdout + r.stderr)
+    assert 'bindep.txt contains unparsable content' in (r.stdout + r.stderr), (r.stdout + r.stderr)
+
+
+@pytest.mark.test_all_runtimes
 def test_blank_execution_environment(cli, runtime, ee_tag, tmp_path, data_dir):
     """Just makes sure that the build process does not require any particular input"""
     bc = tmp_path


### PR DESCRIPTION
Add exit code 2 detection for all bindep invocations in the assemble script. When bindep exits with code 2 (unparsable content), the script now outputs an error message and exits with code 2, providing clear feedback about invalid bindep.txt syntax.

Exit codes 0 (success) and 1 (dependencies not satisfied) continue to be handled normally and do not cause build failures.

Includes integration test with invalid bindep.txt to verify the error detection and reporting behavior.

Fixes: #798 