### PR TITLE
docs: use semantic RST roles throughout

### DIFF
--- a/docs/collection_metadata.rst
+++ b/docs/collection_metadata.rst
@@ -14,7 +14,7 @@ For Ansible Builder to find and install collection dependencies, those dependenc
 
 If you are a collection maintainer, make sure the controller-side dependencies are specified and :ref:`verified<verify_collection_metadata>`.
 
-We recommend you specify paths to dependency files in the ``meta/execution-environment.yml`` file.
+We recommend you specify paths to dependency files in the :file:`meta/execution-environment.yml` file.
 Here is an example of its content:
 
 .. code:: yaml
@@ -23,14 +23,14 @@ Here is an example of its content:
       python: meta/ee-requirements.txt  # List Python package requirements in the file
       system: meta/ee-bindep.txt  # List system package requirements in the file
 
-If the ``meta/execution-environment.yml`` file is not present, by default, Ansible Builder will expect the dependencies to be defined in:
+If the :file:`meta/execution-environment.yml` file is not present, by default, Ansible Builder will expect the dependencies to be defined in:
 
-* the ``requirements.txt`` file in the collection root directory for Python package requirements
-* the ``bindep.txt`` file in the collection root directory for system package requirements
+* the :file:`requirements.txt` file in the collection root directory for Python package requirements
+* the :file:`bindep.txt` file in the collection root directory for system package requirements
 
 .. note::
 
-  If your collection uses the ``requirements.txt`` or ``bindep.txt`` files in its root directory for anything else but its controller-side dependencies, for example, for listing testing requirements, make sure you use the ``meta/execution-environment.yml`` file to specify other dependency files for execution environment purposes.
+  If your collection uses the :file:`requirements.txt` or :file:`bindep.txt` files in its root directory for anything else but its controller-side dependencies, for example, for listing testing requirements, make sure you use the :file:`meta/execution-environment.yml` file to specify other dependency files for execution environment purposes.
 
 Dependency introspection
 ========================
@@ -38,7 +38,7 @@ Dependency introspection
 If any dependencies are given, the introspection is run by Ansible Builder so that the requirements are found before container image assembly.
 
 A user can see the introspection output during
-the builder intermediate phase using the ``build -v3`` option.
+the builder intermediate phase using the :command:`build -v3` option.
 
 .. _verify_collection_metadata:
 
@@ -65,7 +65,7 @@ Run the ``introspect`` command against your collection path:
 
     ansible-builder introspect COLLECTION_PATH
 
-The default collection path used by the ``ansible-galaxy`` command is ``~/.ansible/collections/``.
+The default collection path used by the :program:`ansible-galaxy` command is :file:`~/.ansible/collections/`.
 Read more about collection paths in the `Ansible configuration settings <https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#collections-paths>`_ guide.
 
 .. note::
@@ -88,7 +88,7 @@ For example, if you need to inspect the ``community.docker`` collection, the pat
 
   ansible_collections/community/docker
 
-Then, if the ``ansible_collection`` directory is in your home directory, you can run ``introspect`` with the following command:
+Then, if the :file:`ansible_collection` directory is in your home directory, you can run ``introspect`` with the following command:
 
 ::
 
@@ -101,10 +101,10 @@ Python Dependencies
 
 Ansible Builder combines all the Python requirements files from all collections into a single file.
 
-Certain package names are specifically *ignored* by ``ansible-builder``, meaning that Ansible Builder
+Certain package names are specifically *ignored* by :program:`ansible-builder`, meaning that Ansible Builder
 does not include them in the combined file of Python dependencies, even if a collection lists them as
 dependencies. These include test packages and packages that provide Ansible itself. The full list can
