### PR TITLE
remove deprecated Ubuntu image from RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ formats:
   - pdf
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: '3.10'
 


### PR DESCRIPTION
This change updates the Ubuntu image version in the readthedocs configuration from the deprecated 20.04 LTS to the latest LTS version. See https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/

Probably want to do this separately but I noticed that `build.tools.python` is an old version. The header of `docs/requirements.txt` also shows Python 3.9.