### PR TITLE
Update RTD build image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@ formats:
   - pdf
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: '3.10'
+    python: '3.13'
 
 sphinx:
   builder: dirhtml


### PR DESCRIPTION
Ubuntu 20.04 build image is being deprecated.