-be found in ``EXCLUDE_REQUIREMENTS`` in ``src/ansible_builder/_target_scripts/introspect.py``.
+be found in ``EXCLUDE_REQUIREMENTS`` in :file:`src/ansible_builder/_target_scripts/introspect.py`.
 
 If you need to include one of these ignored package names, use the ``--user-pip`` option of the
 ``introspect`` command to list it in the user requirements file. Packages supplied this way are

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,13 @@ extensions = [
 
 autosectionlabel_prefix_document = True
 
+# Environment variables referenced with :envvar: are defined externally
+# (OS, ansible-core, CLI conventions), so ignore nitpicky "target not found"
+# warnings for any envvar cross-reference.
+nitpick_ignore_regex = [
+    ('envvar', r'.*'),
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -3,9 +3,9 @@
 Execution environment definition
 ================================
 
-You define the content of your execution environment in a YAML file. By default, this file is called ``execution-environment.yml``
-or ``execution-environment.yaml``. This file tells Ansible Builder how to create the build instruction file
-(``Containerfile`` for Podman, ``Dockerfile`` for Docker) and build context for your container image.
+You define the content of your execution environment in a YAML file. By default, this file is called :file:`execution-environment.yml`
+or :file:`execution-environment.yaml`. This file tells Ansible Builder how to create the build instruction file
+(:file:`Containerfile` for Podman, :file:`Dockerfile` for Docker) and build context for your container image.
 
 .. note::
    This page documents the definition schema for Ansible Builder 3.x. If you are running an older version of Ansible Builder, you need an older schema version. Please consult older versions of the docs for more information. We recommend using version 3, which is more configurable and functional than previous versions.
@@ -129,15 +129,15 @@ Each list item must be a dictionary containing the following (non-optional) keys
 
     ``src``
       Specifies the source file(s) to copy into the build context directory. This
-      may either be an absolute path (e.g., ``/home/user/.ansible.cfg``),
+      may either be an absolute path (e.g., :file:`/home/user/.ansible.cfg`),
       or a path that is relative to the execution environment file. Relative paths may be
-      a glob expression matching one or more files (e.g. ``files/*.cfg``). Note
+      a glob expression matching one or more files (e.g. :file:`files/*.cfg`). Note
       that an absolute path may *not* include a regular expression. If ``src`` is
       a directory, the entire contents of that directory are copied to ``dest``.
 
     ``dest``
-      Specifies a subdirectory path underneath the ``_build`` subdirectory of the
-      build context directory that should contain the source file(s) (e.g., ``files/configs``).
+      Specifies a subdirectory path underneath the :file:`_build` subdirectory of the
+      build context directory that should contain the source file(s) (e.g., :file:`files/configs`).
       This may not be an absolute path or contain ``..`` within the path. This directory
       will be created for you if it does not exist.
 
@@ -148,9 +148,9 @@ additional_build_steps
 
 Specifies custom build commands for any build phase.
 These commands will be inserted directly into the build instruction file for the
-container runtime (e.g., `Containerfile` or `Dockerfile`). The commands must conform to any rules required by the containerization tool.
+container runtime (e.g., :file:`Containerfile` or :file:`Dockerfile`). The commands must conform to any rules required by the containerization tool.
 
-You can add build steps before or after any stage of the image creation process. For example, if you need ``git`` to be installed before you install your dependencies, you can add a build step at the end of the ``base`` build stage.
+You can add build steps before or after any stage of the image creation process. For example, if you need :program:`git` to be installed before you install your dependencies, you can add a build step at the end of the ``base`` build stage.
 
 Below are the valid keys for this section. Each supports either a multi-line
 string, or a list of strings.
@@ -191,18 +191,18 @@ build_arg_defaults
 Specifies default values for build args as a dictionary. This is an alternative
 to using the :ref:`build-arg` CLI flag.
 
-Build args used by ``ansible-builder`` are the following:
+Build args used by :program:`ansible-builder` are the following:
 
     ``ANSIBLE_GALAXY_CLI_COLLECTION_OPTS``
-      This allows the user to pass the `--pre` flag (or others) to enable the installation of pre-release collections.
+      This allows the user to pass the ``--pre`` flag (or others) to enable the installation of pre-release collections.
 
     ``ANSIBLE_GALAXY_CLI_ROLE_OPTS``
-      This allows the user to pass any flags, such as `--no-deps`, to the role installation.
+      This allows the user to pass any flags, such as ``--no-deps``, to the role installation.
 
     ``PKGMGR_PRESERVE_CACHE``
       This controls how often the package manager cache is cleared during the image build process.
       If this value is not set, which is the default, the cache is cleared frequently.
-      If it is set to the string `always`, the cache is never cleared.
+      If it is set to the string ``always``, the cache is never cleared.
       Any other value forces the cache to be cleared only after the system dependencies are installed
       in the final build stage.
 
@@ -218,15 +218,15 @@ dependencies
 
 Specifies dependencies to install into the final image, including ``ansible-core``, ``ansible-runner``, Python packages, system packages, and Ansible Collections. Ansible Builder automatically installs dependencies for any Ansible Collections you install.
 
-In general, you can use standard syntax to constrain package versions. Use the same syntax you would pass to ``dnf``, ``pip``, ``ansible-galaxy``, or any other package management utility. You can also define your packages or collections in separate files and reference those files in the ``dependencies`` section of your execution environment definition file.
+In general, you can use standard syntax to constrain package versions. Use the same syntax you would pass to :program:`dnf`, :program:`pip`, :program:`ansible-galaxy`, or any other package management utility. You can also define your packages or collections in separate files and reference those files in the ``dependencies`` section of your execution environment definition file.
 
 The following keys are valid for this section:
 
     ``ansible_core``
       The version of the ``ansible-core`` Python package to be installed. This value is
       a dictionary with a single key, ``package_pip``. The ``package_pip`` value
-      is passed directly to `pip` for installation and can be in any format that
-      pip supports. Below are some example values:
+      is passed directly to :program:`pip` for installation and can be in any format that
+      :program:`pip` supports. Below are some example values:
 
       .. code:: yaml
 
@@ -240,8 +240,8 @@ The following keys are valid for this section:
     ``ansible_runner``
       The version of the Ansible Runner Python package to be installed. This value
       is a dictionary with a single key, ``package_pip``. The ``package_pip`` value
-      is passed directly to `pip` for installation and can be in any format that
-      pip supports. Below are some example values:
+      is passed directly to :program:`pip` for installation and can be in any format that
+      :program:`pip` supports. Below are some example values:
 
       .. code:: yaml
 
@@ -274,7 +274,7 @@ The following keys are valid for this section:
 
     ``python_interpreter``
       A dictionary that defines the Python system package name to be installed by
-      ``dnf`` (``package_system``) and/or a path to the Python interpreter to be used
+      :program:`dnf` (``package_system``) and/or a path to the Python interpreter to be used
       (``python_path``).
 
     ``system``
@@ -389,22 +389,22 @@ Valid keys for this section are:
 
 image verification
 """"""""""""""""""
-You can verify signed container images if you are using the ``podman`` container
+You can verify signed container images if you are using the :program:`podman` container
 runtime. Set the :ref:`container-policy` CLI option to control how this data is used with a Podman
 `policy.json <https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md>`_
 file for container image signature validation.
 
-  * ``ignore_all`` policy: Generate a `policy.json` file in the build
+  * ``ignore_all`` policy: Generate a :file:`policy.json` file in the build
     :ref:`context directory <context>` where no signature validation is
     performed.
 
   * ``system`` policy: Signature validation is performed using pre-existing
-    `policy.json` files in standard system locations. ``ansible-builder`` assumes
+    :file:`policy.json` files in standard system locations. :program:`ansible-builder` assumes
     no responsibility for the content within these files, and the user has complete
     control over the content.
 
-  * ``signature_required`` policy: ``ansible-builder`` will use the container
-    image definitions here to generate a `policy.json` file in the build
+  * ``signature_required`` policy: :program:`ansible-builder` will use the container
+    image definitions here to generate a :file:`policy.json` file in the build
     :ref:`context directory <context>` that will be used during the build to
     validate the images.
 
@@ -431,7 +431,7 @@ builder runtime functionality. Valid keys for this section are:
         Literal value for the ``ENTRYPOINT`` Containerfile directive. The
         default entrypoint behavior handles signal propagation to subprocesses, as well as attempting to
         ensure at runtime that the container user has a proper environment with a valid writeable
-        home directory, represented in ``/etc/passwd``, with the ``HOME`` envvar set to match. The default
+        home directory, represented in :file:`/etc/passwd`, with the :envvar:`HOME` envvar set to match. The default
         entrypoint script may emit warnings to ``stderr`` in cases where it is unable to suitably adjust the
         user runtime environment. This behavior can be ignored or elevated to a fatal error; consult the
         source for the ``entrypoint`` target script for more details. The default value is
@@ -442,17 +442,17 @@ builder runtime functionality. Valid keys for this section are:
         The default value is ``dumb-init==1.2.5``.
 
     ``package_manager_path``
-      A string with the path to the package manager to use. The default is ``/usr/bin/dnf``.
+      A string with the path to the package manager to use. The default is :file:`/usr/bin/dnf`.
 
       This option allows you to choose between different RPM package managers available on
-      your base image, such as ``/usr/bin/dnf`` or ``/usr/bin/microdnf``. The package manager
+      your base image, such as :file:`/usr/bin/dnf` or :file:`/usr/bin/microdnf`. The package manager
       is used to install system packages, and if specified in ``dependencies``, to install
       a Python interpreter during the build phase.
 
       .. warning::
 
-          Only RPM-based package managers (for example, ``dnf`` or ``microdnf``) are supported. Non-RPM package
-          managers such as ``apt-get`` (Debian/Ubuntu) or ``apk`` (Alpine) are not supported and will
+          Only RPM-based package managers (for example, :program:`dnf` or :program:`microdnf`) are supported. Non-RPM package
+          managers such as :program:`apt-get` (Debian/Ubuntu) or :program:`apk` (Alpine) are not supported and will
           cause build failures.
 
     ``skip_ansible_check``
@@ -469,19 +469,19 @@ builder runtime functionality. Valid keys for this section are:
 
     ``relax_passwd_permissions``
       This boolean value controls whether the ``root`` group (GID 0) is explicitly granted
-      write permission to ``/etc/passwd`` in the final container image. The default entrypoint
-      script may attempt to update ``/etc/passwd`` under some container runtimes with dynamically
+      write permission to :file:`/etc/passwd` in the final container image. The default entrypoint
+      script may attempt to update :file:`/etc/passwd` under some container runtimes with dynamically
       created users to ensure a fully functional POSIX user environment and home directory. Disabling
       this capability can cause failures of software features that require users to be listed in
-      ``/etc/passwd`` with a valid and writeable home directory (eg, ``async`` in ansible-core, and the
+      :file:`/etc/passwd` with a valid and writeable home directory (eg, ``async`` in ansible-core, and the
       ``~username`` shell expansion). The default is ``True``.
 
     ``workdir``
       Default current working directory for new processes started under the final container
-      image. Some container runtimes also use this value as ``HOME`` for dynamically-created
+      image. Some container runtimes also use this value as :envvar:`HOME` for dynamically-created
       users in the ``root`` (GID 0) group. When this value is specified, the directory will be
       created (if it doesn't already exist), set to ``root`` group ownership, and ``rwx`` group
-      permissions recursively applied to it. The default value is ``/runner``.
+      permissions recursively applied to it. The default value is :file:`/runner`.
 
     ``user``
       This sets the username or UID to use as the default user for the final container image.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@
 Introduction to Ansible Builder
 *******************************
 
-With ``ansible-builder`` you can configure and build portable, consistent, customized Ansible control nodes that are packaged as containers by Podman or Docker.
+With :program:`ansible-builder` you can configure and build portable, consistent, customized Ansible control nodes that are packaged as containers by Podman or Docker.
 These containers are known as execution environments. You can use them on AWX or Ansible Controller, with Ansible Navigator, for local playbook development and testing, in your CI pipelines, and anywhere else you run automation.
 
 You can design and distribute specialized execution environments for your Ansible content, choosing the versions of Python and
@@ -28,7 +28,7 @@ Ansible Builder depends on more generalized containerization tools like Podman o
 
 Before you start using Ansible Builder, you should understand the following concepts and terms relevant to any use of containers:
 
-- **Build instruction file** (called a ``Containerfile`` in Podman and a ``Dockerfile`` in Docker): an instruction file for creating a container image by installing and configuring the code and dependencies.
+- **Build instruction file** (called a :file:`Containerfile` in Podman and a :file:`Dockerfile` in Docker): an instruction file for creating a container image by installing and configuring the code and dependencies.
 - **Container**: a package of code and dependencies that runs a service or an application across a variety of computing environments.
 - **Image**: a complete but inactive version of a container - you can distribute images and create one or more containers based on each image.
 
@@ -40,10 +40,10 @@ Refer to the `Getting started with Execution Environments guide <https://docs.an
 Quickstart for Ansible Builder
 ==============================
 
-To get started with Ansible Builder, you must install the ``ansible-builder`` utility and a containerization tool.
+To get started with Ansible Builder, you must install the :program:`ansible-builder` utility and a containerization tool.
 
 Once you have the tools you need, create an :ref:`execution environment definition <builder_ee_definition>` file.
-By default, this file is called ``execution-environment.yml`` (the ``.yaml`` extension is also accepted).
+By default, this file is called :file:`execution-environment.yml` (the ``.yaml`` extension is also accepted).
 In the execution environment definition file, you can specify the exact content you want to include in your
 execution environment. You can specify these items:
 
@@ -61,10 +61,10 @@ execution environment. You can specify these items:
 Choosing a base image
 =====================
 
-Ansible Builder requires RPM-based container images that use the ``dnf`` or ``microdnf`` package manager.
+Ansible Builder requires RPM-based container images that use the :program:`dnf` or :program:`microdnf` package manager.
 Non-RPM-based distributions (such as Debian, Ubuntu, or Alpine) are not supported and will fail to build.
 
-Ansible Builder's default configuration and internal tooling assume the use of ``dnf`` package management, which is present
+Ansible Builder's default configuration and internal tooling assume the use of :program:`dnf` package management, which is present
 on RPM-based Linux distributions. The following are examples of images that should work with Ansible Builder:
 
 - **CentOS Stream**: ``quay.io/centos/centos:stream9``
@@ -73,7 +73,7 @@ on RPM-based Linux distributions. The following are examples of images that shou
 - **Red Hat Universal Base Image (UBI)**: ``registry.access.redhat.com/ubi9/ubi:latest``
 - **RHEL-based Ansible Automation Platform images**: ``registry.redhat.io/ansible-automation-platform-*/ee-*``
 
-The examples above demonstrate compatible images, but any RPM-based image with ``dnf`` or ``microdnf`` should work.
+The examples above demonstrate compatible images, but any RPM-based image with :program:`dnf` or :program:`microdnf` should work.
 
 When choosing a base image, prefer smaller images when possible, as they result in smaller final execution environment
 images. However, ensure you understand what packages are already installed on the base image to avoid redundant installations.
@@ -84,18 +84,18 @@ How Ansible Builder executes
 
 Ansible Builder can execute two separate steps:
 
-- The first step is to create a build instruction file (``Containerfile`` for Podman, ``Dockerfile`` for Docker) and a build context based on the execution environment definition file.
+- The first step is to create a build instruction file (:file:`Containerfile` for Podman, :file:`Dockerfile` for Docker) and a build context based on the execution environment definition file.
 - The second step is to run a containerization tool (Podman or Docker) to build an image based on the build instruction file and build context.
 
-The ``ansible-builder build`` command runs both steps.
+The :command:`ansible-builder build` command runs both steps.
 
-The ``ansible-builder create`` command runs only the first step. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
+The :command:`ansible-builder create` command runs only the first step. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
 
 How Ansible Builder builds images
 ---------------------------------
 
 Ansible Builder executes four stages when it runs your containerization tool to build a container image.
-The same four stages get executed if you build your container image directly with Podman or Docker, using a build instruction file and context generated by ``ansible-builder create``. These stages are:
+The same four stages get executed if you build your container image directly with Podman or Docker, using a build instruction file and context generated by :command:`ansible-builder create`. These stages are:
 
 1. **Base**: uses Podman or Docker to pull the base image you defined, then installs the Python version (if defined and different from any Python on the base image), pip, ansible-runner, and ansible-core or ansible. All three later stages of the build process build on the output of the Base stage.
 2. **Galaxy**: downloads the collections you defined from Galaxy and stashes them locally as files.
@@ -105,7 +105,7 @@ The same four stages get executed if you build your container image directly wit
 Ansible Builder injects hooks at each stage of the container build process so you can add custom steps before and after every build stage.
 
 You may need to install certain packages or utilities before the Galaxy and Builder stages.
-For example, if you need to install a collection from GitHub, you must install git after the Base stage to make it available during the Galaxy stage.
+For example, if you need to install a collection from GitHub, you must install :program:`git` after the Base stage to make it available during the Galaxy stage.
 
 To add custom build steps, add an ``additional_build_steps`` section to your execution environment definition. For more details, read through the :ref:`CLI usage docs <builder_cli>`.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,14 +9,14 @@ Installation
 Requirements
 ************
 
-- To build images, you must install a containerization tool - either ``podman`` or ``docker`` - as well as the ``ansible-builder`` Python package.
+- To build images, you must install a containerization tool - either :program:`podman` or :program:`docker` - as well as the ``ansible-builder`` Python package.
 - The ``--container-runtime`` option must correspond to the containerization tool you use.
 - ``ansible-builder`` version ``3.x`` requires Python ``3.9`` or higher.
 
 Base Image Requirements
 ************************
 
-Ansible Builder requires RPM-based container images (those using ``dnf`` or ``microdnf`` package management) as the base for execution environments. Non-RPM-based distributions such as Debian, Ubuntu, or Alpine are not supported.
+Ansible Builder requires RPM-based container images (those using :program:`dnf` or :program:`microdnf` package management) as the base for execution environments. Non-RPM-based distributions such as Debian, Ubuntu, or Alpine are not supported.
 
 For detailed information about choosing an appropriate base image and a list of images that should work, see the :ref:`choosing_base_image` section.
 

--- a/docs/porting_guides/porting_guide_v3.0.rst
+++ b/docs/porting_guides/porting_guide_v3.0.rst
@@ -31,7 +31,7 @@ additional_build_files
 ^^^^^^^^^^^^^^^^^^^^^^
 
 This is a new configuration that can be used to specify files to be added to the build context directory.
-These can then be referenced or copied by `additional_build_steps` during any build stage.
+These can then be referenced or copied by ``additional_build_steps`` during any build stage.
 
 See the :ref:`additional_build_files <additional_build_files>` section for more details.
 
@@ -40,7 +40,7 @@ additional_build_steps
 
 With Ansible Builder 3, you can specify more fine-grained build steps or custom commands for any build phase.
 These commands will be inserted directly into the build instruction file for the
-container runtime (For example, `Containerfile` or `Dockerfile`). The commands must conform to any rules required by the containerization tool.
+container runtime (For example, :file:`Containerfile` or :file:`Dockerfile`). The commands must conform to any rules required by the containerization tool.
 
 These are additional build steps -
 
@@ -60,7 +60,7 @@ dependencies
 
 Specifies dependencies to install into the final image, including ``ansible-core``, ``ansible-runner``, Python packages, system packages, and Ansible Collections. Ansible Builder automatically installs dependencies for any Ansible Collections you install.
 
-In general, you can use standard syntax to constrain package versions. Use the same syntax you would pass to ``dnf``, ``pip``, ``ansible-galaxy``, or any other package management utility. You can also define your packages or collections in separate files and reference those files in the ``dependencies`` section of your execution environment definition file.
+In general, you can use standard syntax to constrain package versions. Use the same syntax you would pass to :program:`dnf`, :program:`pip`, :program:`ansible-galaxy`, or any other package management utility. You can also define your packages or collections in separate files and reference those files in the ``dependencies`` section of your execution environment definition file.
 
 The following keys are valid for this section:
 
@@ -82,7 +82,7 @@ See the :ref:`images <images>` section for more details.
 
 image verification
 """"""""""""""""""
-You can verify signed container images if you are using the ``podman`` container
+You can verify signed container images if you are using the :program:`podman` container
 runtime.
 
 See the :ref:`image verification <image_verification>` section for more details.

--- a/docs/porting_guides/porting_guide_v3.1.rst
+++ b/docs/porting_guides/porting_guide_v3.1.rst
@@ -6,7 +6,7 @@ This section discusses the behavioral changes between ``ansible-builder`` versio
 
 .. note::
 
-    We highly advise running ``ansible-builder`` with increased verbosity using the ``-vvv`` option (``--v3`` for
+    We highly advise running :program:`ansible-builder` with increased verbosity using the ``-vvv`` option (``--v3`` for
     versions older than 3.1) to fully expose any error messages that may help in diagnosing any problems.
 
 .. contents:: Topics
@@ -26,8 +26,8 @@ Builder will *expect* the requirements file to be in this format, but it makes t
 
 #. Comments (lines beginning with ``#``) are ignored.
 #. Any line from the requirements file that is not compliant with PEP508 causes a warning to be emitted and
-   the line passed through to ``pip`` unmodified. It is not recommended to depend on this behavior, as
-   it can change suddenly between ``pip`` releases, and can cause other problems with dependency resolution.
+   the line passed through to :program:`pip` unmodified. It is not recommended to depend on this behavior, as
+   it can change suddenly between :program:`pip` releases, and can cause other problems with dependency resolution.
 
 The passthrough of non-PEP508 compliant lines may expose issues that were hidden by the
 version 3.0 dependency sanitizer, which often silently ignored and removed them.
@@ -35,11 +35,11 @@ version 3.0 dependency sanitizer, which often silently ignored and removed them.
 Dependency Sanitization
 -----------------------
 
-Dependency sanitization (the combining of duplicate dependencies into a single dependency entry) is no longer performed by ``ansible-builder``.
+Dependency sanitization (the combining of duplicate dependencies into a single dependency entry) is no longer performed by :program:`ansible-builder`.
 
 .. note::
 
-    The ``--sanitize`` option to the ``ansible-builder introspect`` command still exists, but is now undocumented
+    The ``--sanitize`` option to the :command:`ansible-builder introspect` command still exists, but is now undocumented
     and does nothing.
 
 The effect of this change is that builder will now pass a listed dependency multiple times for each requirement file
@@ -59,7 +59,7 @@ file as separate entries:
     foo  # from collection A
     foo>=1.0  # from collection B
 
-If your container image has an older version of ``pip``, this change might cause an error during the image build
+If your container image has an older version of :program:`pip`, this change might cause an error during the image build
 process. This guide covers how to deal with this situation below.
 
 Common Issues
@@ -71,7 +71,7 @@ ERROR: Double requirement given
 -------------------------------
 
 Because dependency sanitization has been removed, *all* Python requirements from included collections and user
-requirement files are passed along to the ``pip`` command that installs those requirements. Due to this change,
+requirement files are passed along to the :program:`pip` command that installs those requirements. Due to this change,
 the image build may exit abnormally with an error similar to the following:
 
 ::
@@ -79,12 +79,12 @@ the image build may exit abnormally with an error similar to the following:
     ERROR: Double requirement given: netaddr>=0.10.1 (from -r /tmp/src/requirements.txt (line 13)) (already in netaddr (from -r /tmp/src/requirements.txt (line 4)), name='netaddr')
     Error: building at STEP "RUN /output/scripts/assemble": while running runtime: exit status 1
 
-This error comes from ``pip`` within one of the intermediate container images when attempting to install the Python
+This error comes from :program:`pip` within one of the intermediate container images when attempting to install the Python
 requirements from included collections and/or from the user supplied requirements. This intermediate image is based
-on the base image defined within the Execution Environment file, and it means that the version of ``pip`` installed
+on the base image defined within the Execution Environment file, and it means that the version of :program:`pip` installed
 within that image is too old to handle duplicate requirement entries.
 
-To determine where the duplicate requirements are coming from, run ``ansible-builder`` with the ``-vvv`` option
+To determine where the duplicate requirements are coming from, run :program:`ansible-builder` with the ``-vvv`` option
 to get more verbose output, then look for the output from the introspection phase. It will look similar to:
 
 ::
@@ -99,9 +99,9 @@ to get more verbose output, then look for the output from the introspection phas
 In the example output above, the double Python requirement for ``netaddr`` is coming from the collections
 ``ansible.netcommon`` and ``ansible.utils``.
 
-The solution requires upgrading ``pip`` within the base image to a version that contains an updated dependency resolver.
-Beginning with ``pip`` version 20.3, the dependency resolver can handle duplicate requirements whose versions do not
-conflict, so that version is the minimum required. Upgrade ``pip`` in the base image from within the Execution
+The solution requires upgrading :program:`pip` within the base image to a version that contains an updated dependency resolver.
+Beginning with :program:`pip` version 20.3, the dependency resolver can handle duplicate requirements whose versions do not
+conflict, so that version is the minimum required. Upgrade :program:`pip` in the base image from within the Execution
 Environment file by adding these lines to it:
 
 .. code-block:: yaml
@@ -110,8 +110,8 @@ Environment file by adding these lines to it:
       append_base:
         - RUN $PYCMD -m pip install -U pip
 
-That will upgrade ``pip`` to the latest version within the base image. To restrict the upgrade to a specific
-version of ``pip``, alter the upgrade command to specify that version. For example:
+That will upgrade :program:`pip` to the latest version within the base image. To restrict the upgrade to a specific
+version of :program:`pip`, alter the upgrade command to specify that version. For example:
 
 .. code-block:: yaml
 

--- a/docs/porting_guides/porting_guide_v3.2.rst
+++ b/docs/porting_guides/porting_guide_v3.2.rst
@@ -10,8 +10,8 @@ New Features
 Disabling Colorized Output
 --------------------------
 
-Colorized terminal output can be disabled by either setting the ``NO_COLOR`` environment variable to
-any non-empty value, or by setting the ``CLICOLOR`` environment variable to ``0``.
+Colorized terminal output can be disabled by either setting the :envvar:`NO_COLOR` environment variable to
+any non-empty value, or by setting the :envvar:`CLICOLOR` environment variable to ``0``.
 
 Behavior Changes
 ================
@@ -28,12 +28,12 @@ more information.
 Bindep Parse Error Detection
 ----------------------------
 
-This release adds improved error detection and reporting for invalid ``bindep.txt`` files.
-Previously, when ``bindep`` encountered unparsable content in a ``bindep.txt`` file, the build
+This release adds improved error detection and reporting for invalid :file:`bindep.txt` files.
+Previously, when :program:`bindep` encountered unparsable content in a :file:`bindep.txt` file, the build
 would continue and potentially fail later with unclear error messages. Now, the build will fail
-immediately with a clear error message when bindep reports a parse error.
+immediately with a clear error message when :program:`bindep` reports a parse error.
 
-When the ``bindep`` program exits with code 2 (indicating unparsable content in ``bindep.txt``),
+When the :program:`bindep` program exits with code 2 (indicating unparsable content in :file:`bindep.txt`),
 the build process will now:
 
 #. Stop immediately at the point where the parse error is detected
@@ -51,7 +51,7 @@ Deprecations
 ============
 
 Execution environment schema versions 1 and 2 are deprecated and scheduled to be removed from Ansible Builder 3.3.
-If you are currently using one of these versions, you will need to update your ``execution-environment.yml``
+If you are currently using one of these versions, you will need to update your :file:`execution-environment.yml`
 files to the :ref:`version 3 format <version_3_format>`.
 
 A warning about the deprecation is sent to the logging output of the ``create`` or ``build`` commands when

--- a/docs/scenario_guides/scenario_copy.rst
+++ b/docs/scenario_guides/scenario_copy.rst
@@ -12,13 +12,13 @@ In the example below, we will take a look at copying arbitrary files to an execu
 .. literalinclude:: copy_ee.yml
    :language: yaml
 
-In this example, the `additional_build_files` section allows you to add `rootCA.crt` to the build context directory.
+In this example, the ``additional_build_files`` section allows you to add :file:`rootCA.crt` to the build context directory.
 Once this file is copied to the build context directory, it can be used in the build process.
-In order to use, the file,  we need to copy it from the build context directory using  the `COPY` directive specified in
-the `prepend_base` step of `additional_build_steps` section.
+In order to use, the file,  we need to copy it from the build context directory using  the ``COPY`` directive specified in
+the ``prepend_base`` step of ``additional_build_steps`` section.
 
 Finally, you can perform any action based upon the copied file, such as in this example updating
-dynamic configuration of CA certificates by running `RUN update-ca-trust`.
+dynamic configuration of CA certificates by running ``RUN update-ca-trust``.
 
 .. seealso::
 

--- a/docs/scenario_guides/scenario_custom.rst
+++ b/docs/scenario_guides/scenario_custom.rst
@@ -16,12 +16,12 @@ In the example below, we will take a look at
    :language: yaml
 
 
-You can provide environment variables such as ``ANSIBLE_GALAXY_SERVER_LIST``, ``ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL`` and ``ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL`` using the ``ENV`` directive.
+You can provide environment variables such as :envvar:`ANSIBLE_GALAXY_SERVER_LIST`, :envvar:`ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_URL` and :envvar:`ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_AUTH_URL` using the ``ENV`` directive.
 See `configuring Galaxy client <https://docs.ansible.com/projects/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client>`_ for more details.
 
-For security reasons, we do not want to store sensitive information in this case `ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN`.
-You can use `ARG` directive to receive sensitive information from the user as input. `--build-args` can be used
-to provide this information while invoking the `ansible-builder` command.
+For security reasons, we do not want to store sensitive information in this case :envvar:`ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN`.
+You can use ``ARG`` directive to receive sensitive information from the user as input. ``--build-args`` can be used
+to provide this information while invoking the :program:`ansible-builder` command.
 
 .. seealso::
 

--- a/docs/scenario_guides/scenario_pip_check.rst
+++ b/docs/scenario_guides/scenario_pip_check.rst
@@ -6,8 +6,8 @@ dependencies installed when the final container image is built. This is especial
 important if you have excluded any external collection dependencies and manually
 specified any replacements.
 
-The ``pip`` utility includes a `check option <https://pip-python3.readthedocs.io/en/latest/reference/pip_check.html>`_
-that can perform this validation. When ``pip check`` is run, it will do the validation of the
+The :program:`pip` utility includes a `check option <https://pip-python3.readthedocs.io/en/latest/reference/pip_check.html>`_
+that can perform this validation. When :command:`pip check` is run, it will do the validation of the
 currently installed Python packages, and if any errors are identified, it will exit with a
 non-zero status. A good place to call this check is during the end of the final build phase, just
 after all dependencies have been installed. Add the code below to your execution
@@ -20,5 +20,5 @@ satisfied:
     append_final:
       - RUN $PYCMD -m pip check
 
-Using the ``$PYCMD -m pip`` calling form, instead of calling ``pip`` directly, will guarantee that the same
+Using the ``$PYCMD -m pip`` calling form, instead of calling :program:`pip` directly, will guarantee that the same
 Python executable that was used to install the Python packages is used to do the validation.

--- a/docs/scenario_guides/scenario_using_env.rst
+++ b/docs/scenario_guides/scenario_using_env.rst
@@ -6,15 +6,15 @@ Building EEs with environment variables
 Ansible Builder version 3 schema provides the option to specify environment variables that can be used in the build process.
 See :ref:`version 3 schema <version_3_format>` for more details.
 
-In the example below, we will take a look at specifying `ENV` variables.
+In the example below, we will take a look at specifying ``ENV`` variables.
 
 
 .. literalinclude:: env_ee.yml
    :language: yaml
 
 In this example, we are specifying an environment variable that may be required for the build process.
-In order to achieve this functionality we are using the `ENV` variable
-definition in the ``prepend_base`` step of the `additional_build_steps` section.
+In order to achieve this functionality we are using the ``ENV`` variable
+definition in the ``prepend_base`` step of the ``additional_build_steps`` section.
 
 We can use the same environment variable in the later stage of the build process.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,12 +3,12 @@
 CLI Usage
 =========
 
-Ansible Builder can execute two separate steps. The first step is to create a build instruction file (Containerfile for Podman, Dockerfile for Docker) and a build context based on your :ref:`definition <builder_ee_definition>` file. The second step is to run a containerization tool (Podman or Docker) to build an image based on the build instruction file and build context. The ``ansible-builder build`` command executes both steps, giving you a build instruction file, a build context, and a fully built container image. The ``ansible-builder create`` command only executes the first step, giving you a build instruction file and a build context. If you use ``ansible-builder create``, you can use the resulting build instruction file and build context to build your container images on the platform of your choice.
+Ansible Builder can execute two separate steps. The first step is to create a build instruction file (:file:`Containerfile` for Podman, :file:`Dockerfile` for Docker) and a build context based on your :ref:`definition <builder_ee_definition>` file. The second step is to run a containerization tool (Podman or Docker) to build an image based on the build instruction file and build context. The :command:`ansible-builder build` command executes both steps, giving you a build instruction file, a build context, and a fully built container image. The :command:`ansible-builder create` command only executes the first step, giving you a build instruction file and a build context. If you use :command:`ansible-builder create`, you can use the resulting build instruction file and build context to build your container images on the platform of your choice.
 
 .. note::
 
-   Ansible Builder is colorized by default when outputting to a terminal. Color output can be disabled by setting the ``NO_COLOR`` environment variable to any non-empty value,
-   or by setting the ``CLICOLOR`` environment variable to ``0``.
+   Ansible Builder is colorized by default when outputting to a terminal. Color output can be disabled by setting the :envvar:`NO_COLOR` environment variable to any non-empty value,
+   or by setting the :envvar:`CLICOLOR` environment variable to ``0``.
 
 
 .. contents::
@@ -17,14 +17,14 @@ Ansible Builder can execute two separate steps. The first step is to create a bu
 The ``build`` command
 ---------------------
 
-The ``ansible-builder build`` command:
+The :command:`ansible-builder build` command:
 
 * takes an :ref:`execution environment definition file<builder_ee_definition>` as an input,
-* outputs a build instruction file (Containerfile for Podman, Dockerfile for Docker),
+* outputs a build instruction file (:file:`Containerfile` for Podman, :file:`Dockerfile` for Docker),
 * creates a build context necessary for building an execution environment image,
 * builds the image.
 
-By default, it looks for a file named ``execution-environment.yml`` (or ``execution-environment.yaml``) in the current directory.
+By default, it looks for a file named :file:`execution-environment.yml` (or :file:`execution-environment.yaml`) in the current directory.
 
 To build an execution environment using the default definition file, run:
 
@@ -49,7 +49,7 @@ Customizes the tagged name applied to the built image. To create an image with a
 
    $ ansible-builder build --tag=my-custom-ee
 
-More recent versions of ``ansible-builder`` support multiple tags:
+More recent versions of :program:`ansible-builder` support multiple tags:
 
 .. code::
 
@@ -67,7 +67,7 @@ Specifies the execution environment file. To use a file other than the default:
 ``--galaxy-keyring``
 ********************
 
-Specifies a keyring for ``ansible-galaxy`` to use to verify collection signatures during installation. To verify collection signatures:
+Specifies a keyring for :program:`ansible-galaxy` to use to verify collection signatures during installation. To verify collection signatures:
 
 .. code::
 
@@ -79,7 +79,7 @@ If you do not pass this option, no signature verification is performed. If you d
 ``--galaxy-ignore-signature-status-code``
 *****************************************
 
-Ignores certain errors that may occur while verifying collections. This option is passed unmodified to ``ansible-galaxy`` calls. Valid only when ``--galaxy-keyring`` is also set. See the ``ansible-galaxy`` documentation for more information.
+Ignores certain errors that may occur while verifying collections. This option is passed unmodified to :program:`ansible-galaxy` calls. Valid only when ``--galaxy-keyring`` is also set. See the :program:`ansible-galaxy` documentation for more information.
 
 .. code::
 
@@ -89,7 +89,7 @@ Ignores certain errors that may occur while verifying collections. This option i
 ``--galaxy-required-valid-signature-count``
 *******************************************
 
-Overrides the number of required valid collection signatures. This option is passed unmodified to ``ansible-galaxy`` calls. Valid only when ``--galaxy-keyring`` is also set. See the ``ansible-galaxy`` documentation for more information.
+Overrides the number of required valid collection signatures. This option is passed unmodified to :program:`ansible-galaxy` calls. Valid only when ``--galaxy-keyring`` is also set. See the :program:`ansible-galaxy` documentation for more information.
 
 .. code::
 
@@ -102,7 +102,7 @@ Overrides the number of required valid collection signatures. This option is pas
 ``--context``
 *************
 
-Specifies the directory name for the build context Ansible Builder creates. Default directory name is ``context`` in the current working directory. To specify another location:
+Specifies the directory name for the build context Ansible Builder creates. Default directory name is :file:`context` in the current working directory. To specify another location:
 
 .. code::
 
@@ -114,9 +114,9 @@ Specifies the directory name for the build context Ansible Builder creates. Defa
 ``--build-arg``
 ***************
 
-Passes build-time arguments to Podman or Docker. Specify these flags or variables the same way you would with ``podman build`` or ``docker build``.
+Passes build-time arguments to Podman or Docker. Specify these flags or variables the same way you would with :command:`podman build` or :command:`docker build`.
 
-By default, the Containerfile / Dockerfile created by Ansible Builder contains a build argument ``EE_BASE_IMAGE``, which can be useful for rebuilding execution environments without modifying any files.
+By default, the :file:`Containerfile` / :file:`Dockerfile` created by Ansible Builder contains a build argument ``EE_BASE_IMAGE``, which can be useful for rebuilding execution environments without modifying any files.
 
 .. code::
 
@@ -154,12 +154,12 @@ Specifies the containerization tool used to build images. Default is Podman. To 
 
 .. note:: Added in version 1.2
 
-Specifies the container image validation policy to use. Valid only when :ref:`container-runtime` is ``podman``. Valid values are one of:
+Specifies the container image validation policy to use. Valid only when :ref:`container-runtime` is :program:`podman`. Valid values are one of:
 
-* ``ignore_all``: Run podman with generated policy that ignores all signatures.
-* ``system``: Relies on podman's consumption of system policy/signature with
+* ``ignore_all``: Run :program:`podman` with generated policy that ignores all signatures.
+* ``system``: Relies on :program:`podman`'s consumption of system policy/signature with
   inline keyring paths. No builder-specific overrides are possible.
-* ``signature_required``: Run podman with ``--pull-always`` and a generated
+* ``signature_required``: Run :program:`podman` with ``--pull-always`` and a generated
    policy that rejects all by default, with generated identity requirements for
    referenced container images, using an explicitly-provided keyring (specified
    with the :ref:`container-keyring` CLI option).
@@ -181,9 +181,9 @@ Specifies the path to a GPG keyring file to use for validating container image s
 .. note:: Added in version 3.1
 
 This option allows the user to pass any additional command line arguments to the container engine
-build command (``docker build`` or ``podman build``). Take care when using this option as there is
+build command (:command:`docker build` or :command:`podman build`). Take care when using this option as there is
 no attempt to identify or resolve conflicting argument values from this option and arguments
-normally added by ``ansible-builder``.
+normally added by :program:`ansible-builder`.
 
 .. code::
 
@@ -220,7 +220,7 @@ Removes unused images created after the build process:
 
 .. note::
 
-   This flag removes all the dangling images on the given machine whether they already existed or were created by ``ansible-builder`` build process.
+   This flag removes all the dangling images on the given machine whether they already existed or were created by :program:`ansible-builder` build process.
 
 
 ``--squash``
@@ -236,20 +236,20 @@ Controls the final image layer squashing. Valid values are:
 
 .. note::
 
-   This flag is compatible only with the ``podman`` runtime and will be ignored for any other runtime. Docker does not support layer squashing; it is considered an experimental feature.
+   This flag is compatible only with the :program:`podman` runtime and will be ignored for any other runtime. Docker does not support layer squashing; it is considered an experimental feature.
 
 
 The ``create`` command
 ----------------------
 
-The ``ansible-builder create`` command accepts an execution environment definition as an input and outputs the build context necessary for building an execution environment image. However, the ``create`` command *will not* build the execution environment image; this is useful for creating just the build context and a ``Containerfile`` that can then be shared.
+The :command:`ansible-builder create` command accepts an execution environment definition as an input and outputs the build context necessary for building an execution environment image. However, the ``create`` command *will not* build the execution environment image; this is useful for creating just the build context and a :file:`Containerfile` that can then be shared.
 
 
 The ``introspect`` command
 ---------------------------
 
-The ``ansible-builder introspect`` command loops over collections in a specified folder and returns data about their
-dependencies. This command is used internally by ``ansible-builder`` and is exposed here for verification purposes. It is
+The :command:`ansible-builder introspect` command loops over collections in a specified folder and returns data about their
+dependencies. This command is used internally by :program:`ansible-builder` and is exposed here for verification purposes. It is
 primarily targeted toward collection authors and maintainers who need to understand or validate collection dependencies.
 
 To introspect collections in the default location:
@@ -352,15 +352,15 @@ collection name (in the format ``namespace.name``) whose requirements should be 
 Examples
 --------
 
-The example in ``test/data/pytz`` requires the ``awx.awx`` collection in the execution environment definition. The lookup plugin
+The example in :file:`test/data/pytz` requires the ``awx.awx`` collection in the execution environment definition. The lookup plugin
 ``awx.awx.schedule_rrule`` requires the PyPI ``pytz`` and another
-library to work. If ``test/data/pytz/execution-environment.yml`` file is
-given to the ``ansible-builder build`` command, then it will install the
-collection inside the image, read ``requirements.txt`` inside of the
+library to work. If :file:`test/data/pytz/execution-environment.yml` file is
+given to the :command:`ansible-builder build` command, then it will install the
+collection inside the image, read :file:`requirements.txt` inside of the
 collection, and then install ``pytz`` into the image.
 
-The image produced can be used inside of an ``ansible-runner`` project
-by placing these variables inside the ``env/settings`` file, inside of
+The image produced can be used inside of an :program:`ansible-runner` project
+by placing these variables inside the :file:`env/settings` file, inside of
 the private data directory.
 
 


### PR DESCRIPTION
Apply Sphinx semantic roles consistently across all documentation:

- `:program:` for executable/tool names (ansible-builder, dnf, microdnf, podman, docker, git, pip, ansible-galaxy, bindep, apt-get, apk)
- `:command:` for inline command invocations with subcommands
- `:file:` for filenames and paths
- `:envvar:` for environment variables

YAML config keys, build-arg names, package names, container image names, and Dockerfile directives remain inline literals. Also fixes several single-backtick (title-reference) mistakes in the scenario and porting guides.

Since the docs build runs in nitpicky mode with warnings-as-errors (-n -W), add `nitpick_ignore_regex` for envvar cross-references, which are defined externally (OS, ansible-core) rather than in these docs.

Fixes #783

Co-Authored-By: Claude Code