### PR TITLE
Bump min Python to 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,9 @@ jobs:
         # NOTE: to improve the responsiveness. It's nice to see the most
         # NOTE: important results first.
         - 3.14
-        - 3.9
+        - 3.11
         - 3.13
         - 3.12
-        - 3.11
-        - >-
-          3.10
         - ~3.15.0-0
         runner-vm-os:
         - ubuntu-24.04

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ Requirements
 
 - To build images, you must install a containerization tool - either :program:`podman` or :program:`docker` - as well as the ``ansible-builder`` Python package.
 - The ``--container-runtime`` option must correspond to the containerization tool you use.
-- ``ansible-builder`` version ``3.x`` requires Python ``3.9`` or higher.
+- ``ansible-builder`` version ``3.2`` requires Python ``3.11`` or higher.
 
 Base Image Requirements
 ************************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ansible-builder"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 authors = [
     {name = "Ansible Project"},
 ]
@@ -21,8 +21,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Natural Language :: English",
     "Operating System :: POSIX",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
DO NOT MERGE until Oct

In preparation for a new release, bump the minimum supported Python to 3.11. Python 3.10 is EOL in Oct 2026.

See: https://devguide.python.org/versions/#supported-versions