### PR TITLE
Fix logging summary of failed commands

### DIFF
--- a/src/ansible_builder/utils.py
+++ b/src/ansible_builder/utils.py
@@ -89,11 +89,13 @@ def run_command(command, capture_output=False, allow_error=False):
 
             rc = process.wait()
             if rc is not None and rc != 0 and (not allow_error):
-                main_logger = logging.getLogger('ansible_builder')
-                if main_logger.level > logging.INFO:
+                # Show command that had error if logging level is -v (WARNING) (already shown at higher logging)
+                if logging.root.level > logging.INFO:
                     logger.error('Command that had error:')
                     logger.error('  %s', ' '.join(command))
-                if main_logger.level > logging.DEBUG:
+                # Show error summary with -v (WARNING) or -vv (INFO) verbosity. We expect -vvv (DEBUG) will have
+                # the full output, so a summary shouldn't be necessary.
+                if logging.root.level > logging.DEBUG:
                     if capture_output:
                         for line in output:
                             logger.error(line)
@@ -104,7 +106,7 @@ def run_command(command, capture_output=False, allow_error=False):
                         for line in trailing_output:
                             logger.error(line)
                         logger.error('')
-                logger.error("An error occurred (rc=%s), see output line(s) above for details.", rc)
+                logger.error("An error occurred (rc=%s). Use -vvv for full details.", rc)
                 sys.exit(1)
 
             return rc, output

--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -349,6 +349,44 @@ def test_missing_runner(cli, runtime, ee_tag, data_dir, tmp_path):
 
 
 @pytest.mark.test_all_runtimes
+def test_target_script_logging_summary(cli, runtime, ee_tag, data_dir, tmp_path):
+    """
+    Test that the error summary output is correct at each logging level.
+    """
+    ee_def = data_dir / 'v3' / 'check_ansible' / 'ee-missing-runner.yml'
+
+    # Logging level -v should have a summary and the command in error
+    with pytest.raises(subprocess.CalledProcessError) as einfo:
+        cli(
+            f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} '
+            f'--container-runtime={runtime} -v'
+        )
+    assert "Command that had error" in einfo.value.stdout
+    assert "showing last 20 lines of output" in einfo.value.stdout
+    assert "An error occurred (rc=1). Use -vvv for full details." in einfo.value.stdout
+
+    # Logging level -vv should have a summary but not the command in error
+    with pytest.raises(subprocess.CalledProcessError) as einfo:
+        cli(
+            f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} '
+            f'--container-runtime={runtime} -vv'
+        )
+    assert "Command that had error" not in einfo.value.stdout
+    assert "showing last 20 lines of output" in einfo.value.stdout
+    assert "An error occurred (rc=1). Use -vvv for full details." in einfo.value.stdout
+
+    # Logging level -vvv should not have a summary
+    with pytest.raises(subprocess.CalledProcessError) as einfo:
+        cli(
+            f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} '
+            f'--container-runtime={runtime} -vvv'
+        )
+    assert "Command that had error" not in einfo.value.stdout
+    assert "showing last 20 lines of output" not in einfo.value.stdout
+    assert "An error occurred (rc=1). Use -vvv for full details." in einfo.value.stdout
+
+
+@pytest.mark.test_all_runtimes
 def test_bad_ansible_cfg(cli, runtime, ee_tag, data_dir, tmp_path):
     """
     Test that the check_galaxy script will cause build failure with


### PR DESCRIPTION
The logic to check the logging levels was incorrect after PR #727, thus we never got a proper summary of any failures of subprocess calls. This corrects the logic and restores the previous logging behavior.

- `-v`: show command that failed and last 20 lines of output
- `-vv`: show last 20 lines of output (also the default) (command that failed already logged elsewhere)
- `-vvv`: show all output, but not the summary

Example output with `-v`:
```
$ ansible-builder build -t junk:latest -v
Command that had error:
  podman build -f context/Containerfile -t junk:latest context
...showing last 20 lines of output...
+ '[' 127 -ne 0 ']'
+ cat
**********************************************************************
ERROR - 'ansible-galaxy' command not functioning as expected

  There was an error running the 'ansible-galaxy' command. Some
  possible causes are 'ansible-core' missing from the base image, an
  incorrect 'ansible.cfg', or 'ansible-galaxy' not being available to
  the selected Python interpreter. Please use the -vvv option to
  examine the build output for any errors.

  Ansible must be installed in the base image. If you are using a
  recent enough version of the execution environment file, you may
  use the 'dependencies.ansible_core' configuration option to install
  Ansible for you, or use 'additional_build_steps' to manually do
  this yourself. Alternatively, use a base image with Ansible already
  installed.
**********************************************************************
+ exit 1
Error: building at STEP "RUN /output/scripts/check_galaxy": while running runtime: exit status 1

An error occurred (rc=1). Use -vvv for full details.
```

Example output with `-vv`:
```
$ ansible-builder build -t junk:latest -vv
Running command:
  podman build -f context/Containerfile -t junk:latest context
...showing last 20 lines of output...
+ '[' 127 -ne 0 ']'
+ cat
**********************************************************************
ERROR - 'ansible-galaxy' command not functioning as expected

  There was an error running the 'ansible-galaxy' command. Some
  possible causes are 'ansible-core' missing from the base image, an
  incorrect 'ansible.cfg', or 'ansible-galaxy' not being available to
  the selected Python interpreter. Please use the -vvv option to
  examine the build output for any errors.

  Ansible must be installed in the base image. If you are using a
  recent enough version of the execution environment file, you may
  use the 'dependencies.ansible_core' configuration option to install
  Ansible for you, or use 'additional_build_steps' to manually do
  this yourself. Alternatively, use a base image with Ansible already
  installed.
**********************************************************************
+ exit 1
Error: building at STEP "RUN /output/scripts/check_galaxy": while running runtime: exit status 1

An error occurred (rc=1). Use -vvv for full details.
```